### PR TITLE
Removed deactivated users from leaderboards

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -478,7 +478,7 @@ def is_in_contest(request, contest):
 
 
 def contest_ranking_list(contest, problems):
-    return base_contest_ranking_list(contest, problems, contest.users.filter(virtual=0)
+    return base_contest_ranking_list(contest, problems, contest.users.filter(user__user__is_active=True,virtual=0)
                                                                      .prefetch_related('user__organizations')
                                                                      .order_by('-score', 'cumtime'))
 

--- a/judge/views/ranked_submission.py
+++ b/judge/views/ranked_submission.py
@@ -25,7 +25,8 @@ class RankedSubmissions(ProblemSubmissions):
             contest_join = ''
             points = 'sub.points'
             constraint = ''
-        queryset = super(RankedSubmissions, self).get_queryset().filter(id__in=RawSQL(
+        queryset = super(RankedSubmissions, self).get_queryset().filter(user__user__is_active=True,
+                                                                        id__in=RawSQL(
                 '''
                     SELECT sub.id
                     FROM (

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -262,7 +262,7 @@ class UserList(QueryStringSortMixin, DiggPaginatorMixin, TitleMixin, ListView):
     default_sort = '-performance_points'
 
     def get_queryset(self):
-        return (Profile.objects.order_by(self.order, 'id').select_related('user')
+        return (Profile.objects.filter(user__is_active=True).order_by(self.order, 'id').select_related('user')
                 .only('display_rank', 'user__username', 'name', 'points', 'rating', 'performance_points',
                       'problem_count'))
 


### PR DESCRIPTION
Prevent deactivated users from showing up in `Best Submissions`, Contest Leaderboards, and on the general `Users` list.