### PR TITLE
`LoginRequiredMixin` should be leftmost in inheritance

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -552,7 +552,7 @@ class ContestRanking(ContestRankingBase):
         return context
 
 
-class ContestParticipationList(ContestRankingBase, LoginRequiredMixin):
+class ContestParticipationList(LoginRequiredMixin, ContestRankingBase):
     tab = 'participation'
 
     def get_title(self):


### PR DESCRIPTION
From Django 2.1 docs:

When using class-based views, you can achieve the same behavior as with login_required by using the `LoginRequiredMixin`. This mixin should be at the leftmost position in the inheritance list.