### PR TITLE
Fix more language stats chart UI issues related to ac8421a

### DIFF
--- a/judge/views/stats.py
+++ b/judge/views/stats.py
@@ -36,12 +36,11 @@ def repeat_chain(iterable):
 
 def language_data(request, language_count=Language.objects.annotate(count=Count('submission'))):
     languages = language_count.filter(count__gt=0).values('key', 'name', 'count').order_by('-count')
-    threshold = settings.DMOJ_STATS_LANGUAGE_THRESHOLD
-    num_languages = min(len(languages), threshold)
+    num_languages = min(len(languages), settings.DMOJ_STATS_LANGUAGE_THRESHOLD)
     other_count = sum(map(itemgetter('count'), languages[num_languages:]))
 
     return JsonResponse({
-        'labels': list(map(itemgetter('name'), languages)) + ['Other'],
+        'labels': list(map(itemgetter('name'), languages[:num_languages])) + ['Other'],
         'datasets': [
             {
                 'backgroundColor': chart_colors[:num_languages] + ['#FDB45C'],

--- a/templates/stats/language.html
+++ b/templates/stats/language.html
@@ -4,63 +4,29 @@
         .chart {
             margin: 10px 0;
         }
-
-        ul.legend {
-            list-style-type: none;
-            padding: 0;
-        }
-
-        .legend .square {
-            display: inline-block;
-            width: 1em;
-            height: 1em;
-            margin-right: .3em;
-        }
-
-        @media (max-width: 450px) {
-            ul.legend {
-                -moz-columns: 5 7em;
-            }
-
-            .chart canvas {
-                display: block;
-                margin: 0 auto;
-            }
-        }
-
-        @media (min-width: 451px) {
-            .chart {
-                display: flex;
-            }
-
-            ul.legend {
-                margin-left: 20px;
-            }
-        }
     </style>
 {% endblock %}
 
 {% block chart_body %}
     <h3>{{ _('Submission Statistics') }}</h3>
     <div id="status-counts" class="chart">
-        <canvas width="300" height="300"></canvas>
-        <ul class="legend"></ul>
+        <canvas width="400" height="300"></canvas>
     </div>
 
     <h3>{{ _('Submissions by Language') }}</h3>
     <div id="lang-all" class="chart">
-        <canvas width="300" height="300"></canvas>
-        <ul class="legend"></ul>
+        <canvas width="400" height="300"></canvas>
     </div>
 
     <h3>{{ _('AC Submissions by Language') }}</h3>
     <div id="lang-ac" class="chart">
-        <canvas width="300" height="300"></canvas>
-        <ul class="legend"></ul>
+        <canvas width="400" height="300"></canvas>
     </div>
 
     <h3>{{ _('Language AC Rate') }}</h3>
-    <canvas id="ac-rate" width="350" height="700"></canvas>
+    <div id="ac-rate" class="chart">
+        <canvas width="400"><canvas>
+    </div>
 {% endblock %}
 
 {% block bodyend %}
@@ -82,17 +48,14 @@
                             responsive: false,
                             animation: false,
                             legend: {
-                                display: false,
-                            }
+                                position: 'right',
+                                labels: {
+                                    fontColor: 'black',
+                                    boxWidth: 20,
+                                },
+                            },
                         }
                     });
-                    var $legend = $chart.find('.legend');
-                    for (var i = 0; i < data.labels.length; ++i) {
-                        $legend.append($('<li>')
-                            .append($('<span>').addClass('square').css('background-color', data.datasets[0].backgroundColor[i]))
-                            .append($('<span>').text(data.labels[i]))
-                        );
-                    }
                 });
             }
 
@@ -101,14 +64,13 @@
             draw_pie_chart('{{ url('stats_data_status') }}', $('#status-counts'));
 
             $.getJSON('{{ url('language_stats_data_ac_rate') }}', function (data) {
-                var ctx = $('canvas#ac-rate').get(0).getContext('2d');
-                ctx.canvas.height = 20 * data.labels.length;
+                var ctx = $('#ac-rate').find('canvas').get(0).getContext('2d');
+                ctx.canvas.height = 20 * data.labels.length + 100;
                 new Chart(ctx, {
                     type: 'horizontalBar',
                     data: data,
                     options: {
                         maintainAspectRatio: false,
-                        responsive: false,
                         legend: {
                             display: false,
                         },


### PR DESCRIPTION
In particular: 
 - Switch to Chart.js's legend instead of a custom legend, which supports filtering by labels, and is more robust.
 - Fix issue with showing all label names when only some would be present on chart (can be seen on the second and third charts on https://dmoj.ca/stats/language/).
 - Fix issue with the language AC rate chart cutting off if there are only a few languages, as `ctx.canvas.height = 20 * data.labels.length;` did not account for the axis labels.
![Screenshot from 2019-11-09 14-29-02](https://user-images.githubusercontent.com/29607503/68533965-4c66ac00-02fd-11ea-92b1-870de79b2c76.png)
