### PR TITLE
Stop escaping contest name in private contest error page twice

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -18,7 +18,7 @@ from django.template.defaultfilters import date as date_filter
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.html import escape, format_html
+from django.utils.html import format_html
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _, gettext_lazy
 from django.views.generic import ListView, TemplateView
@@ -215,7 +215,7 @@ class ContestMixin(object):
                                        _('Could not find such contest.'))
         except PrivateContestError as e:
             return render(request, 'contest/private.html', {
-                'error': e, 'title': _('Access to contest "%s" denied') % escape(e.name),
+                'error': e, 'title': _('Access to contest "%s" denied') % e.name,
             }, status=403)
 
 


### PR DESCRIPTION
For example, a `'` becomes `&amp;#39;` before this PR.