### PR TITLE
Allow contest organizers to rejudge all submissions

### DIFF
--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -176,18 +176,7 @@ class ContestAdmin(VersionAdmin):
         ] + super(ContestAdmin, self).get_urls()
 
     def rejudge_view(self, request, contest_id, problem_id):
-        if not request.user.has_perm('judge.rejudge_submission'):
-            self.message_user(request, ugettext('You do not have the permission to rejudge submissions.'),
-                              level=messages.ERROR)
-            return
-
         queryset = ContestSubmission.objects.filter(problem_id=problem_id).select_related('submission')
-        if not request.user.has_perm('judge.rejudge_submission_lot') and \
-                len(queryset) > settings.DMOJ_SUBMISSIONS_REJUDGE_LIMIT:
-            self.message_user(request, ugettext('You do not have the permission to rejudge THAT many submissions.'),
-                              level=messages.ERROR)
-            return
-
         for model in queryset:
             model.submission.judge(rejudge=True)
 

--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -1,6 +1,5 @@
-from django.conf import settings
 from django.conf.urls import url
-from django.contrib import admin, messages
+from django.contrib import admin
 from django.core.exceptions import PermissionDenied
 from django.db import connection, transaction
 from django.db.models import Q, TextField
@@ -9,7 +8,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
 from django.utils.html import format_html
-from django.utils.translation import gettext_lazy as _, ugettext, ungettext
+from django.utils.translation import gettext_lazy as _, ungettext
 from reversion.admin import VersionAdmin
 
 from judge.models import Contest, ContestProblem, ContestSubmission, Profile, Rating


### PR DESCRIPTION
This removes the need for contest organizers to be given the much more powerful `rejudge_submission_lot` permission, while still being able to do their work.