### PR TITLE
Allow overflow on button row.

### DIFF
--- a/resources/pagedown_widget.css
+++ b/resources/pagedown_widget.css
@@ -27,7 +27,7 @@
     margin: 10px 5px 5px;
     padding: 0;
     height: 20px;
-    overflow-x: scroll;
+    overflow-x: auto;
 }
 
 .wmd-spacer {

--- a/resources/pagedown_widget.css
+++ b/resources/pagedown_widget.css
@@ -27,6 +27,7 @@
     margin: 10px 5px 5px;
     padding: 0;
     height: 20px;
+    overflow-x: scroll;
 }
 
 .wmd-spacer {


### PR DESCRIPTION
This fixes many issues involving random size changes on mobile.

Before: 
![image](https://user-images.githubusercontent.com/11021327/69909189-3fe9e680-13c5-11ea-960c-9267514447e9.png)

After: 
![image](https://user-images.githubusercontent.com/11021327/69909193-509a5c80-13c5-11ea-8389-7757a5d7f58b.png)

(the bottom dark bar is just to illustrate the scroll bar)
