### PR TITLE
Show contest scoreboard while contest is running if visible

### DIFF
--- a/judge/views/api/api_v1.py
+++ b/judge/views/api/api_v1.py
@@ -44,9 +44,7 @@ def api_v1_contest_detail(request, contest):
                       .annotate(username=F('user__user__username'))
                       .order_by('-score', 'cumtime') if can_see_rankings else [])
 
-    if not (in_contest or contest.ended or request.user.is_superuser or
-            (request.user.is_authenticated and contest.organizers.filter(id=request.profile.id).exists())):
-        problems = []
+    can_see_problems = (in_contest or contest.ended or contest.is_editable_by(request.user))
 
     return JsonResponse({
         'time_limit': contest.time_limit and contest.time_limit.total_seconds(),
@@ -68,7 +66,7 @@ def api_v1_contest_detail(request, contest):
                 'partial': problem.partial,
                 'name': problem.problem.name,
                 'code': problem.problem.code,
-            } for problem in problems],
+            } for problem in problems] if can_see_problems else [],
         'rankings': [
             {
                 'user': participation.username,


### PR DESCRIPTION
Currently, all `solutions` are hidden during the contest regardless of if the scoreboard is hidden or visible. This is because an empty `problems` list is always passed [here](https://github.com/DMOJ/online-judge/compare/master...Ninjaclasher:fix-contest-api?expand=1#diff-2a1e8f336f765476c4f924743f7b7376R76), leading to nothing being returned `contest.format.get_problem_breakdown`.