### PR TITLE
Scroll tabs if overflow.

### DIFF
--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -206,6 +206,7 @@ input {
         list-style: outside none none;
         display: flex;
         overflow-x: auto;
+        overflow-y: hidden;
 
         > li {
             margin-bottom: -1px;

--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -205,6 +205,7 @@ input {
         padding: 0;
         list-style: outside none none;
         display: flex;
+        overflow-x: auto;
 
         > li {
             margin-bottom: -1px;


### PR DESCRIPTION
This fixes some scaling issues on mobile when there are too many tabs.