### PR TITLE
dmoj/settings.py: Bump jquery to 3.4.1

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -127,7 +127,7 @@ PUPPETEER_PAPER_SIZE = 'Letter'
 PYGMENT_THEME = 'pygment-github.css'
 INLINE_JQUERY = True
 INLINE_FONTAWESOME = True
-JQUERY_JS = '//ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js'
+JQUERY_JS = '//ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js'
 FONTAWESOME_CSS = '//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css'
 DMOJ_CANONICAL = ''
 


### PR DESCRIPTION
For whoever accidentally toggled `INLINE_JQUERY` off, we can bump jquery to 3.4.1 here as the same as whoever doesn't change the option [using jquery 3.4.1](https://github.com/DMOJ/online-judge/blob/0a724b4c06a274c19463e76e05734255060e797b/templates/base.html#L77).