### PR TITLE
Limit size of wmd-input to size of their container; closes #945

### DIFF
--- a/resources/pagedown_widget.css
+++ b/resources/pagedown_widget.css
@@ -12,6 +12,7 @@
 .wmd-input {
     height: 300px;
     width: 100%;
+    max-width: 100%;
     background: #fff;
     border: 1px solid DarkGray;
     font-family: Consolas, "Liberation Mono", Monaco, "Courier New", monospace !important;


### PR DESCRIPTION
This fixes specific `textarea`s from spilling past their `div` on several pages including the ticket page and profile page.