### PR TITLE
Remove s for single author on editorial page

### DIFF
--- a/templates/problem/editorial.html
+++ b/templates/problem/editorial.html
@@ -23,7 +23,14 @@
         {% endif %}
         {% with authors=solution.authors.all() %}
             {% if authors %}
-                <p>Authors: {{ link_users(authors) }}</p>
+                <p>
+                    {% trans trimmed count=authors|length %}
+                        Author: 
+                    {% pluralize %}
+                        Authors: 
+                    {% endtrans %}
+                    {{ link_users(authors) }}
+                </p>
             {% endif %}
         {% endwith %}
         {{ solution.content|markdown('solution', MATH_ENGINE)|reference|str|safe }}


### PR DESCRIPTION
Changes "Authors: username" to "Author: username" on the editorial page when there is only 1 author listed.