### PR TITLE
Use getattr to avoid mis-using Mathoid

### DIFF
--- a/judge/jinja2/markdown/__init__.py
+++ b/judge/jinja2/markdown/__init__.py
@@ -115,7 +115,7 @@ def markdown(value, style, math_engine=None, lazy_load=False):
     escape = styles.get('safe_mode', True)
     nofollow = styles.get('nofollow', True)
     texoid = TEXOID_ENABLED and styles.get('texoid', False)
-    math = hasattr(settings, 'MATHOID_URL') and styles.get('math', False)
+    math = getattr(settings, 'MATHOID_URL') and styles.get('math', False)
 
     post_processors = []
     if styles.get('use_camo', False) and camo_client is not None:


### PR DESCRIPTION
* `MATHOID_URL = False` is set in the default settings: [src](https://github.com/DMOJ/online-judge/blob/master/dmoj/settings.py#L90)
* False is also a valid property value so `hasattr(settings, 'MATHOID_URL')` will be a `True`, even when `MATHOID_URL = False`
* This will cause the MathoidMathParser to be called, even no valid Mathoid server is configured: [src](https://github.com/DMOJ/online-judge/blob/master/judge/jinja2/markdown/math.py#L52)

Using `getattr`, a `False` or `None` will be consider as falsy, thus solves the problem.