### PR TITLE
pagedown_math: $.load(handler) is deprecated

### DIFF
--- a/resources/pagedown_math.js
+++ b/resources/pagedown_math.js
@@ -12,6 +12,6 @@ function mathjax_pagedown($) {
 
 window.mathjax_pagedown = mathjax_pagedown;
 
-$(window).load(function () {
+$(window).on('load', function () {
     (mathjax_pagedown)('$' in window ? $ : django.jQuery);
 });


### PR DESCRIPTION
In #1225 I proposed to upgrade the jQuery version of inline jQuery, and I'm experiencing:

```
e.indexOf is not a function
```

in pagedown_math.js. Finally I realized that `$.load(handler)` was [deprecated](https://api.jquery.com/load-event/) in jQuery 3.0. Therefore we also migrate this to a up-to-date jQuery API.