### PR TITLE
Move all contest filtering into a single class method

### DIFF
--- a/judge/views/api/api_v1.py
+++ b/judge/views/api/api_v1.py
@@ -17,9 +17,8 @@ def sane_time_repr(delta):
 
 
 def api_v1_contest_list(request):
-    queryset = Contest.objects.filter(is_visible=True, is_private=False,
-                                      is_organization_private=False).prefetch_related(
-        Prefetch('tags', queryset=ContestTag.objects.only('name'), to_attr='tag_list')).defer('description')
+    queryset = Contest.get_visible_contests(request.user).prefetch_related(
+        Prefetch('tags', queryset=ContestTag.objects.only('name'), to_attr='tag_list'))
 
     return JsonResponse({c.key: {
         'name': c.name,

--- a/judge/views/select2.py
+++ b/judge/views/select2.py
@@ -65,21 +65,8 @@ class ProblemSelect2View(Select2View):
 
 class ContestSelect2View(Select2View):
     def get_queryset(self):
-        queryset = Contest.objects.filter(Q(key__icontains=self.term) | Q(name__icontains=self.term))
-        if not self.request.user.has_perm('judge.see_private_contest'):
-            queryset = queryset.filter(is_visible=True)
-        if not self.request.user.has_perm('judge.edit_all_contest'):
-            q = Q(is_private=False, is_organization_private=False) | Q(organizers=self.request.profile)
-            if self.request.user.is_authenticated:
-                q |= Q(is_organization_private=False, is_private=True, private_contestants=self.request.profile)
-                q |= Q(is_organization_private=True, is_private=False,
-                       organizations__in=self.request.profile.organizations.all())
-                q |= Q(is_organization_private=True, is_private=True,
-                       organizations__in=self.request.profile.organizations.all(),
-                       private_contestants=self.request.profile)
-                q |= Q(view_contest_scoreboard=self.request.profile)
-            queryset = queryset.filter(q)
-        return queryset.distinct()
+        return Contest.get_visible_contests(self.request.user) \
+                      .filter(Q(key__icontains=self.term) | Q(name__icontains=self.term))
 
 
 class CommentSelect2View(Select2View):


### PR DESCRIPTION
Currently, the same code is duplicated in three places: `views/contests.py`, `views/blogs.py`, and `views/select2.py` with very minor changes in filtering (e.g filtering only `is_visible=True` contests on `views/blog.py`). Also, the current API only shows contests that are visible to everyone. With #1254 implemented, it would be useful if the API showed user-specific results.

This PR refactors the code to filter visible contests into a single class method in the Contest model, and makes the API show user-specific results.

Note that this could be done for problems as well, but that is out of the scope of this PR.