### PR TITLE
Fix PhantomJS ssl error

### DIFF
--- a/judge/pdf_problems.py
+++ b/judge/pdf_problems.py
@@ -138,7 +138,8 @@ page.open(param.input, function (status) {
         with io.open(os.path.join(self.dir, '_render.js'), 'w', encoding='utf-8') as f:
             f.write(self.get_render_script())
         cmdline = [settings.PHANTOMJS, '_render.js']
-        self.proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=self.dir)
+        env = {'OPENSSL_CONF': '/etc/ssl'}
+        self.proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=self.dir, env=env)
         self.log = self.proc.communicate()[0]
 
 


### PR DESCRIPTION
PhantomJS has had an error for the past while (direct issue [here](https://github.com/wch/webshot/issues/90), but mentioned in 2018 [here](https://stackoverflow.com/questions/53355217/genymotion-throws-libssl-conf-so-cannot-open-shared-object-file-no-such-file-o)) where certain system configurations (Debian) would cause the following error on pdf generation:
```
Auto configuration failed
140098268257920:error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library:dso_dlfcn.c:185:filename(libssl_conf.so): libssl_conf.so: cannot open shared object file: No such file or directory
140098268257920:error:25070067:DSO support routines:DSO_load:could not load the shared library:dso_lib.c:244:
140098268257920:error:0E07506E:configuration file routines:MODULE_LOAD_DSO:error loading dso:conf_mod.c:285:module=ssl_conf, path=ssl_conf
140098268257920:error:0E076071:configuration file routines:MODULE_RUN:unknown module name:conf_mod.c:222:module=ssl_conf
```

The solution to this is to assign an environment variable `OPENSSL_CONF` to `/etc/ssl/`. Some systems are unaffected by the issue and won't be affected by this fix.