### PR TITLE
Call `get_python3` when `get_default_language` fails

### DIFF
--- a/judge/apps.py
+++ b/judge/apps.py
@@ -30,7 +30,7 @@ class JudgeAppConfig(AppConfig):
         from django.contrib.auth.models import User
 
         try:
-            lang = Language.get_python3()
+            lang = Language.get_default_language()
             for user in User.objects.filter(profile=None):
                 # These poor profileless users
                 profile = Profile(user=user, language=lang)

--- a/judge/migrations/0096_profile_language_set_default.py
+++ b/judge/migrations/0096_profile_language_set_default.py
@@ -6,6 +6,11 @@ from django.db import migrations, models
 import judge.models.runtime
 
 
+def create_python3(apps, schema_editor):
+    Language = apps.get_model('judge', 'Language')
+    Language.objects.get_or_create(key='PY3', defaults={'name': 'Python 3'})[0]
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -13,6 +18,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(create_python3, reverse_code=migrations.RunPython.noop),
         migrations.AlterField(
             model_name='profile',
             name='language',

--- a/judge/models/runtime.py
+++ b/judge/models/runtime.py
@@ -97,7 +97,10 @@ class Language(models.Model):
 
     @classmethod
     def get_default_language(cls):
-        return Language.objects.get(key=settings.DEFAULT_USER_LANGUAGE)
+        try:
+            return Language.objects.get(key=settings.DEFAULT_USER_LANGUAGE)
+        except Language.DoesNotExist:
+            return cls.get_python3()
 
     @classmethod
     def get_default_language_pk(cls):

--- a/judge/social_auth.py
+++ b/judge/social_auth.py
@@ -83,7 +83,7 @@ def make_profile(backend, user, response, is_new=False, *args, **kwargs):
     if is_new:
         if not hasattr(user, 'profile'):
             profile = Profile(user=user)
-            profile.language = Language.get_python3()
+            profile.language = Language.get_default_language()
             logger.info('Info from %s: %s', backend.name, response)
             profile.save()
             form = ProfileForm(instance=profile, user=user)

--- a/judge/views/register.py
+++ b/judge/views/register.py
@@ -71,7 +71,7 @@ class RegistrationView(OldRegistrationView):
     def register(self, form):
         user = super(RegistrationView, self).register(form)
         profile, _ = Profile.objects.get_or_create(user=user, defaults={
-            'language': Language.get_python3(),
+            'language': Language.get_default_language(),
         })
 
         cleaned_data = form.cleaned_data


### PR DESCRIPTION
Fixes #1277.