### PR TITLE
view_scoreboard check in wrong location causing logic error

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -164,12 +164,12 @@ class Contest(models.Model):
             return True
         if user.is_authenticated and self.organizers.filter(id=user.profile.id).exists():
             return True
-        if user.is_authenticated and self.view_contest_scoreboard.filter(id=user.profile.id).exists():
-            return True
         if not self.is_visible:
             return False
         if self.start_time is not None and self.start_time > timezone.now():
             return False
+        if user.is_authenticated and self.view_contest_scoreboard.filter(id=user.profile.id).exists():
+            return True
         if self.hide_scoreboard and not self.is_in_contest(user) and self.end_time > timezone.now():
             return False
         return True


### PR DESCRIPTION
In PR #1247 a logic error was introduced in lines [145/146](https://github.com/DMOJ/online-judge/pull/1247/files#diff-6214273cbb91d688f9535971cd4235ffR145) in judge/models/contest.py. This is as the View Scoreboard permission should only work if is_visible is enabled. However, here View Scoreboard is checked before is_visible.