### PR TITLE
404 contests that the user should not have access to in the API

### DIFF
--- a/judge/views/api/api_v1.py
+++ b/judge/views/api/api_v1.py
@@ -32,6 +32,9 @@ def api_v1_contest_list(request):
 def api_v1_contest_detail(request, contest):
     contest = get_object_or_404(Contest, key=contest)
 
+    if not contest.is_accessible_by(request.user):
+        raise Http404()
+
     in_contest = contest.is_in_contest(request.user)
     can_see_rankings = contest.can_see_scoreboard(request.user)
     if contest.hide_scoreboard and in_contest:


### PR DESCRIPTION
Looks like this bug has been a thing since 789f8fcccc103de58c58447a012195459727b622...

Example: `olylvl7hw200328` is an organization private contest but an anonymous user can access https://dmoj.ca/api/contest/info/olylvl7hw200328.