### PR TITLE
Fix martor padding issues for lists; #1287

### DIFF
--- a/resources/martor-description.scss
+++ b/resources/martor-description.scss
@@ -3,11 +3,11 @@
 form .martor-preview {
     @include content-description;
     
-    .martor-preview ul li {
+    ul li {
         list-style: unset !important;
     }
 
-    .martor-preview ul, .martor-preview ol {
+    ul, ol {
         margin-left: 0 !important;
     }
 }


### PR DESCRIPTION
With the following markdown:
```
- 1
- 2
```

Before:
![](https://user-images.githubusercontent.com/29607503/78382321-add93100-75a4-11ea-895c-f1b790b1b1b7.png)

After:
![](https://user-images.githubusercontent.com/29607503/78382327-af0a5e00-75a4-11ea-982a-962ab01b3438.png)
