### PR TITLE
Refactor contest join and organizer vs editor code

### DIFF
--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -2,7 +2,7 @@
 
 {% block tabs %}
     {{ make_tab('detail', 'fa-info-circle', url('contest_view', contest.key), _('Info')) }}
-    {% if contest.ended or contest.is_editable_by(request.user) %}
+    {% if contest.ended or can_edit %}
         {{ make_tab('stats', 'fa-pie-chart', url('contest_stats', contest.key), _('Statistics')) }}
     {% endif %}
 
@@ -16,7 +16,7 @@
             {{ make_tab('participation', 'fa-users', url('contest_participation_own', contest.key), _('Participation')) }}
         {% endif %}
     {% endif %}
-    {% if contest.is_editable_by(request.user) %}
+    {% if can_edit %}
         {% if perms.judge.moss_contest and has_moss_api_key %}
             {{ make_tab('moss', 'fa-gavel', url('contest_moss', contest.key), _('MOSS')) }}
         {% endif %}
@@ -27,17 +27,18 @@
     {% endif %}
 
     {% if request.user.is_authenticated %}
-        {% if contest.can_join or participating or is_organizer %}
+        {% if contest.can_join or is_organizer %}
+            {% set in_contest = contest.is_in_contest(request.user) %}
             {% if contest.ended %}
+                {# Allow users to leave the virtual contest #}
                 {% if in_contest %}
-                    {# They're in the contest because they're participating virtually #}
                     <form action="{{ url('contest_leave', contest.key) }}" method="post"
                           class="contest-join-pseudotab unselectable button">
                         {% csrf_token %}
                         <input type="submit" class="leaving-forever" value="{{ _('Leave contest') }}">
                     </form>
                 {% else %}
-                    {# They're in the contest because they're participating virtually #}
+                    {# Allow users to virtual join #}
                     <form action="{{ url('contest_join', contest.key) }}" method="post"
                           class="contest-join-pseudotab unselectable button">
                         {% csrf_token %}
@@ -45,35 +46,30 @@
                     </form>
                 {% endif %}
             {% else %}
+                {# Allow users to leave the contest #}
                 {% if in_contest %}
-                    {# Allow people with ended participations to continue spectating #}
                     <form action="{{ url('contest_leave', contest.key) }}" method="post"
                           class="contest-join-pseudotab unselectable button">
                         {% csrf_token %}
                         <input type="submit" value="
-                            {%- if participating and participation.ended or request.profile in contest.organizers.all() %}
+                            {%- if request.participation.spectate %}
                                 {{- _('Stop spectating') -}}
                             {% else %}
                                 {{- _('Leave contest') -}}
                             {% endif %}">
                     </form>
-                {% elif participating and participation.ended or is_organizer %}
+                {% elif is_organizer or has_finished_participating %}
                     <form action="{{ url('contest_join', contest.key) }}" method="post"
                           class="contest-join-pseudotab unselectable button">
                         {% csrf_token %}
                         <input type="submit" value="{{ _('Spectate contest') }}">
                     </form>
-                {% elif participating %}
-                    <form action="{{ url('contest_join', contest.key) }}" method="post"
-                          class="contest-join-pseudotab unselectable button">
-                        {% csrf_token %}
-                        <input type="submit" value="{{ _('Join contest') }}">
-                    </form>
                 {% else %}
                     <form action="{{ url('contest_join', contest.key) }}" method="post"
                           class="contest-join-pseudotab unselectable button">
                         {% csrf_token %}
-                        <input type="submit" class="first-join" value="{{ _('Join contest') }}">
+                        <input type="submit" {% if not has_joined %}class="first-join"{% endif %}
+                               value="{{ _('Join contest') }}">
                     </form>
                 {% endif %}
             {% endif %}

--- a/templates/contest/ranking-table.html
+++ b/templates/contest/ranking-table.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block user_data %}
-    {% if is_organizer %}
+    {% if can_edit %}
         <span class="contest-participation-operation">
             <form action="{{ url('contest_participation_disqualify', contest.key) }}" method="post">
                 {% csrf_token %}

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -165,7 +165,7 @@
 {% endblock %}
 
 {% block users_js_media %}
-    {% if is_organizer %}
+    {% if can_edit %}
         <script type="text/javascript">
             $(function () {
                 $('a.disqualify-participation').click(function (e) {


### PR DESCRIPTION
The contest access code is a bit messy, as it was written before a lot of the current helper methods were made. Also, there is a lot of misuses of a contest organizer (someone who is explicitly set as a contest organizer) versus an editor (a user who can _edit_ the contest). Both of these issues are fixed in this PR.

```
Contest has not started:
 - Contest organizers can SPECTATE

Contest is ongoing:
 - Contest organizers can SPECTATE
 - All other users can JOIN

Contest has ended:
 - All users can VIRTUAL JOIN

Conditions when problems listed at the bottom of the contest page should be visible (this is unchanged from the current check):
 - Contest has ended
 - User is a superuser
 - User is a contest organizer

For all other purposes, contest editor checks should be used (by calling `contest.is_editable_by`).
```