### PR TITLE
Only show red error box in comment editting overlay if there are errors

### DIFF
--- a/templates/comments/edit-ajax.html
+++ b/templates/comments/edit-ajax.html
@@ -3,11 +3,12 @@
         <span style="display: none" class="comment-id">{{ comment.id }}</span>
         <span style="display: none" class="read-back">{{ url('comment_content', comment.id) }}</span>
         {% csrf_token %}
-        <div class="form-errors">
-            {{ form.non_field_errors() }}
-            {{ form.body.errors }}
-
-        </div>
+        {% if form.non_field_errors() or form.body.errors %}
+            <div class="form-errors">
+                {{ form.non_field_errors() }}
+                {{ form.body.errors }}
+            </div>
+        {% endif %}
         <div class="comment-post-wrapper">
             <div id="comment-form-body">{{ form.body }}</div>
         </div>


### PR DESCRIPTION
Fixes: 
![Screenshot from 2020-04-05 20-55-19](https://user-images.githubusercontent.com/29607503/78514516-c5b8dc80-777f-11ea-84b4-bd073523c679.png)
