### PR TITLE
Move problem filtering into class methods

### DIFF
--- a/judge/feed.py
+++ b/judge/feed.py
@@ -15,7 +15,7 @@ class ProblemFeed(Feed):
     description = 'The latest problems added on the %s website' % settings.SITE_LONG_NAME
 
     def items(self):
-        return Problem.objects.filter(is_public=True, is_organization_private=False).order_by('-date', '-id')[:25]
+        return Problem.get_public_problems().order_by('-date', '-id')[:25]
 
     def item_title(self, problem):
         return problem.name

--- a/judge/sitemap.py
+++ b/judge/sitemap.py
@@ -11,7 +11,7 @@ class ProblemSitemap(Sitemap):
     priority = 0.8
 
     def items(self):
-        return Problem.objects.filter(is_public=True, is_organization_private=False).values_list('code')
+        return Problem.get_public_problems().values_list('code')
 
     def location(self, obj):
         return reverse('problem_detail', args=obj)

--- a/judge/utils/problems.py
+++ b/judge/utils/problems.py
@@ -112,8 +112,8 @@ def hot_problems(duration, limit):
     cache_key = 'hot_problems:%d:%d' % (duration.total_seconds(), limit)
     qs = cache.get(cache_key)
     if qs is None:
-        qs = Problem.objects.filter(is_public=True, is_organization_private=False,
-                                    submission__date__gt=timezone.now() - duration, points__gt=3, points__lt=25)
+        qs = Problem.get_public_problems() \
+                    .filter(submission__date__gt=timezone.now() - duration, points__gt=3, points__lt=25)
         qs0 = qs.annotate(k=Count('submission__user', distinct=True)).order_by('-k').values_list('k', flat=True)
 
         if not qs0:

--- a/judge/views/api/api_v1.py
+++ b/judge/views/api/api_v1.py
@@ -90,7 +90,7 @@ def api_v1_contest_detail(request, contest):
 
 
 def api_v1_problem_list(request):
-    queryset = Problem.objects.filter(is_public=True, is_organization_private=False)
+    queryset = Problem.get_visible_problems(request.user)
     if settings.ENABLE_FTS and 'search' in request.GET:
         query = ' '.join(request.GET.getlist('search')).strip()
         if query:

--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -39,7 +39,7 @@ class PostList(ListView):
         context['first_page_href'] = reverse('home')
         context['page_prefix'] = reverse('blog_post_list')
         context['comments'] = Comment.most_recent(self.request.user, 10)
-        context['new_problems'] = Problem.objects.filter(is_public=True, is_organization_private=False) \
+        context['new_problems'] = Problem.get_public_problems() \
                                          .order_by('-date', '-id')[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
         context['page_titles'] = CacheDict(lambda page: Comment.get_page_title(page))
 
@@ -52,7 +52,7 @@ class PostList(ListView):
                 context['clarifications'] = clarifications.order_by('-date')
 
         context['user_count'] = lazy(Profile.objects.count, int, int)
-        context['problem_count'] = lazy(Problem.objects.filter(is_public=True).count, int, int)
+        context['problem_count'] = lazy(Problem.get_public_problems().count, int, int)
         context['submission_count'] = lazy(Submission.objects.count, int, int)
         context['language_count'] = lazy(Language.objects.count, int, int)
 

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -360,17 +360,8 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
                                    'problem__group__full_name', 'points', 'partial', 'user_count')]
 
     def get_normal_queryset(self):
-        filter = Q(is_public=True)
-        if self.profile is not None:
-            filter |= Q(authors=self.profile)
-            filter |= Q(curators=self.profile)
-            filter |= Q(testers=self.profile)
-        queryset = Problem.objects.filter(filter).select_related('group').defer('description')
-        if not self.request.user.has_perm('see_organization_problem'):
-            filter = Q(is_organization_private=False)
-            if self.profile is not None:
-                filter |= Q(organizations__in=self.profile.organizations.all())
-            queryset = queryset.filter(filter)
+        queryset = Problem.get_visible_problems(self.request.user).select_related('group')
+
         if self.profile is not None and self.hide_solved:
             queryset = queryset.exclude(id__in=Submission.objects.filter(user=self.profile, points=F('problem__points'))
                                         .values_list('problem__id', flat=True))

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -360,8 +360,17 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
                                    'problem__group__full_name', 'points', 'partial', 'user_count')]
 
     def get_normal_queryset(self):
-        queryset = Problem.get_visible_problems(self.request.user).select_related('group')
-
+        filter = Q(is_public=True)
+        if self.profile is not None:
+            filter |= Q(authors=self.profile)
+            filter |= Q(curators=self.profile)
+            filter |= Q(testers=self.profile)
+        queryset = Problem.objects.filter(filter).select_related('group').defer('description')
+        if not self.request.user.has_perm('see_organization_problem'):
+            filter = Q(is_organization_private=False)
+            if self.profile is not None:
+                filter |= Q(organizations__in=self.profile.organizations.all())
+            queryset = queryset.filter(filter)
         if self.profile is not None and self.hide_solved:
             queryset = queryset.exclude(id__in=Submission.objects.filter(user=self.profile, points=F('problem__points'))
                                         .values_list('problem__id', flat=True))

--- a/judge/views/select2.py
+++ b/judge/views/select2.py
@@ -54,13 +54,8 @@ class OrganizationSelect2View(Select2View):
 
 class ProblemSelect2View(Select2View):
     def get_queryset(self):
-        queryset = Problem.objects.filter(Q(code__icontains=self.term) | Q(name__icontains=self.term))
-        if not self.request.user.has_perm('judge.see_private_problem'):
-            filter = Q(is_public=True)
-            if self.request.user.is_authenticated:
-                filter |= Q(authors=self.request.profile) | Q(curators=self.request.profile)
-            queryset = queryset.filter(filter).distinct()
-        return queryset.distinct()
+        return Problem.get_visible_problems(self.request.user) \
+                      .filter(Q(code__icontains=self.term) | Q(name__icontains=self.term))
 
 
 class ContestSelect2View(Select2View):

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -254,13 +254,7 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
     def get_queryset(self):
         queryset = self._get_queryset()
         if not self.in_contest:
-            if not self.request.user.has_perm('judge.see_private_problem'):
-                queryset = queryset.filter(problem__is_public=True)
-            if not self.request.user.has_perm('judge.see_organization_problem'):
-                filter = Q(problem__is_organization_private=False)
-                if self.request.user.is_authenticated:
-                    filter |= Q(problem__organizations__in=self.request.profile.organizations.all())
-                queryset = queryset.filter(filter)
+            queryset = queryset.filter(problem__in=Problem.get_visible_problems(self.request.user))
         return queryset
 
     def get_my_submissions_page(self):


### PR DESCRIPTION
Similar PR as #1263.

Note that unlike that #1263, this PR has some changes to problem visibilities:
 - [judge/models/profile.py](https://github.com/DMOJ/online-judge/compare/master...Ninjaclasher:problem-filter?expand=1#diff-2a2fcc9e01812a880588bc5c5e8f36b6R147) - Before, all `is_public=True` problems were included, even if they were organization private. This has been changed to `is_public=True, is_organization_private=False`, as it feels like a bug.
 - [judge/views/blog.py](https://github.com/DMOJ/online-judge/compare/master...Ninjaclasher:problem-filter?expand=1#diff-fcb42be28f0a0164573dbcf8b8b48f77R55) - Similar modification as above.
 - [judge/views/problem.py](https://github.com/DMOJ/online-judge/compare/master...Ninjaclasher:problem-filter?expand=1#diff-76c07cd9466d20d4489fb6cc3fa8a0adR363) - Before, only problems that were public or where the user was explicitly set as accessible were visible on the problems list. Now, _all_ visible problems are shown. **Cannot tell if this is a bug or a feature.**
 - [judge/views/select2.py](https://github.com/DMOJ/online-judge/compare/master...Ninjaclasher:problem-filter?expand=1#diff-e5e7ff9f4e4a093600d0999663dd30c0R57) - Before, any public problem or problem where the user was author or curator were visible here, even if they were organization private. This seems like a bug, and has been changed to any visible problem.