### PR TITLE
Use `width` instead of `max-width` for `content-left`

### DIFF
--- a/resources/content-description.scss
+++ b/resources/content-description.scss
@@ -22,7 +22,7 @@
         width: 100%;
 
         &.split-common-content {
-            max-width: 86%;
+            width: 70%;
         }
 
         .content-description {


### PR DESCRIPTION
Fixes #1282.

Before:
![image](https://user-images.githubusercontent.com/11021327/78580954-30f6c300-7801-11ea-83c6-c8e23b0d48c0.png)

After:
![image](https://user-images.githubusercontent.com/11021327/78580968-38b66780-7801-11ea-9748-0f8d0a1452e8.png)
