### PR TITLE
Pass in problem tester ids to not require a query per submission row

### DIFF
--- a/judge/jinja2/submission.py
+++ b/judge/jinja2/submission.py
@@ -2,7 +2,7 @@ from . import registry
 
 
 @registry.function
-def submission_layout(submission, profile_id, user, editable_problem_ids, completed_problem_ids):
+def submission_layout(submission, profile_id, user, completed_problem_ids, editable_problem_ids, tester_problem_ids):
     problem_id = submission.problem_id
     can_view = False
 
@@ -16,6 +16,6 @@ def submission_layout(submission, profile_id, user, editable_problem_ids, comple
         can_view = True
 
     if submission.problem_id in completed_problem_ids:
-        can_view |= submission.problem.is_public or profile_id in submission.problem.tester_ids
+        can_view |= submission.problem.is_public or submission.problem_id in tester_problem_ids
 
     return can_view

--- a/judge/utils/problems.py
+++ b/judge/utils/problems.py
@@ -9,12 +9,11 @@ from django.utils.translation import gettext as _, gettext_noop
 
 from judge.models import Problem, Submission
 
-__all__ = ['contest_completed_ids', 'get_result_data', 'user_completed_ids', 'user_authored_ids', 'user_editable_ids']
+__all__ = ['contest_completed_ids', 'get_result_data', 'user_completed_ids', 'user_editable_ids', 'user_tester_ids']
 
 
-def user_authored_ids(profile):
-    result = set(Problem.objects.filter(authors=profile).values_list('id', flat=True))
-    return result
+def user_tester_ids(profile):
+    return set(Problem.objects.filter(testers=profile).values_list('id', flat=True))
 
 
 def user_editable_ids(profile):

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -22,7 +22,7 @@ from django.views.generic import DetailView, ListView
 from judge import event_poster as event
 from judge.highlight_code import highlight_code
 from judge.models import Contest, Language, Problem, ProblemTranslation, Profile, Submission
-from judge.utils.problems import get_result_data, user_authored_ids, user_completed_ids, user_editable_ids
+from judge.utils.problems import get_result_data, user_completed_ids, user_editable_ids, user_tester_ids
 from judge.utils.raw_sql import join_sql_subquery, use_straight_join
 from judge.utils.views import DiggPaginatorMixin, TitleMixin
 
@@ -282,8 +282,8 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
         context['dynamic_update'] = False
         context['show_problem'] = self.show_problem
         context['completed_problem_ids'] = user_completed_ids(self.request.profile) if authenticated else []
-        context['authored_problem_ids'] = user_authored_ids(self.request.profile) if authenticated else []
         context['editable_problem_ids'] = user_editable_ids(self.request.profile) if authenticated else []
+        context['tester_problem_ids'] = user_tester_ids(self.request.profile) if authenticated else []
 
         context['all_languages'] = Language.objects.all().values_list('key', 'name')
         context['selected_languages'] = self.selected_languages
@@ -463,9 +463,9 @@ def single_submission(request, submission_id, show_problem=True):
 
     return render(request, 'submission/row.html', {
         'submission': submission,
-        'authored_problem_ids': user_authored_ids(request.profile) if authenticated else [],
         'completed_problem_ids': user_completed_ids(request.profile) if authenticated else [],
         'editable_problem_ids': user_editable_ids(request.profile) if authenticated else [],
+        'tester_problem_ids': user_tester_ids(request.profile) if authenticated else [],
         'show_problem': show_problem,
         'problem_name': show_problem and submission.problem.translated_name(request.LANGUAGE_CODE),
         'profile_id': request.profile.id if authenticated else 0,

--- a/templates/submission/row.html
+++ b/templates/submission/row.html
@@ -1,4 +1,4 @@
-{% set can_view = submission_layout(submission, profile_id, request.user, editable_problem_ids, completed_problem_ids) %}
+{% set can_view = submission_layout(submission, profile_id, request.user, completed_problem_ids, editable_problem_ids, tester_problem_ids) %}
 <div class="sub-result {{ submission.result_class }}">
     <div class="score">
         {%- if submission.is_graded -%}


### PR DESCRIPTION
Currently, the `submission.problem.tester_ids` in [here](https://github.com/DMOJ/online-judge/compare/master...Ninjaclasher:patch-4?expand=1#diff-63245bf8eebdfd28c89922c02e4f8f8bL19) fetches the tester ids from the database for every submission. In the worse case, this could cause 50 (the page size) uneeded queries for a submission page.

This is usually not that big of an issue, since it is pretty hard to get a submission where:
 1. You do not have edit access to the problem.
 2. The submission is not by you.
 3. You do not have the permission `judge.change_submission`.
 4. The problem is not public.
 5. You have solved the problem.

The only case I can think of where this is an issue is in a contest where there are problems you normally would not have access to, and you have solved the problem. All the other checks in `submission_layout` would return false, and the `profile_id in submission.problem.tester_ids` code would run.