### PR TITLE
Move submission access check into a helper method

### DIFF
--- a/judge/jinja2/submission.py
+++ b/judge/jinja2/submission.py
@@ -6,13 +6,13 @@ def submission_layout(submission, profile_id, user, completed_problem_ids, edita
     problem_id = submission.problem_id
     can_view = False
 
-    if problem_id in editable_problem_ids:
+    if user.has_perm('judge.view_all_submission'):
         can_view = True
 
     if profile_id == submission.user_id:
         can_view = True
 
-    if user.has_perm('judge.change_submission'):
+    if problem_id in editable_problem_ids:
         can_view = True
 
     if submission.problem_id in completed_problem_ids:

--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -123,6 +123,22 @@ class Submission(models.Model):
 
     abort.alters_data = True
 
+    def can_see_detail(self, user):
+        profile = user.profile
+        if not user.is_authenticated:
+            return False
+        if user.has_perm('judge.view_all_submission'):
+            return True
+        if self.user_id == profile.id:
+            return True
+        if self.problem.is_editor(profile):
+            return True
+        if (self.problem.is_public or self.problem.testers.filter(id=profile.id).exists()) and \
+                self.problem.submission_set.filter(user_id=profile.id, result='AC',
+                                                   points=self.problem.points).exists():
+            return True
+        return False
+
     def update_contest(self):
         try:
             contest = self.contest

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -43,19 +43,9 @@ class SubmissionMixin(object):
 class SubmissionDetailBase(LoginRequiredMixin, TitleMixin, SubmissionMixin, DetailView):
     def get_object(self, queryset=None):
         submission = super(SubmissionDetailBase, self).get_object(queryset)
-        profile = self.request.profile
-        problem = submission.problem
-        if self.request.user.has_perm('judge.view_all_submission'):
-            return submission
-        if submission.user_id == profile.id:
-            return submission
-        if problem.is_editor(profile):
-            return submission
-        if problem.is_public or problem.testers.filter(id=profile.id).exists():
-            if Submission.objects.filter(user_id=profile.id, result='AC', problem_id=problem.id,
-                                         points=problem.points).exists():
-                return submission
-        raise PermissionDenied()
+        if not submission.can_see_detail(self.request.user):
+            raise PermissionDenied()
+        return submission
 
     def get_title(self):
         submission = self.object


### PR DESCRIPTION
Also fixes the permission name in the template check.

This is necessary for #1291.

