### PR TITLE
Use the problem from the URL rather than the id in ProblemSubmitForm

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -72,15 +72,13 @@ class ProblemSubmitForm(ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(ProblemSubmitForm, self).__init__(*args, **kwargs)
-        self.fields['problem'].empty_label = None
-        self.fields['problem'].widget = forms.HiddenInput()
         self.fields['language'].empty_label = None
         self.fields['language'].label_from_instance = attrgetter('display_name')
         self.fields['language'].queryset = Language.objects.filter(judges__online=True).distinct()
 
     class Meta:
         model = Submission
-        fields = ['problem', 'language']
+        fields = ['language']
 
 
 class EditOrganizationForm(ModelForm):

--- a/templates/problem/submit.html
+++ b/templates/problem/submit.html
@@ -128,7 +128,7 @@
                 margin-top: 0.7em;
             }
 
-            #submit-wrapper #problem-id, #submit-wrapper #editor, #submit-wrapper #language {
+            #submit-wrapper #editor, #submit-wrapper #language {
                 margin-top: 4px;
             }
 
@@ -227,10 +227,6 @@
         {% csrf_token %}
         {{ form.non_field_errors() }}
         <div id="submit-wrapper">
-            <div id="problem-id">
-                {{ form.problem.errors }}
-                {{ form.problem }}
-            </div>
             <div id="editor">
                 {{ form.source.errors }}
                 {{ form.source }}


### PR DESCRIPTION
There are no endpoints where `problem` is None, we can just use the problem code from the URL instead of using the problem id in the submit form and juggling between 2 different problem objects.

This PR will make #1325 significantly easier to finish.