### PR TITLE
Make selenium imports determine whether it is used

### DIFF
--- a/judge/pdf_problems.py
+++ b/judge/pdf_problems.py
@@ -11,6 +11,8 @@ import uuid
 from django.conf import settings
 from django.utils.translation import gettext
 
+logger = logging.getLogger('judge.problem.pdf')
+
 HAS_SELENIUM = False
 if settings.USE_SELENIUM:
     try:
@@ -20,8 +22,8 @@ if settings.USE_SELENIUM:
         from selenium.webdriver.support import expected_conditions as EC
         from selenium.webdriver.support.ui import WebDriverWait
         HAS_SELENIUM = True
-    except ImportError:
-        pass
+    except ImportError as e:
+        logger.warning(e, exc_info=True)
 
 HAS_PHANTOMJS = os.access(settings.PHANTOMJS, os.X_OK)
 HAS_SLIMERJS = os.access(settings.SLIMERJS, os.X_OK)
@@ -35,8 +37,6 @@ HAS_PDF = (os.path.isdir(settings.DMOJ_PDF_PROBLEM_CACHE) and
 
 EXIFTOOL = settings.EXIFTOOL
 HAS_EXIFTOOL = os.access(EXIFTOOL, os.X_OK)
-
-logger = logging.getLogger('judge.problem.pdf')
 
 
 class BasePdfMaker(object):

--- a/judge/pdf_problems.py
+++ b/judge/pdf_problems.py
@@ -23,7 +23,7 @@ if settings.USE_SELENIUM:
         from selenium.webdriver.support.ui import WebDriverWait
         HAS_SELENIUM = True
     except ImportError:
-        logger.warning('Failed to import Selenium')
+        logger.warning('Failed to import Selenium', exc_info=True)
 
 HAS_PHANTOMJS = os.access(settings.PHANTOMJS, os.X_OK)
 HAS_SLIMERJS = os.access(settings.SLIMERJS, os.X_OK)

--- a/judge/pdf_problems.py
+++ b/judge/pdf_problems.py
@@ -22,8 +22,8 @@ if settings.USE_SELENIUM:
         from selenium.webdriver.support import expected_conditions as EC
         from selenium.webdriver.support.ui import WebDriverWait
         HAS_SELENIUM = True
-    except ImportError as e:
-        logger.warning(e, exc_info=True)
+    except ImportError:
+        logger.warning('Failed to import Selenium')
 
 HAS_PHANTOMJS = os.access(settings.PHANTOMJS, os.X_OK)
 HAS_SLIMERJS = os.access(settings.SLIMERJS, os.X_OK)

--- a/judge/pdf_problems.py
+++ b/judge/pdf_problems.py
@@ -13,12 +13,15 @@ from django.utils.translation import gettext
 
 HAS_SELENIUM = False
 if settings.USE_SELENIUM:
-    from selenium import webdriver
-    from selenium.common.exceptions import TimeoutException
-    from selenium.webdriver.common.by import By
-    from selenium.webdriver.support import expected_conditions as EC
-    from selenium.webdriver.support.ui import WebDriverWait
-    HAS_SELENIUM = True
+    try:
+        from selenium import webdriver
+        from selenium.common.exceptions import TimeoutException
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.support import expected_conditions as EC
+        from selenium.webdriver.support.ui import WebDriverWait
+        HAS_SELENIUM = True
+    except ImportError:
+        pass
 
 HAS_PHANTOMJS = os.access(settings.PHANTOMJS, os.X_OK)
 HAS_SLIMERJS = os.access(settings.SLIMERJS, os.X_OK)


### PR DESCRIPTION
Right now, selenium *must* import successfully if the `USE_SELENIUM` variable is set, raising an `ImportError` otherwise. However, this also poses an issue if different parts of the site are running from different clones of the repository. It requires all parts, such as the bridge, to have selenium installed, unless separate `local_settings.py` files are used.

This PR sets the `HAS_SELENIUM` variable based off of whether the importing of `selenium` has succeeded or failed, if `USE_SELENIUM` is set to `True`.