### PR TITLE
 Use class instead of nth-child for hiding problem list columns; #1055

### DIFF
--- a/resources/problem.scss
+++ b/resources/problem.scss
@@ -232,19 +232,19 @@ ul.problem-list {
 }
 
 @media (max-width: 550px) {
-    #problem-table tr :nth-child(6) {
+    #problem-table tr .users {
         display: none;
     }
 }
 
 @media (max-width: 450px) {
-    #problem-table tr :nth-child(4) {
+    #problem-table tr .ac-rate {
         display: none;
     }
 }
 
 @media (max-width: 350px) {
-    #problem-table tr :nth-child(3) {
+    #problem-table tr .category {
         display: none;
     }
 }


### PR DESCRIPTION
Fixes #1055.

Side question: why are columns being hidden in the first place? Why not make the table scroll horizontally instead?