### PR TITLE
Fix UI issues related to #1368

### DIFF
--- a/resources/table.scss
+++ b/resources/table.scss
@@ -3,7 +3,6 @@
 $table_header_rounding: 6px;
 
 .h-scrollable-table {
-    display: block;
     overflow-x: auto;
 }
 

--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -195,8 +195,8 @@
                 </div>
             </div>
         {% endif %}
-        <div id="content-left" class="problems">
-            <table id="problem-table" class="table h-scrollable-table striped">
+        <div id="content-left" class="problems h-scrollable-table">
+            <table id="problem-table" class="table striped">
                 <thead>
                 <tr>
                     {% if request.in_contest %}

--- a/templates/status/judge-status.html
+++ b/templates/status/judge-status.html
@@ -17,7 +17,9 @@
 {% endblock %}
 
 {% block body %}
-    <table id="judge-status" class="table h-scrollable-table">
-        {% include "status/judge-status-table.html" %}
-    </table>
+    <div class="h-scrollable-table">
+        <table id="judge-status" class="table">
+            {% include "status/judge-status-table.html" %}
+        </table>
+    </div>
 {% endblock %}

--- a/templates/status/language-list.html
+++ b/templates/status/language-list.html
@@ -27,34 +27,36 @@
 {% endblock %}
 
 {% block body %}
-    <table class="table h-scrollable-table">
-        <thead>
-        <tr>
-            <th>{{ _('ID') }}</th>
-            <th>{{ _('Name') }}</th>
-            <th>{{ _('Runtime Info') }}</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for language in languages %}
-            {# All online languages have runtime_versions, even if we're not going to display them #}
-            {% if language.runtime_versions %}
-                <tr>
-                    <td>{{ language.short_display_name }}</td>
-                    <td class="language">{{ language.name }}</td>
-                    <td class="info">
-                        <code>{{ runtime_versions(language.runtime_versions()) }}</code>
-                        {% if language.description %}
-                            <div class="content-description">
-                                {% cache 86400 'language_html' language.id %}
-                                    {{ language.description|markdown('language') }}
-                                {% endcache %}
-                            </div>
-                        {% endif %}
-                    </td>
-                </tr>
-            {% endif %}
-        {% endfor %}
-        </tbody>
-    </table>
+    <div class="h-scrollable-table">
+        <table class="table">
+            <thead>
+            <tr>
+                <th>{{ _('ID') }}</th>
+                <th>{{ _('Name') }}</th>
+                <th>{{ _('Runtime Info') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for language in languages %}
+                {# All online languages have runtime_versions, even if we're not going to display them #}
+                {% if language.runtime_versions %}
+                    <tr>
+                        <td>{{ language.short_display_name }}</td>
+                        <td class="language">{{ language.name }}</td>
+                        <td class="info">
+                            <code>{{ runtime_versions(language.runtime_versions()) }}</code>
+                            {% if language.description %}
+                                <div class="content-description">
+                                    {% cache 86400 'language_html' language.id %}
+                                        {{ language.description|markdown('language') }}
+                                    {% endcache %}
+                                </div>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
 {% endblock %}

--- a/templates/status/versions.html
+++ b/templates/status/versions.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block body %}
-    <table id="judge-versions" class="table h-scrollable-table">
+    <table id="judge-versions" class="table">
         <tr>
             <th></th>
             {% for judge in judges %}

--- a/templates/ticket/list.html
+++ b/templates/ticket/list.html
@@ -254,22 +254,24 @@
             {% if page_obj.num_pages > 1 %}
                 <div style="margin-bottom:6px; margin-top:3px">{% include "list-pages.html" %}</div>
             {% endif %}
-            <table id="ticket-list" class="table h-scrollable-table">
-                <thead>
-                <tr>
-                    <th></th>
-                    <th>{{ _('ID') }}</th>
-                    <th>{{ _('Title') }}</th>
-                    <th>{{ _('User') }}</th>
-                    <th>{{ _('Assignees') }}</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for ticket in tickets %}
-                    {% include "ticket/row.html" %}
-                {% endfor %}
-                </tbody>
-            </table>
+            <div class="h-scrollable-table">
+                <table id="ticket-list" class="table">
+                    <thead>
+                    <tr>
+                        <th></th>
+                        <th>{{ _('ID') }}</th>
+                        <th>{{ _('Title') }}</th>
+                        <th>{{ _('User') }}</th>
+                        <th>{{ _('Assignees') }}</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for ticket in tickets %}
+                        {% include "ticket/row.html" %}
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
             {% if page_obj.num_pages > 1 %}
                 <div style="margin-top:10px">{% include "list-pages.html" %}</div>
             {% endif %}

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -71,9 +71,11 @@
                 </div>
             {% endif %}
 
-            <table id="users-table" class="table h-scrollable-table">
-                {% block users_table %}{% endblock %}
-            </table>
+            <div class="h-scrollable-table">
+                <table id="users-table" class="table">
+                    {% block users_table %}{% endblock %}
+                </table>
+            </div>
 
             {% if page_obj and page_obj.num_pages > 1 %}
                 <div style="margin-top:10px;">{% include "list-pages.html" %}</div>


### PR DESCRIPTION
1. Tables do not take the full width of the screen in special cases.
2. Runtime versions table header is broken if the table is set to horizontally scrollable.