### PR TITLE
Show admin links for submissions that the user can edit

### DIFF
--- a/templates/submission/info-base.html
+++ b/templates/submission/info-base.html
@@ -3,14 +3,16 @@
 {% block header %}
     <span class="submission-info">
         <span class="submission-date">{{ submission.date|date(_("N j, Y, g:i a")) }}
-            {%- if perms.judge.change_submission and submission.judged_on %}
-                on {{ submission.judged_on.name }}
-            {% endif %}
-            <br>
-            <span>{{ submission.language }}</span>
-            {% if perms.judge.change_submission %}
-                [<a href="{{ url('admin:judge_submission_change', submission.id) }}">{{ _('Admin') }}</a>]
-            {% endif %}
+            {% with can_edit=submission.problem.is_editable_by(request.user) %}
+                {%- if can_edit and submission.judged_on %}
+                    on {{ submission.judged_on.name }}
+                {% endif %}
+                <br>
+                <span>{{ submission.language }}</span>
+                {% if can_edit %}
+                    [<a href="{{ url('admin:judge_submission_change', submission.id) }}">{{ _('Admin') }}</a>]
+                {% endif %}
+            {% endwith %}
         </span>
     </span>
 {% endblock %}


### PR DESCRIPTION
Users that can edit a problem can already access submissions for that problem through the admin site. This PR exposes the `Admin` link on submissions for users that can edit the problem, rather than depending on `judge.change_submission` which is not even used in the admin access check.