### PR TITLE
Fix some UI issues related to user ranking tables

### DIFF
--- a/resources/users.scss
+++ b/resources/users.scss
@@ -79,7 +79,6 @@ th.header.rank {
     display: inline-block;
     vertical-align: top;
     width: 225px;
-    float: right;
 
     .select2-selection__arrow {
         display: none;

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -247,7 +247,7 @@
     {% include "contest/media-js.html" %}
 {% endblock %}
 
-{% block users_table %}
+{% block before_users_table %}
     <div style="margin-bottom: 0.5em">
         {% if tab == 'participation' %}
             {% if contest.start_time <= now or perms.judge.see_private_contest %}
@@ -257,5 +257,8 @@
         <input id="show-organizations-checkbox" type="checkbox" style="vertical-align: bottom">
         <label for="show-organizations-checkbox" style="vertical-align: bottom">{{ _('Show organizations') }}</label>
     </div>
+{% endblock %}
+
+{% block users_table %}
     {% include "contest/ranking-table.html" %}
 {% endblock %}

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -56,13 +56,22 @@
 
 {% block media %}
     {% block users_media %}{% endblock %}
+    <style>
+        .user-pagination {
+            margin-bottom: 7px;
+            margin-top: 3px;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+        }
+    </style>
 {% endblock %}
 
 {% block body %}
     <div id="common-content">
         <div id="content-left" class="users">
             {% if page_obj and page_obj.num_pages > 1 %}
-                <div style="margin-bottom: 7px; margin-top: 3px;">
+                <div class="user-pagination">
                     {% include "list-pages.html" %}
                     <form id="search-form" name="form" action="{{ url('user_ranking_redirect') }}" method="get">
                         <input id="search-handle" type="text" name="search"

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -80,6 +80,8 @@
                 </div>
             {% endif %}
 
+            {% block before_users_table %}{% endblock %}
+
             <div class="h-scrollable-table">
                 <table id="users-table" class="table">
                     {% block users_table %}{% endblock %}


### PR DESCRIPTION
Note that it may be easier to view the commits in this PR separately, but they are put together in one PR since they directly affect one another.

1. The main user leaderboard is cutoff since the `float:right` from the search bar covers over the table. The solution here was to convert to flexbox.

2. The `View user participation` and `Show organizations` controls were part of the contest ranking table before, which meant they would scroll off the screen when the contest ranking table was scrolled. The solution here was to move it out of the `<table></table>`.