### PR TITLE
Refactor contest scoreboard access checks into two methods

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -165,17 +165,30 @@ class Contest(models.Model):
         return False
 
     def can_see_scoreboard(self, user):
+        if self.can_see_full_scoreboard(user):
+            return True
+        if not self.can_join:
+            return False
+        if not self.show_scoreboard and not self.is_in_contest(user):
+            return False
+        return True
+
+    def can_see_full_scoreboard(self, user):
+        if self.show_scoreboard:
+            return True
         if user.has_perm('judge.see_private_contest'):
             return True
-        if user.is_authenticated and self.organizers.filter(id=user.profile.id).exists():
+        if self.is_editable_by(user):
             return True
-        if not self.is_visible:
-            return False
-        if self.start_time is not None and self.start_time > timezone.now():
-            return False
         if user.is_authenticated and self.view_contest_scoreboard.filter(id=user.profile.id).exists():
             return True
-        if self.hide_scoreboard and not self.is_in_contest(user) and self.end_time > timezone.now():
+        return False
+
+    @cached_property
+    def show_scoreboard(self):
+        if not self.can_join:
+            return False
+        if self.hide_scoreboard and not self.ended:
             return False
         return True
 
@@ -221,12 +234,6 @@ class Contest(models.Model):
         self.save()
 
     update_user_count.alters_data = True
-
-    @cached_property
-    def show_scoreboard(self):
-        if self.hide_scoreboard and not self.ended:
-            return False
-        return True
 
     class Inaccessible(Exception):
         pass

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -164,7 +164,7 @@ class Contest(models.Model):
             return profile and profile.current_contest is not None and profile.current_contest.contest == self
         return False
 
-    def can_see_scoreboard(self, user):
+    def can_see_own_scoreboard(self, user):
         if self.can_see_full_scoreboard(user):
             return True
         if not self.can_join:

--- a/judge/views/api/api_v1.py
+++ b/judge/views/api/api_v1.py
@@ -36,9 +36,7 @@ def api_v1_contest_detail(request, contest):
         raise Http404()
 
     in_contest = contest.is_in_contest(request.user)
-    can_see_rankings = contest.can_see_scoreboard(request.user)
-    if contest.hide_scoreboard and in_contest:
-        can_see_rankings = False
+    can_see_rankings = contest.can_see_full_scoreboard(request.user)
 
     problems = list(contest.contest_problems.select_related('problem')
                     .defer('problem__description').order_by('order'))

--- a/judge/views/api/api_v2.py
+++ b/judge/views/api/api_v2.py
@@ -180,9 +180,7 @@ class APIContestDetail(APIDetailView):
 
     def get_object_data(self, contest):
         in_contest = contest.is_in_contest(self.request.user)
-        can_see_rankings = contest.can_see_scoreboard(self.request.user)
-        if contest.hide_scoreboard and in_contest:
-            can_see_rankings = False
+        can_see_rankings = contest.can_see_full_scoreboard(self.request.user)
         can_see_problems = (in_contest or contest.ended or contest.is_editable_by(self.request.user))
 
         problems = list(

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -632,7 +632,7 @@ class ContestRankingBase(ContestMixin, TitleMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        if not self.object.can_see_scoreboard(self.request.user):
+        if not self.object.can_see_own_scoreboard(self.request.user):
             raise Http404()
 
         users, problems = self.get_ranking_list()

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -587,10 +587,6 @@ def get_contest_ranking_list(request, contest, participation=None, ranking_list=
                              show_current_virtual=True, ranker=ranker):
     problems = list(contest.contest_problems.select_related('problem').defer('problem__description').order_by('order'))
 
-    if contest.hide_scoreboard and contest.is_in_contest(request.user):
-        return ([(_('???'), make_contest_ranking_profile(contest, request.profile.current_contest, problems))],
-                problems)
-
     users = ranker(ranking_list(contest, problems), key=attrgetter('points', 'cumtime', 'tiebreaker'))
 
     if show_current_virtual:
@@ -608,7 +604,7 @@ def contest_ranking_ajax(request, contest, participation=None):
     if not exists:
         return HttpResponseBadRequest('Invalid contest', content_type='text/plain')
 
-    if not contest.can_see_scoreboard(request.user):
+    if not contest.can_see_full_scoreboard(request.user):
         raise Http404()
 
     users, problems = get_contest_ranking_list(request, contest, participation)
@@ -654,6 +650,14 @@ class ContestRanking(ContestRankingBase):
         return _('%s Rankings') % self.object.name
 
     def get_ranking_list(self):
+        if not self.object.can_see_full_scoreboard(self.request.user):
+            queryset = self.object.users.filter(user=self.request.profile, virtual=ContestParticipation.LIVE)
+            return get_contest_ranking_list(
+                self.request, self.object,
+                ranking_list=partial(base_contest_ranking_list, queryset=queryset),
+                ranker=lambda users, key: ((_('???'), user) for user in users),
+            )
+
         return get_contest_ranking_list(self.request, self.object)
 
     def get_context_data(self, **kwargs):
@@ -671,6 +675,9 @@ class ContestParticipationList(LoginRequiredMixin, ContestRankingBase):
         return _("%s's participation in %s") % (self.profile.username, self.object.name)
 
     def get_ranking_list(self):
+        if not self.object.can_see_full_scoreboard(self.request.user) and self.profile != self.request.profile:
+            raise Http404()
+
         queryset = self.object.users.filter(user=self.profile, virtual__gte=0).order_by('-virtual')
         live_link = format_html('<a href="{2}#!{1}">{0}</a>', _('Live'), self.profile.username,
                                 reverse('contest_ranking', args=[self.object.key]))

--- a/judge/views/select2.py
+++ b/judge/views/select2.py
@@ -104,8 +104,7 @@ class UserSearchSelect2View(BaseListView):
 class ContestUserSearchSelect2View(UserSearchSelect2View):
     def get_queryset(self):
         contest = get_object_or_404(Contest, key=self.kwargs['contest'])
-        if not contest.can_see_scoreboard(self.request.user) or \
-                contest.hide_scoreboard and contest.is_in_contest(self.request.user):
+        if not contest.is_accessible_by(self.request.user) or not contest.can_see_full_scoreboard(self.request.user):
             raise Http404()
 
         return Profile.objects.filter(contest_history__contest=contest,

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -223,7 +223,7 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
                                                               language=self.request.LANGUAGE_CODE), to_attr='_trans'))
         if self.in_contest:
             queryset = queryset.filter(contest_object=self.contest)
-            if self.contest.hide_scoreboard and self.contest.is_in_contest(self.request.user):
+            if not self.contest.can_see_full_scoreboard(self.request.user):
                 queryset = queryset.filter(user=self.request.profile)
         else:
             queryset = queryset.select_related('contest_object').defer('contest_object__description')

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -373,7 +373,7 @@ class ProblemSubmissionsBase(SubmissionsListBase):
                            reverse('problem_detail', args=[self.problem.code]))
 
     def access_check_contest(self, request):
-        if self.in_contest and not self.contest.can_see_scoreboard(request.user):
+        if self.in_contest and not self.contest.can_see_own_scoreboard(request.user):
             raise Http404()
 
     def access_check(self, request):

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -7,13 +7,13 @@
     {% endif %}
 
     {% if contest.start_time <= now or perms.judge.see_private_contest %}
-        {% if contest.show_scoreboard or contest.can_see_scoreboard(request.user) %}
+        {% if contest.can_see_scoreboard(request.user) %}
             {{ make_tab('ranking', 'fa-bar-chart', url('contest_ranking', contest.key), _('Rankings')) }}
+            {% if request.user.is_authenticated %}
+                {{ make_tab('participation', 'fa-users', url('contest_participation_own', contest.key), _('Participation')) }}
+            {% endif %}
         {% else %}
             {{ make_tab('ranking', 'fa-bar-chart', None, _('Hidden Rankings')) }}
-        {% endif %}
-        {% if contest.show_scoreboard and request.user.is_authenticated %}
-            {{ make_tab('participation', 'fa-users', url('contest_participation_own', contest.key), _('Participation')) }}
         {% endif %}
     {% endif %}
     {% if can_edit %}

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -7,7 +7,7 @@
     {% endif %}
 
     {% if contest.start_time <= now or perms.judge.see_private_contest %}
-        {% if contest.can_see_scoreboard(request.user) %}
+        {% if contest.can_see_own_scoreboard(request.user) %}
             {{ make_tab('ranking', 'fa-bar-chart', url('contest_ranking', contest.key), _('Rankings')) }}
             {% if request.user.is_authenticated %}
                 {{ make_tab('participation', 'fa-users', url('contest_participation_own', contest.key), _('Participation')) }}

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -114,7 +114,7 @@
 {% endmacro %}
 
 {% macro user_count(contest, user) %}
-    {% if contest.show_scoreboard or contest.can_see_scoreboard(user) %}
+    {% if contest.can_see_scoreboard(user) %}
         <a href="{{ url('contest_ranking', contest.key) }}">{{ contest.user_count }}</a>
     {% else %}
         {{ contest.user_count }}

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -114,7 +114,7 @@
 {% endmacro %}
 
 {% macro user_count(contest, user) %}
-    {% if contest.can_see_scoreboard(user) %}
+    {% if contest.can_see_own_scoreboard(user) %}
         <a href="{{ url('contest_ranking', contest.key) }}">{{ contest.user_count }}</a>
     {% else %}
         {{ contest.user_count }}

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -250,7 +250,7 @@
 {% block before_users_table %}
     <div style="margin-bottom: 0.5em">
         {% if tab == 'participation' %}
-            {% if contest.start_time <= now or perms.judge.see_private_contest %}
+            {% if contest.can_see_full_scoreboard(request.user) %}
                 <input id="search-contest" type="text" placeholder="{{ _('View user participation') }}">
             {% endif %}
         {% endif %}


### PR DESCRIPTION
Currently, there is one method to determine whether a user can access the contest scoreboard, `can_see_scoreboard`. However, it doesn't distinguish between whether the user can see _their_ performance or the _entire_ rankings, and it is left to the caller to distinguish.

This PR refactors this logic into two methods, `can_see_scoreboard` - whether the user can click on "Rankings", and `can_see_full_scoreboard` - whether the user can see the entire rankings. 

Most of the code here has been in production on MCPT for a while now (a few months), so there should not be any accidental scoreboard leaks.