### PR TITLE
Move login requirement check out of TicketMixin

### DIFF
--- a/judge/views/ticket.py
+++ b/judge/views/ticket.py
@@ -99,13 +99,11 @@ class TicketCommentForm(forms.Form):
     body = forms.CharField(widget=ticket_widget)
 
 
-class TicketMixin(object):
+class TicketMixin(LoginRequiredMixin):
     model = Ticket
 
     def get_object(self, queryset=None):
         ticket = super(TicketMixin, self).get_object(queryset)
-        if not self.request.user.is_authenticated:
-            raise PermissionDenied()
         profile_id = self.request.profile.id
         if self.request.user.has_perm('judge.change_ticket'):
             return ticket
@@ -119,7 +117,7 @@ class TicketMixin(object):
         raise PermissionDenied()
 
 
-class TicketView(TitleMixin, LoginRequiredMixin, TicketMixin, SingleObjectFormView):
+class TicketView(TitleMixin, TicketMixin, SingleObjectFormView):
     form_class = TicketCommentForm
     template_name = 'ticket/ticket.html'
     context_object_name = 'ticket'
@@ -151,7 +149,7 @@ class TicketView(TitleMixin, LoginRequiredMixin, TicketMixin, SingleObjectFormVi
         return context
 
 
-class TicketStatusChangeView(LoginRequiredMixin, TicketMixin, SingleObjectMixin, View):
+class TicketStatusChangeView(TicketMixin, SingleObjectMixin, View):
     open = None
 
     def post(self, request, *args, **kwargs):
@@ -178,7 +176,7 @@ class TicketNotesForm(forms.Form):
     notes = forms.CharField(widget=forms.Textarea(), required=False)
 
 
-class TicketNotesEditView(LoginRequiredMixin, TicketMixin, SingleObjectFormView):
+class TicketNotesEditView(TicketMixin, SingleObjectFormView):
     template_name = 'ticket/edit-notes.html'
     form_class = TicketNotesForm
     context_object_name = 'ticket'


### PR DESCRIPTION
Instead, inherit LoginRequiredMixin in TicketMixin and remove it
from all views that use the TicketMixin.

Supersedes #1387 