### PR TITLE
Add admin action to set problem publish date to now

### DIFF
--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -39,7 +39,7 @@ class PostList(ListView):
         context['page_prefix'] = reverse('blog_post_list')
         context['comments'] = Comment.most_recent(self.request.user, 10)
         context['new_problems'] = Problem.get_public_problems() \
-                                         .order_by('-date', '-id')[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
+                                         .order_by('-date', 'code')[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
         context['page_titles'] = CacheDict(lambda page: Comment.get_page_title(page))
 
         context['has_clarifications'] = False


### PR DESCRIPTION
Usually, when batch publicing problems (e.g contest problems), you also want to set the publish date. This would mean you would have to click into each problem to update the publish date (which is very slow if you have a lot of problems). 

This PR adds an action to update the publish date so that you can batch update publish date + problem visibility without individually going into each problem.