### PR TITLE
Fix contest ranking scroll on medium width screens for some browsers

### DIFF
--- a/resources/users.scss
+++ b/resources/users.scss
@@ -1,21 +1,6 @@
-@media(min-width: 400px) {
-    #content-right {
-        &.users {
-            padding-left: 1.5em;
-        }
-    }
-}
-
-#content-right {
-    &.users {
-        flex: 40%;
-        max-width: 17em;
-    }
-}
-
 #content-left {
     &.users {
-        flex: 60%;
+        flex: unset;
     }
 }
 


### PR DESCRIPTION
`content-right` is not even used in any user tables. This has caused issues on some browsers with the contest ranking table overflowing to the left (without a scrollbar) rather than overflowing to the right (with a scrollbar). 