### PR TITLE
Do not write empty `init.yml`

### DIFF
--- a/judge/utils/problem_data.py
+++ b/judge/utils/problem_data.py
@@ -190,7 +190,13 @@ class ProblemDataCompiler(object):
         else:
             self.data.feedback = ''
             self.data.save()
-            problem_data_storage.save(yml_file, ContentFile(init))
+            if init:
+                problem_data_storage.save(yml_file, ContentFile(init))
+            else:
+                # Don't write empty init.yml since we should be looking in manually managed
+                # judge-server#670 will not update cache on empty init.yml,
+                # but will do so if there is no init.yml, so we delete the init.yml
+                problem_data_storage.delete(yml_file)
 
     @classmethod
     def generate(cls, *args, **kwargs):


### PR DESCRIPTION
If the `init.yml` is empty, we should probably be looking in manually managed data. DMOJ/judge-server#670 will not remove the folder from the cache if it sees an `init.yml`, even an empty one, so we delete it instead.