### PR TITLE
Remove widget if no open organizations available

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -64,16 +64,12 @@ class ProfileForm(ModelForm):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)
         super(ProfileForm, self).__init__(*args, **kwargs)
-        if not Organization.objects.exists():
-            del self.fields['organizations']
-        elif not user.has_perm('judge.edit_all_organization'):
-            filtered_organizations = Organization.objects.filter(
+        if not user.has_perm('judge.edit_all_organization'):
+            self.fields['organizations'].queryset = Organization.objects.filter(
                 Q(is_open=True) | Q(id__in=user.profile.organizations.all()),
             )
-            if not filtered_organizations.exists():
-                del self.fields['organizations']
-            else:
-                self.fields['organizations'].queryset = filtered_organizations
+        if not self.fields['organizations'].queryset.exists():
+            self.fields.pop('organizations')
 
 
 class DownloadDataForm(Form):

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -73,8 +73,8 @@ class ProfileForm(ModelForm):
             if not filtered_organizations.exists():
                 del self.fields['organizations']
             else:
-                self.fields['organizations'].queryset = filtered_organizations            
-        
+                self.fields['organizations'].queryset = filtered_organizations
+   
 
 class DownloadDataForm(Form):
     comment_download = BooleanField(required=False, label=_('Download comments?'))

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -68,7 +68,7 @@ class ProfileForm(ModelForm):
             self.fields['organizations'].queryset = Organization.objects.filter(
                 Q(is_open=True) | Q(id__in=user.profile.organizations.all()),
             )
-        if not self.fields['organizations'].queryset.exists():
+        if not self.fields['organizations'].queryset:
             self.fields.pop('organizations')
 
 

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -74,7 +74,7 @@ class ProfileForm(ModelForm):
                 del self.fields['organizations']
             else:
                 self.fields['organizations'].queryset = filtered_organizations
-   
+
 
 class DownloadDataForm(Form):
     comment_download = BooleanField(required=False, label=_('Download comments?'))

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -64,11 +64,17 @@ class ProfileForm(ModelForm):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)
         super(ProfileForm, self).__init__(*args, **kwargs)
-        if not user.has_perm('judge.edit_all_organization'):
-            self.fields['organizations'].queryset = Organization.objects.filter(
+        if not Organization.objects.exists():
+            del self.fields['organizations']
+        elif not user.has_perm('judge.edit_all_organization'):
+            filtered_organizations = Organization.objects.filter(
                 Q(is_open=True) | Q(id__in=user.profile.organizations.all()),
             )
-
+            if not filtered_organizations.exists():
+                del self.fields['organizations']
+            else:
+                self.fields['organizations'].queryset = filtered_organizations            
+        
 
 class DownloadDataForm(Form):
     comment_download = BooleanField(required=False, label=_('Download comments?'))

--- a/templates/user/edit-profile.html
+++ b/templates/user/edit-profile.html
@@ -226,12 +226,14 @@
                         {% endif %}
                     </table>
                 </div>
-                <div class="pane">
-                    <div style="padding-bottom:0.3em; margin-top:0.3em" class="block-header">
-                        {{ _('Affiliated organizations') }}:
+                {% if form.organizations %}
+                    <div class="pane">
+                        <div style="padding-bottom:0.3em; margin-top:0.3em" class="block-header">
+                            {{ _('Affiliated organizations') }}:
+                        </div>
+                        {{ form.organizations }}
                     </div>
-                    {{ form.organizations }}
-                </div>
+                {% endif %}
             </div>
             <hr>
             <div class="settings" style="padding-top:0.7em">


### PR DESCRIPTION
In regards to [Issue 656](https://github.com/DMOJ/online-judge/issues/656)

Removes the "Affiliated organizations" widget when no open organizations are available to the user. Prevents the browser from crashing due to a problem in the JavaScript code in a third party library.

[Comment regarding fix](https://github.com/DMOJ/online-judge/issues/656#issuecomment-354601730)