### PR TITLE
Remove contest editorial column if empty

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -217,6 +217,9 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
             .annotate(has_public_editorial=Sum(Case(When(solution__is_public=True, then=1),
                                                     default=0, output_field=IntegerField()))) \
             .add_i18n_name(self.request.LANGUAGE_CODE)
+        context['contest_has_public_editorials'] = any(
+            problem.is_public and problem.has_public_editorial for problem in context['contest_problems']
+        )
         return context
 
 

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -84,7 +84,9 @@
                     <th>{{ _('Points') }}</th>
                     <th>{{ _('AC Rate') }}</th>
                     <th>{{ _('Users') }}</th>
-                    <th></th>
+                    {% if contest_has_public_editorials %}
+                        <th>{{ _('Editorials') }}</th>
+                    {% endif %}
                 </tr>
                 </thead>
                 <tbody>
@@ -106,11 +108,13 @@
                                 {{ problem.user_count }}
                             {% endif %}
                         </td>
-                        <td>
-                            {% if problem.is_public and problem.has_public_editorial %}
-                                <a href="{{ url('problem_editorial', problem.code) }}">{{ _('Editorial') }}</a>
-                            {% endif %}
-                        </td>
+                        {% if contest_has_public_editorials %}
+                            <td>
+                                {% if problem.is_public and problem.has_public_editorial %}
+                                    <a href="{{ url('problem_editorial', problem.code) }}">{{ _('Editorial') }}</a>
+                                {% endif %}
+                            </td>
+                        {% endif %}
                     </tr>
                 {% endfor %}
                 </tbody>


### PR DESCRIPTION
Removes editorial column on a finished contest if there are no public editorials.
To replicate original bug:
- Find or create a contest with only problems that have no public editorials
- Open contest page and look at "Problems" table
![](https://cdn.discordapp.com/attachments/707315602037014538/716772745261744208/unknown.png)
Note the empty column at the end of the table, where editorials would be if public editorials existed
Fix:
![image](https://user-images.githubusercontent.com/38621453/83365264-db5c1400-a374-11ea-93a2-eb76bf61458d.png)
