### PR TITLE
Remove secondary ID sort on user list

### DIFF
--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -419,7 +419,7 @@ class UserList(QueryStringSortMixin, DiggPaginatorMixin, TitleMixin, ListView):
     default_sort = '-performance_points'
 
     def get_queryset(self):
-        return (Profile.objects.filter(is_unlisted=False).order_by(self.order, 'id').select_related('user')
+        return (Profile.objects.filter(is_unlisted=False).order_by(self.order).select_related('user')
                 .only('display_rank', 'user__username', 'points', 'rating', 'performance_points',
                       'problem_count'))
 


### PR DESCRIPTION
The query runs more than 2× as fast without it.