### PR TITLE
Fix `Submission.can_see_detail` erroring when user is not authenticated

### DIFF
--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -126,9 +126,9 @@ class Submission(models.Model):
     abort.alters_data = True
 
     def can_see_detail(self, user):
-        profile = user.profile
         if not user.is_authenticated:
             return False
+        profile = user.profile
         if self.problem.is_editable_by(user):
             return True
         elif user.has_perm('judge.view_all_submission'):


### PR DESCRIPTION
This is not an issue for the current uses of `Submission.can_see_detail` as all instances are guarded by some variation of `LoginRequiredMixin`, but it's nice to have working code...

This PR is required to allow the unittests in #1416 to pass (correctly).