### PR TITLE
Remove random 'k' in contest template

### DIFF
--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -138,4 +138,3 @@
     {{ super() }}
     {% include "comments/math.html" %}
 {% endblock %}
-k


### PR DESCRIPTION
This has been here for 5 years, and I'm not sure why...

Thanks to @6167656e74323431 for finding it.