### PR TITLE
Properly redirect when the organization slug is wrong

### DIFF
--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -60,7 +60,7 @@ class OrganizationDetailView(OrganizationMixin, DetailView):
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
         if self.object.slug != kwargs['slug']:
-            return HttpResponsePermanentRedirect(request.get_full_path().replace(kwargs['slug'], self.object.slug))
+            return HttpResponsePermanentRedirect(reverse('organization_home', args=(self.object.id, self.object.slug)))
         context = self.get_context_data(object=self.object)
         return self.render_to_response(context)
 


### PR DESCRIPTION
Stops redirects like https://dmoj.ca/organization/24-organization to https://dmoj.ca/a-b-lucas-ss/24-a-b-lucas-ss.