### PR TITLE
Break usernames and problem names in submission row instead of overflow

### DIFF
--- a/resources/submission.scss
+++ b/resources/submission.scss
@@ -57,6 +57,7 @@
     .sub-info {
         flex: 1;
         padding-left: 20px !important;
+        word-break: break-word;
 
         .name {
             font-weight: 700;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/29607503/84571969-ecd5f080-ad64-11ea-95f8-808cebbf663b.png)
After:
![image](https://user-images.githubusercontent.com/29607503/84571971-f2cbd180-ad64-11ea-85e2-fe79793b872e.png)
