### PR TITLE
Add (slightly better) mobile support for comments

### DIFF
--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -58,7 +58,7 @@ a {
 }
 
 .comment-operation {
-    float: right;
+    flex: auto;
 
     .fa {
         color: #444;
@@ -102,8 +102,7 @@ a {
 .comment {
     list-style: none none;
     border-radius: $widget_border_radius;
-    margin: (-50px) -4px 10px -40px;
-    padding-top: 50px;
+    margin: 0px -4px 10px -40px;
 
     &:target > .comment-box {
         border-left: 10px solid $highlight_blue;
@@ -116,6 +115,19 @@ a {
         margin-top: -50px;
         height: 50px;
         visibility: hidden;
+    }
+}
+
+.reply-comment {
+    margin: 0 23px 10px -40px;
+}
+
+@media (max-width: 760px) {
+    .comments {
+        padding-inline-start: 5%;
+    }
+    .comment {
+        margin-left: -5%;
     }
 }
 

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -29,14 +29,21 @@
                                 {% endif %}
                             </div>
                             {% with author=node.author, user=node.author.user %}
-                                <a href="{{ url('user_page', user.username) }}" class="user">
+                                <a href="{{ url('user_page', user.username) }}" class="user gravatar-main">
                                     <img src="{{ gravatar(author, 135) }}" class="gravatar">
                                 </a>
                             {% endwith %}
                         </div>
                         <div class="detail">
                             <div class="header">
-                                {{ link_user(node.author) }}&nbsp;
+                                <span>
+                                    {% with author=node.author, user=node.author.user %}
+                                        <a href="{{ url('user_page', user.username) }}" class="user gravatar-mobile">
+                                            <img src="{{ gravatar(author, 135) }}" class="gravatar">
+                                        </a>
+                                    {% endwith %}
+                                    {{ link_user(node.author) }}&nbsp;
+                                </span>
                                 {{ relative_time(node.time, abs=_('commented on {time}'), rel=_('commented {time}')) }}
                                 <span class="comment-spacer"></span>
                                 <span class="comment-operation">

--- a/templates/comments/media-css.html
+++ b/templates/comments/media-css.html
@@ -32,7 +32,6 @@
         .new-comments .comment .detail {
             margin: 0px 15px 0px;
             width: 100%;
-            max-width: calc(100% - 134px);
         }
 
         .new-comments .comment-edits {
@@ -41,6 +40,8 @@
 
         .new-comments .comment .detail .header {
             display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
             padding: 2px 0px;
             font-weight: normal;
             border-bottom: 1px #888 solid;
@@ -66,10 +67,37 @@
             max-width: 75px;
         }
 
+        .new-comments .gravatar-mobile {
+            display: none;
+        }
+
+        .new-comments .gravatar-main {
+            display: unset;
+        }
+
         .new-comments .vote {
             margin-right: 1em;
             height: 75px;
             padding-top: 0.4em;
+        }
+
+        @media (max-width: 760px) {
+            .new-comments .gravatar {
+                width: 10px;
+                max-width: 10px;
+            }
+
+            .new-comments .gravatar-mobile {
+                display: unset;
+            }
+
+            .new-comments .gravatar-main {
+                display: none;
+            }
+
+            .new-comments .vote {
+                margin-right: 0em;
+            }
         }
 
         .new-comments .comment-display {
@@ -98,11 +126,6 @@
             -ms-transform: translatez(0);
             -o-transform: translatez(0);
             transform: translatez(0);
-        }
-
-        .reply-comment {
-            margin: -50px 23px 10px -40px;
-            padding-top: 50px;
         }
     </style>
 {% endcompress %}


### PR DESCRIPTION
In particular:
 - Less indenting for small-width screens
 - Decreased gravatar width for small-width screens
 - Use flexbox instead of `float:right;` to make the admin controls display nicer.

Everything should look exactly the same on a computer screen.

**Before:**
![image](https://user-images.githubusercontent.com/29607503/84608495-c6a57300-ae80-11ea-8ce9-cd239a5e9a47.png)

**After:**
![image](https://user-images.githubusercontent.com/29607503/84608668-7aa6fe00-ae81-11ea-84a8-c978381c337e.png)
