### PR TITLE
Vertically align checkbox input type

### DIFF
--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -96,6 +96,10 @@ input {
     &[type=number] {
         padding: 2px 0 2px 5px;
     }
+    
+    &[type=checkbox] {
+        vertical-align: middle;   
+    }
 }
 
 textarea {


### PR DESCRIPTION
This makes the checkbox input types vertically aligned.

**Note**: I originally tested this by just using the development console of Firefox, then trying to edit the necessary file and`./make_style.sh`. Unfortunately, I can't get it to add the css to the processed file and I'm not sure why. Perhaps I'm doing something wrong, either with generating styles or this actual code.

## Before
![screenshot_20200621_032356](https://user-images.githubusercontent.com/52835679/85219069-95d8a880-b36e-11ea-9e08-506a40d11b84.png)
![screenshot_20200621_032348](https://user-images.githubusercontent.com/52835679/85219070-96713f00-b36e-11ea-8531-5bbb587c5a41.png)
![screenshot_20200621_032345](https://user-images.githubusercontent.com/52835679/85219071-96713f00-b36e-11ea-9c22-285fb028adc4.png)

## After
![screenshot_20200621_032606](https://user-images.githubusercontent.com/52835679/85219104-dd5f3480-b36e-11ea-8bc5-91667172d59f.png)
![screenshot_20200621_032546](https://user-images.githubusercontent.com/52835679/85219105-dd5f3480-b36e-11ea-9889-e2ced2a7b873.png)
![screenshot_20200621_032540](https://user-images.githubusercontent.com/52835679/85219107-dd5f3480-b36e-11ea-9b93-326f65a271f0.png)
