### PR TITLE
Fix CSS in case where only extended feedback is displayed

### DIFF
--- a/resources/submission.scss
+++ b/resources/submission.scss
@@ -290,7 +290,7 @@ label[for="language"], label[for="status"] {
         vertical-align: top;
     }
 
-    .case-ext-feedback {
+    td.case-output + td.case-ext-feedback {
         width: 50%;
     }
 }

--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -96,7 +96,7 @@
             {% if print_case_output or case.extended_feedback %}
                 <tr id="{{ case.id }}-output" style="display:none" class="case-feedback toggled">
                     {% if print_case_output %}
-                        <td colspan="5">
+                        <td colspan="5" class="case-output">
                             <div class="case-info">
                                 <strong>{{ _('Your output (clipped)') }}</strong>
                                 {% if prefix_length is none %}


### PR DESCRIPTION
## Previous behaviour

![](https://user-images.githubusercontent.com/461885/89111602-ce67a980-d425-11ea-977a-25e253cc8b7f.png)

## New behaviour

With both output and feedback:
![image](https://user-images.githubusercontent.com/15059063/89111571-45507280-d425-11ea-88ef-e63f832cbdf7.png)
With only feedback;
![image](https://user-images.githubusercontent.com/15059063/89111576-539e8e80-d425-11ea-9aa7-1723594de4dd.png)
With only output:
![image](https://user-images.githubusercontent.com/15059063/89111579-5f8a5080-d425-11ea-9f2e-766628bddf50.png)
