### PR TITLE
Make comment votes icon use pointer cursor

### DIFF
--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -93,7 +93,7 @@
                                             <a data-featherlight="{{ url('comment_votes_ajax', node.id) }}"
                                                href="javascript:void(0)"
                                                title="{{ _('Votes') }}" class="votes-link"><i class="fa fa-bar-chart fa-fw"></i></a>
-                                            <a href="javascript:" title="{{ _('Hide') }}" data-id="{{ node.id }}"
+                                            <a href="javascript:void(0)" title="{{ _('Hide') }}" data-id="{{ node.id }}"
                                                class="hide-comment"><i class="fa fa-trash fa-fw"></i></a>
                                             <a href="{{ url('admin:judge_comment_change', node.id) }}"
                                                title="{{ _('Admin') }}"><i class="fa fa-cog fa-fw"></i></a>

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -91,6 +91,7 @@
                                                    class="edit-link"><i class="fa fa-pencil fa-fw"></i></a>
                                             {% endif %}
                                             <a data-featherlight="{{ url('comment_votes_ajax', node.id) }}"
+                                               href="javascript:void(0)"
                                                title="{{ _('Votes') }}" class="votes-link"><i class="fa fa-bar-chart fa-fw"></i></a>
                                             <a href="javascript:" title="{{ _('Hide') }}" data-id="{{ node.id }}"
                                                class="hide-comment"><i class="fa fa-trash fa-fw"></i></a>


### PR DESCRIPTION
Firefox doesn't switch to the pointer cursor for an `<a>` tag without an `href` attribute. Adding one here fixes that.

In this case, we want it to look like it's clickable so doing so is appropriate. If this is *always* the case  with an `<a>` tag having a pointer, it would be better to just add css along the lines of:
```css
a {
    cursor: pointer;
}
```
---
This affects the following admin comment icon:
![image](https://user-images.githubusercontent.com/52835679/85326779-d1bd5c00-b49b-11ea-9fb7-56762e5b77f0.png)
