### PR TITLE
Revert "Replace join text with spectate if user is finished contest; fixes #544"

### DIFF
--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -124,7 +124,7 @@
 {% macro contest_join(contest, request) %}
     {% if not request.in_contest %}
         <td>
-            {% if request.profile in contest.organizers.all() or contest.is_in_contest(request.user) %}
+            {% if request.profile in contest.organizers.all() %}
                 <form action="{{ url('contest_join', contest.key) }}" method="post">
                     {% csrf_token %}
                     <input type="submit" class="unselectable button full participate-button"


### PR DESCRIPTION
Reverts DMOJ/online-judge#1272.

As stated in https://github.com/DMOJ/online-judge/issues/544#issuecomment-609083032, the change from #1272 does not fix #544. In fact, this code is never true, since if `not request.in_contest`, then `contest.is_in_contest(request.user)` is false.

Thus, we revert that commit to reduce dead code.