### PR TITLE
Add past contests anchor for the pagination bar pages

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -104,6 +104,7 @@ class ContestList(DiggPaginatorMixin, TitleMixin, ContestListMixin, ListView):
         context['future_contests'] = future
         context['now'] = self._now
         context['first_page_href'] = '.'
+        context['page_suffix'] = '#past-contests'
         return context
 
 

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -257,7 +257,7 @@
         <br>
 
         {% if past_contests %}
-            <h4>{{ _('Past Contests') }}</h4>
+            <h4 id="past-contests">{{ _('Past Contests') }}</h4>
             {% if page_obj and page_obj.has_other_pages() %}
                 <div style="margin-bottom: 4px;">
                     {% include "list-pages.html" %}


### PR DESCRIPTION
This way, clicking the pages for the contest pagination bar will not redirect to the top of the page (which requires scrolling down to change pages again).