### PR TITLE
Make submission list more mobile friendly

### DIFF
--- a/resources/misc.scss
+++ b/resources/misc.scss
@@ -62,3 +62,9 @@
         float: right;
     }
 }
+
+@media (min-width: 700px) {
+    .xs-br {
+        display: none;
+    }
+}

--- a/resources/submission.scss
+++ b/resources/submission.scss
@@ -54,25 +54,34 @@
         }
     }
 
-    .sub-info {
+    .sub-main {
+        display: flex;
         flex: 1;
-        padding-left: 20px !important;
-        word-break: break-word;
+        flex-direction: row;
+        place-items: center;
+        justify-content: space-between;
+        padding-left: 20px;
 
-        .name {
-            font-weight: 700;
-            font-size: 1.2em;
+        .sub-info {
+            flex: 1;
+            word-break: break-word;
+
+            .name {
+                font-weight: 700;
+                font-size: 1.2em;
+            }
         }
-    }
 
-    .sub-testcase {
-        color: #555;
-        white-space: nowrap;
-    }
-
-    .sub-prop {
-        a {
+        .sub-testcase {
+            color: #555;
             white-space: nowrap;
+            padding-right: 5px;
+        }
+
+        .sub-prop {
+            a {
+                white-space: nowrap;
+            }
         }
     }
 
@@ -136,6 +145,12 @@ label[for="language"], label[for="status"] {
 }
 
 @media(max-width: 700px) {
+    .sub-main {
+        padding-left: 10px !important;
+        flex-direction: column !important;
+        place-items: flex-start !important;
+    }
+
     .sub-prop {
         .label {
             display: none;

--- a/templates/submission/row.html
+++ b/templates/submission/row.html
@@ -21,7 +21,9 @@
 <div class="sub-main">
     <div class="sub-info{% if submission.status == 'G' %} sub-info-grading{% endif %}">
         {% if show_problem %}
-            <div class="name"><a href="{{ url('problem_detail', submission.problem.code) }}">{{ problem_name }}</a></div>
+            <div class="name">
+                <a href="{{ url('problem_detail', submission.problem.code) }}">{{ problem_name }}</a>
+            </div>
         {% endif %}
         <div>
             {{ link_user(submission.user) }}
@@ -57,7 +59,11 @@
                         <i class="fa fa-refresh fa-fw"></i><span class="label">{{ _('rejudge') }}</span>
                     </a>
                 {% else %}
-                    <i class="fa fa-refresh fa-fw grey-icon"></i><span class="label grey-label" title="{{ _('This submission has been locked, and cannot be rejudged.') }}">{{ _('locked') }}</span>
+                    <i class="fa fa-refresh fa-fw grey-icon"></i>
+                    <span class="label grey-label"
+                          title="{{ _('This submission has been locked, and cannot be rejudged.') }}">
+                        {{ _('locked') }}
+                    </span>
                 {% endif %}
             {% endif %}
             {% if can_edit %} ·

--- a/templates/submission/row.html
+++ b/templates/submission/row.html
@@ -17,53 +17,57 @@
         <span class="language">{{ submission.language.short_display_name }}</span>
     </div>
 </div>
-<div class="sub-info{% if submission.status == 'G' %} sub-info-grading{% endif %}">
-    {% if show_problem %}
-        <div class="name"><a href="{{ url('problem_detail', submission.problem.code) }}">{{ problem_name }}</a></div>
-    {% endif %}
-    <div>
-        {{ link_user(submission.user) }}
-        <span class="time">{{ relative_time(submission.date) }}</span>
-        {% if not request.in_contest and submission.contest_object_id %}
-            <a href="{{ url('contest_view', submission.contest_object.key) }}"
-               class="submission-contest">
-                <i title="{{ submission.contest_object.name }}" class="fa fa-dot-circle-o"></i>
-            </a>
+
+<div class="sub-main">
+    <div class="sub-info{% if submission.status == 'G' %} sub-info-grading{% endif %}">
+        {% if show_problem %}
+            <div class="name"><a href="{{ url('problem_detail', submission.problem.code) }}">{{ problem_name }}</a></div>
         {% endif %}
-    </div>
-</div>
-
-{% if submission.status == 'G' %}
-    <div class="sub-testcase">
-        {%- if submission.current_testcase > 0 -%}
-            {{ _('Case #%(case)s', case=submission.current_testcase) }}
-        {%- else -%}
-            ...
-        {%- endif -%}
-    </div>
-{% endif %}
-
-{% if can_view %}
-    <div class="sub-prop"><div>
-        <a href="{{ url('submission_status', submission.id) }}">
-            <i class="fa fa-eye fa-fw"></i><span class="label">{{ _('view') }}</span>
-        </a>
-        {% if perms.judge.rejudge_submission and can_edit %} ·
-            {% if not submission.is_locked %}
-                <a href="#" onclick="rejudge_submission({{ submission.id }}, event);return false">
-                    <i class="fa fa-refresh fa-fw"></i><span class="label">{{ _('rejudge') }}</span>
+        <div>
+            {{ link_user(submission.user) }}
+            <br class="xs-br">
+            <span class="time">{{ relative_time(submission.date) }}</span>
+            {% if not request.in_contest and submission.contest_object_id %}
+                <a href="{{ url('contest_view', submission.contest_object.key) }}"
+                   class="submission-contest">
+                    <i title="{{ submission.contest_object.name }}" class="fa fa-dot-circle-o"></i>
                 </a>
-            {% else %}
-                <i class="fa fa-refresh fa-fw grey-icon"></i><span class="label grey-label" title="{{ _('This submission has been locked, and cannot be rejudged.') }}">{{ _('locked') }}</span>
             {% endif %}
-        {% endif %}
-        {% if can_edit %} ·
-            <a href="{{ url('admin:judge_submission_change', submission.id) }}">
-                <i class="fa fa-cog fa-fw"></i><span class="label">{{ _('admin') }}</span>
+        </div>
+    </div>
+
+    {% if submission.status == 'G' %}
+        <div class="sub-testcase">
+            {%- if submission.current_testcase > 0 -%}
+                {{ _('Case #%(case)s', case=submission.current_testcase) }}
+            {%- else -%}
+                ...
+            {%- endif -%}
+        </div>
+    {% endif %}
+
+    {% if can_view %}
+        <div class="sub-prop"><div>
+            <a href="{{ url('submission_status', submission.id) }}">
+                <i class="fa fa-eye fa-fw"></i><span class="label">{{ _('view') }}</span>
             </a>
-        {% endif %}
-    </div></div>
-{% endif %}
+            {% if perms.judge.rejudge_submission and can_edit %} ·
+                {% if not submission.is_locked %}
+                    <a href="#" onclick="rejudge_submission({{ submission.id }}, event);return false">
+                        <i class="fa fa-refresh fa-fw"></i><span class="label">{{ _('rejudge') }}</span>
+                    </a>
+                {% else %}
+                    <i class="fa fa-refresh fa-fw grey-icon"></i><span class="label grey-label" title="{{ _('This submission has been locked, and cannot be rejudged.') }}">{{ _('locked') }}</span>
+                {% endif %}
+            {% endif %}
+            {% if can_edit %} ·
+                <a href="{{ url('admin:judge_submission_change', submission.id) }}">
+                    <i class="fa fa-cog fa-fw"></i><span class="label">{{ _('admin') }}</span>
+                </a>
+            {% endif %}
+        </div></div>
+    {% endif %}
+</div>
 
 <div class="sub-usage">
     {% if submission.status in ('QU', 'P', 'G', 'CE', 'IE', 'AB') %}


### PR DESCRIPTION
With f28cef204e7b6936825e9acb86ad57d66cb3b458, usernames and problem names are broken to prevent overflow on small-width screens. However, this makes the look suboptimal for admins who have additional admin icons.

**Before:**
![image](https://user-images.githubusercontent.com/29607503/86536700-b862d980-beb7-11ea-9ec4-0d3974139c32.png)

**After (for admins):**
![image](https://user-images.githubusercontent.com/29607503/86536703-bdc02400-beb7-11ea-9e10-4ca2d56a2ddf.png)

**After (for normal users):**
![image](https://user-images.githubusercontent.com/29607503/86536777-3a530280-beb8-11ea-86a9-bdfd581ebed2.png)


Everything should look identical on a computer screen.