### PR TITLE
Add participation start time tooltip to contest rankings

### DIFF
--- a/templates/contest/ranking-table.html
+++ b/templates/contest/ranking-table.html
@@ -21,6 +21,16 @@
 {% endblock %}
 
 {% block user_data %}
+    {% if not contest.ended %}
+        {% if not user.participation.ended %}
+            <div class="start-time active">
+                {{ relative_time(user.participation.start, abs=_('Started on {time}'), rel=_('Started {time}')) }}
+            </div>
+        {% else %}
+            <div class="start-time">{{ _('Participation ended.') }}</div>
+        {% endif %}
+    {% endif %}
+
     {% if can_edit %}
         <span class="contest-participation-operation">
             <form action="{{ url('contest_participation_disqualify', contest.key) }}" method="post">

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -177,27 +177,14 @@
             });
         </script>
     {% endif %}
-    {% if perms.judge.change_contestparticipation %}
-        <script type="text/javascript">
-            $(function () {
-                $('td.user').find('a.user-name').click(function (e) {
-                    var data = $(this).siblings('.edit-participation');
-                    if (e.altKey && data.length) {
-                        window.open(data.attr('data-link'), '_blank');
-                        return false;
-                    }
-                });
-            });
-        </script>
-    {% endif %}
     {% if not contest.ended %}
         <script type="text/javascript">
             $(function () {
                 window.install_tooltips = function () {
-                    $('td.user').find('a.user-name').each(function () {
+                    $('td.user-name').find('span.user').each(function () {
                         var link = $(this);
                         link.mouseenter(function (e) {
-                            var start_time = link.siblings('.start-time').text();
+                            var start_time = link.siblings('.start-time').text().trim();
                             link.addClass('tooltipped tooltipped-e').attr('aria-label', start_time);
                         }).mouseleave(function (e) {
                             link.removeClass('tooltipped tooltipped-e').removeAttr('aria-label');


### PR DESCRIPTION
This has existed since 91821128b901ed57b73773c76b94eeaef987df8d, but it was broken in 895462bbbfd074c492fd0358676e7590f2f82031 ([line](https://github.com/DMOJ/online-judge/commit/895462bbbfd074c492fd0358676e7590f2f82031#diff-9e63d3b1d99ce39c44ab7956250f3931L29)) (and has remained broken for the past 3 years, somehow). This was made worse in 41a3c6e75 ([lines](https://github.com/DMOJ/online-judge/commit/41a3c6e75#diff-5f05d094a4559d103d6488aab42c62d7L24-L32)) since the seemingly unused code was deleted.

This PR adds back the features originally suggested in #476 and #498.

**Screenshots:**
![image](https://user-images.githubusercontent.com/29607503/86934098-4a155580-c109-11ea-9865-d274e3fba6a6.png)

![image](https://user-images.githubusercontent.com/29607503/86934238-77fa9a00-c109-11ea-98f7-aa504a50d916.png)

