### PR TITLE
Add page to view all user submissions in given contest

### DIFF
--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -215,6 +215,8 @@ urlpatterns = [
         url(r'^/rank/(?P<problem>\w+)/',
             paged_list_view(ranked_submission.ContestRankedSubmission, 'contest_ranked_submissions')),
 
+        url(r'^/submissions/(?P<user>\w+)/',
+            paged_list_view(submission.UserAllContestSubmissions, 'contest_all_user_submissions')),
         url(r'^/submissions/(?P<user>\w+)/(?P<problem>\w+)/',
             paged_list_view(submission.UserContestSubmissions, 'contest_user_submissions')),
 

--- a/judge/contest_format/default.py
+++ b/judge/contest_format/default.py
@@ -62,7 +62,9 @@ class DefaultContestFormat(BaseContestFormat):
 
     def display_participation_result(self, participation):
         return format_html(
-            u'<td class="user-points">{points}<div class="solving-time">{cumtime}</div></td>',
+            u'<td class="user-points"><a href="{url}">{points}<div class="solving-time">{cumtime}</div></a></td>',
+            url=reverse('contest_all_user_submissions',
+                        args=[self.contest.key, participation.user.user.username]),
             points=floatformat(participation.score),
             cumtime=nice_repr(timedelta(seconds=participation.cumtime), 'noday'),
         )

--- a/judge/contest_format/ecoo.py
+++ b/judge/contest_format/ecoo.py
@@ -119,7 +119,9 @@ class ECOOContestFormat(DefaultContestFormat):
 
     def display_participation_result(self, participation):
         return format_html(
-            '<td class="user-points">{points}<div class="solving-time">{cumtime}</div></td>',
+            '<td class="user-points"><a href="{url}">{points}<div class="solving-time">{cumtime}</div></a></td>',
+            url=reverse('contest_all_user_submissions',
+                        args=[self.contest.key, participation.user.user.username]),
             points=floatformat(participation.score),
             cumtime=nice_repr(timedelta(seconds=participation.cumtime), 'noday') if self.config['cumtime'] else '',
         )

--- a/judge/contest_format/legacy_ioi.py
+++ b/judge/contest_format/legacy_ioi.py
@@ -86,7 +86,9 @@ class LegacyIOIContestFormat(DefaultContestFormat):
 
     def display_participation_result(self, participation):
         return format_html(
-            '<td class="user-points">{points}<div class="solving-time">{cumtime}</div></td>',
+            '<td class="user-points"><a href="{url}">{points}<div class="solving-time">{cumtime}</div></a></td>',
+            url=reverse('contest_all_user_submissions',
+                        args=[self.contest.key, participation.user.user.username]),
             points=floatformat(participation.score),
             cumtime=nice_repr(timedelta(seconds=participation.cumtime), 'noday') if self.config['cumtime'] else '',
         )

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -77,7 +77,7 @@
             color: red;
         }
 
-        .user-points {
+        .user-points, .user-points a {
             font-weight: bold;
             color: black;
         }


### PR DESCRIPTION
P1 is publicly visible, and P2 is not publicly visible.

As regular user, with public scoreboard:
![image](https://user-images.githubusercontent.com/15059063/89740949-6cc5c180-da5b-11ea-8c21-d5f62c3993d2.png)

![image](https://user-images.githubusercontent.com/15059063/89740965-89fa9000-da5b-11ea-9a92-b83e5091ba89.png)

(Link for P2 will 404)

Combined submissions:
![image](https://user-images.githubusercontent.com/15059063/89740980-9848ac00-da5b-11ea-804e-68a285d1cab4.png)

As SU/organizer:
![image](https://user-images.githubusercontent.com/15059063/89741002-b1e9f380-da5b-11ea-846a-ae1186f2bd17.png)

Tested:
- SU while contest is running
- Contest organizer while contest was running, and once done, with private scoreboard.
- Contestant while contest was running, and once done, with private scoreboard.
- Random 3rd user, while contest was running, and once done, with and without private scoreboard.
- Not logged in, while contest was running, and once done, with and without private scoreboard.