### PR TITLE
Surface maximum runtime on single test case for AC submissions

### DIFF
--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -122,8 +122,11 @@ def group_test_cases(cases):
     result = []
     status = []
     buf = []
+    max_execution_time = 0.0
     last = None
     for case in cases:
+        if case.time:
+            max_execution_time = max(max_execution_time, case.time)
         if case.batch != last and buf:
             result.append(make_batch(last, buf))
             status.extend(get_statuses(last, buf))
@@ -133,7 +136,7 @@ def group_test_cases(cases):
     if buf:
         result.append(make_batch(last, buf))
         status.extend(get_statuses(last, buf))
-    return result, status
+    return result, status, max_execution_time
 
 
 class SubmissionStatus(SubmissionDetailBase):
@@ -144,7 +147,7 @@ class SubmissionStatus(SubmissionDetailBase):
         submission = self.object
         context['last_msg'] = event.last()
 
-        context['batches'], statuses = group_test_cases(submission.test_cases.all())
+        context['batches'], statuses, context['max_execution_time'] = group_test_cases(submission.test_cases.all())
         context['statuses'] = combine_statuses(statuses, submission)
 
         context['time_limit'] = submission.problem.time_limit

--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -134,6 +134,11 @@
                 {% endif %}
                 {{ submission.memory|kbdetailformat }}
                 <br>
+                {% if submission.result == "AC" %}
+                    <b>{{ _('Maximum runtime on single test case:') }}</b>
+                    <span title="{{ max_execution_time }}s">{{ max_execution_time|floatformat(3) }}s</span>
+                    <br>
+                {% endif %}
                 {% if is_pretest %}
                     <b>{{ _('Final pretest score:') }}</b>
                 {% else %}


### PR DESCRIPTION
The maximum run time for a single test case can be helpful to see how close one is to the time limit.