### PR TITLE
Explicitly set `case_points` and `case_total` to 0

### DIFF
--- a/judge/judgeapi.py
+++ b/judge/judgeapi.py
@@ -56,8 +56,8 @@ def judge_submission(submission, rejudge=False, batch_rejudge=False, judge_id=No
     REJUDGE_PRIORITY = 2
     BATCH_REJUDGE_PRIORITY = 3
 
-    updates = {'time': None, 'memory': None, 'points': None, 'result': None, 'error': None,
-               'was_rejudged': rejudge or batch_rejudge, 'status': 'QU'}
+    updates = {'time': None, 'memory': None, 'points': None, 'result': None, 'case_points': 0,
+               'case_total': 0, 'error': None, was_rejudged': rejudge or batch_rejudge, 'status': 'QU'}
     try:
         # This is set proactively; it might get unset in judgecallback's on_grading_begin if the problem doesn't
         # actually have pretests stored on the judge.

--- a/judge/judgeapi.py
+++ b/judge/judgeapi.py
@@ -57,7 +57,7 @@ def judge_submission(submission, rejudge=False, batch_rejudge=False, judge_id=No
     BATCH_REJUDGE_PRIORITY = 3
 
     updates = {'time': None, 'memory': None, 'points': None, 'result': None, 'case_points': 0,
-               'case_total': 0, 'error': None, was_rejudged': rejudge or batch_rejudge, 'status': 'QU'}
+               'case_total': 0, 'error': None, 'was_rejudged': rejudge or batch_rejudge, 'status': 'QU'}
     try:
         # This is set proactively; it might get unset in judgecallback's on_grading_begin if the problem doesn't
         # actually have pretests stored on the judge.


### PR DESCRIPTION
In the case that a rejudge leads to a CE (possible if the submission uses several `pragmas`), these fields will not be updated.

This can then lead to the situation where a rescore results in a CE sub with non-zero score.