### PR TITLE
Add is_public to APIProblemDetail

### DIFF
--- a/judge/views/api/api_v2.py
+++ b/judge/views/api/api_v2.py
@@ -392,6 +392,7 @@ class APIProblemDetail(APIDetailView):
             'organizations': list(
                 problem.organizations.values_list('id', flat=True) if problem.is_organization_private else [],
             ),
+            'is_public': problem.is_public,
         }
 
 


### PR DESCRIPTION
Adds is_public to tell which problems are public, so you don't leak your private problems when using the api token