### PR TITLE
Change wording of "Maximum runtime on single test case"

### DIFF
--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -135,7 +135,7 @@
                 {{ submission.memory|kbdetailformat }}
                 <br>
                 {% if submission.result == "AC" %}
-                    <b>{{ _('Maximum runtime on single test case:') }}</b>
+                    <b>{{ _('Maximum single-case runtime:') }}</b>
                     <span title="{{ max_execution_time }}s">{{ max_execution_time|floatformat(3) }}s</span>
                     <br>
                 {% endif %}


### PR DESCRIPTION
"Maximum runtime on single test case" sounds unnatural, so I think replacing it with "Maximum single-case runtime" would sound better.

Note: please mark this PR as invalid or spam so it does not contribute to my hacktoberfest pull requests.