### PR TITLE
remove lambda function from url lazystr

### DIFF
--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -400,7 +400,7 @@ favicon_paths = ['apple-touch-icon-180x180.png', 'apple-touch-icon-114x114.png',
 
 for favicon in favicon_paths:
     urlpatterns.append(url(r'^%s$' % favicon, RedirectView.as_view(
-        url=lazystr(lambda: static('icons/' + favicon)),
+        url=lazystr(static('icons/' + favicon)),
     )))
 
 handler404 = 'judge.views.error.error404'


### PR DESCRIPTION
Django 2.2.17 with Python 3.7.3. It seems that `lazystr` will return garbage for a lambda function. Therefore, we don't need a lambda function here.

```
>>> from django.utils.functional import lazystr
'23'
>>> lazystr("test")
'test'
>>> lazystr(lambda: 3)
'<function <lambda> at 0x7f00eb7a1598>'
```