### PR TITLE
Fix ticket author indenting on front page sidebar

### DIFF
--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -40,7 +40,7 @@
             font-style: italic;
         }
 
-        .open-tickets .user {
+        .open-tickets .author {
             margin-left: 1em;
         }
 
@@ -256,7 +256,7 @@
                                         <a href="{{ ticket.linked_item.get_absolute_url() }}">
                                             {{ ticket.linked_item|item_title }}</a>
                                     </div>
-                                    <div>{{ link_user(ticket.user) }}</div>
+                                    <div class="author">{{ link_user(ticket.user) }}</div>
                                 </li>
                             {% endfor %}
                         </ul>


### PR DESCRIPTION
Example from prod:
![image](https://user-images.githubusercontent.com/29607503/101270684-6ca7ab00-3749-11eb-9e5a-936355bf80a7.png)
