### PR TITLE
Remove share to Google Plus on Contests and Blogs

### DIFF
--- a/judge/jinja2/social.py
+++ b/judge/jinja2/social.py
@@ -1,13 +1,14 @@
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
-from django_social_share.templatetags.social_share import post_to_facebook_url, post_to_gplus_url, post_to_twitter_url
+from django_social_share.templatetags.social_share import post_to_facebook_url, post_to_twitter_url
 
 from . import registry
 
 SHARES = [
     ('post_to_twitter', 'django_social_share/templatetags/post_to_twitter.html', post_to_twitter_url),
     ('post_to_facebook', 'django_social_share/templatetags/post_to_facebook.html', post_to_facebook_url),
-    ('post_to_gplus', 'django_social_share/templatetags/post_to_gplus.html', post_to_gplus_url),
+    # Deprecated:
+    # ('post_to_gplus', 'django_social_share/templatetags/post_to_gplus.html', post_to_gplus_url),
     # For future versions:
     # ('post_to_linkedin', 'django_social_share/templatetags/post_to_linkedin.html', post_to_linkedin_url),
     # ('post_to_reddit', 'django_social_share/templatetags/post_to_reddit.html', post_to_reddit_url),

--- a/templates/blog/content.html
+++ b/templates/blog/content.html
@@ -37,7 +37,6 @@
     </div>
     <hr>
     <span class="social">
-        {{ post_to_gplus(request, post, '<i class="fa fa-google-plus-square"></i>') }}
         {{ post_to_facebook(request, post, '<i class="fa fa-facebook-official"></i>') }}
         {{ post_to_twitter(request, SITE_NAME + ':', post, '<i class="fa fa-twitter"></i>') }}
     </span>

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -124,7 +124,6 @@
 
     <hr>
     <span class="social">
-        {{ post_to_gplus(request, contest, '<i class="fa fa-google-plus-square"></i>') }}
         {{ post_to_facebook(request, contest, '<i class="fa fa-facebook-official"></i>') }}
         {{ post_to_twitter(request, SITE_NAME + ':', contest, '<i class="fa fa-twitter"></i>') }}
     </span>


### PR DESCRIPTION
Not a very important PR but since Google [shut down consumer Google+ accounts](https://support.google.com/googlecurrents/answer/9195133?hl=en) 2 years ago, I think the "share to Google+ button" on blogs and contests can be removed (unless DMOJ has an organisational Google+ community in which case this PR can be closed and ignored).