### PR TITLE
Consolidate pagination bar spacings

### DIFF
--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -322,6 +322,16 @@ ul.pagination {
     }
 }
 
+.top-pagination-bar {
+    margin-top: 11px;
+    margin-bottom: 7px;
+    display: flex;
+}
+
+.bottom-pagination-bar {
+    margin-top: 10px;
+}
+
 .alert {
     padding: 15px;
     margin-bottom: 20px;

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -120,7 +120,7 @@
                 {% endfor %}
             </div>
             {% if page_obj.has_other_pages() %}
-                <div style="margin-bottom:10px;margin-top:10px">{% include "list-pages.html" %}</div>
+                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
             {% endif %}
         </div>
 

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -259,9 +259,7 @@
         {% if past_contests %}
             <h4 id="past-contests">{{ _('Past Contests') }}</h4>
             {% if page_obj and page_obj.has_other_pages() %}
-                <div style="margin-bottom: 4px;">
-                    {% include "list-pages.html" %}
-                </div>
+                <div class="top-pagination-bar">{% include "list-pages.html" %}</div>
             {% endif %}
             <table class="contest-list table striped">
                 <thead>
@@ -301,9 +299,7 @@
                 </tbody>
             </table>
             {% if page_obj and page_obj.has_other_pages() %}
-                <div style="margin-top: 10px;">
-                    {% include "list-pages.html" %}
-                </div>
+                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
             {% endif %}
         {% endif %}
     </div>

--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -300,10 +300,9 @@
                 {% endfor %}
                 </tbody>
             </table>
-            {% if page_obj.has_other_pages() %}
-                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
-            {% endif %}
         </div>
     </div>
-    <br>
+   {% if page_obj.has_other_pages() %}
+       <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
+   {% endif %}
 {% endblock %}

--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -169,9 +169,7 @@
 
 {% block body %}
     {% if page_obj.has_other_pages() %}
-        <div style="margin-bottom: 7px; margin-top: 11px;">
-            {% include "list-pages.html" %}
-        </div>
+        <div class="top-pagination-bar">{% include "list-pages.html" %}</div>
     {% endif %}
 
     <div id="common-content">
@@ -303,7 +301,7 @@
                 </tbody>
             </table>
             {% if page_obj.has_other_pages() %}
-                <div style="margin-top:10px;">{% include "list-pages.html" %}</div>
+                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
             {% endif %}
         </div>
     </div>

--- a/templates/submission/list.html
+++ b/templates/submission/list.html
@@ -297,9 +297,7 @@
 
 {% block body %}
     {% if page_obj.has_other_pages() %}
-        <div style="margin-bottom: 6px; margin-top: 11px">
-            {% include "list-pages.html" %}
-        </div>
+        <div class="top-pagination-bar">{% include "list-pages.html" %}</div>
     {% endif %}
 
     <div id="common-content">
@@ -366,7 +364,7 @@
                 {% endfor %}
             </div>
             {% if page_obj.has_other_pages() %}
-                <div style="margin-top:10px;">{% include "list-pages.html" %}</div>
+                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
             {% endif %}
         </div>
     </div>

--- a/templates/submission/list.html
+++ b/templates/submission/list.html
@@ -363,11 +363,11 @@
                     </div>
                 {% endfor %}
             </div>
-            {% if page_obj.has_other_pages() %}
-                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
-            {% endif %}
         </div>
     </div>
+    {% if page_obj.has_other_pages() %}
+        <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
+    {% endif %}
 {% endblock %}
 
 {% block bodyend %}

--- a/templates/ticket/list.html
+++ b/templates/ticket/list.html
@@ -269,9 +269,9 @@
                     </tbody>
                 </table>
             </div>
-            {% if page_obj.has_other_pages() %}
-                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
-            {% endif %}
         </main>
     </div>
+    {% if page_obj.has_other_pages() %}
+        <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
+    {% endif %}
 {% endblock %}

--- a/templates/ticket/list.html
+++ b/templates/ticket/list.html
@@ -210,6 +210,9 @@
 {% endblock %}
 
 {% block body %}
+    {% if page_obj.has_other_pages() %}
+        <div class="top-pagination-bar">{% include "list-pages.html" %}</div>
+    {% endif %}
     <div id="container">
         <aside>
             <div>
@@ -248,9 +251,6 @@
         </aside>
 
         <main>
-            {% if page_obj.has_other_pages() %}
-                <div style="margin-bottom:6px; margin-top:3px">{% include "list-pages.html" %}</div>
-            {% endif %}
             <div class="h-scrollable-table">
                 <table id="ticket-list" class="table">
                     <thead>
@@ -270,7 +270,7 @@
                 </table>
             </div>
             {% if page_obj.has_other_pages() %}
-                <div style="margin-top:10px">{% include "list-pages.html" %}</div>
+                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
             {% endif %}
         </main>
     </div>

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -82,10 +82,9 @@
                     {% block users_table %}{% endblock %}
                 </table>
             </div>
-
-            {% if page_obj and page_obj.has_other_pages() %}
-                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
-            {% endif %}
         </div>
     </div>
+    {% if page_obj and page_obj.has_other_pages() %}
+        <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
+    {% endif %}
 {% endblock %}

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -55,8 +55,6 @@
     {% block users_media %}{% endblock %}
     <style>
         .user-pagination {
-            margin-bottom: 7px;
-            margin-top: 3px;
             display: flex;
             flex-wrap: wrap;
             justify-content: space-between;
@@ -65,18 +63,18 @@
 {% endblock %}
 
 {% block body %}
+    {% if page_obj and page_obj.has_other_pages() %}
+        <div class="top-pagination-bar user-pagination">
+            {% include "list-pages.html" %}
+            <form id="search-form" name="form" action="{{ url('user_ranking_redirect') }}" method="get">
+                <input id="search-handle" type="text" name="search"
+                       placeholder="{{ _('Search by handle...') }}">
+            </form>
+        </div>
+    {% endif %}
+
     <div id="common-content">
         <div id="content-left" class="users">
-            {% if page_obj and page_obj.has_other_pages() %}
-                <div class="user-pagination">
-                    {% include "list-pages.html" %}
-                    <form id="search-form" name="form" action="{{ url('user_ranking_redirect') }}" method="get">
-                        <input id="search-handle" type="text" name="search"
-                               placeholder="{{ _('Search by handle...') }}">
-                    </form>
-                </div>
-            {% endif %}
-
             {% block before_users_table %}{% endblock %}
 
             <div class="h-scrollable-table">
@@ -86,7 +84,7 @@
             </div>
 
             {% if page_obj and page_obj.has_other_pages() %}
-                <div style="margin-top:10px;">{% include "list-pages.html" %}</div>
+                <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
Everything should line up now...

Todo:
 - [x] The bottom pagination bar is inside a `div` while the top pagination bar is outside. Should probably move either both bars outside or both bars inside.