### PR TITLE
Don't rate contests which have not finished yet

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -334,8 +334,10 @@ class Contest(models.Model):
         return queryset.distinct()
 
     def rate(self):
-        Rating.objects.filter(contest__end_time__gte=self.end_time).delete()
-        for contest in Contest.objects.filter(is_rated=True, end_time__gte=self.end_time).order_by('end_time'):
+        Rating.objects.filter(contest__end_time__range=(self.end_time, self._now)).delete()
+        for contest in Contest.objects.filter(
+            is_rated=True, end_time__range=(self.end_time, self._now),
+        ).order_by('end_time'):
             rate_contest(contest)
 
     class Meta:


### PR DESCRIPTION
Fixes #1590.

After this commit, contests which have not ended cannot be rated. We should probably make sure there _isn't_ a case where someone might want to rate an ongoing contest.

On a side note, should we hide (or maybe grey out) the `Rate` button if the contest has not ended yet? It might be confusing if clicking the rate button does nothing for an ongoing contest.