### PR TITLE
Remove CSS For Google+ Features

### DIFF
--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -5,7 +5,7 @@
     font-size: 1.9em;
 }
 
-.facebook-this, .tweet-this, .gplus-this {
+.facebook-this, .tweet-this {
     display: inline;
 }
 
@@ -15,10 +15,6 @@
 
 .facebook-this it {
     color: #133783;
-}
-
-.gplus-this i {
-    color: #DD4B38;
 }
 
 .social {
@@ -96,9 +92,9 @@ input {
     &[type=number] {
         padding: 2px 0 2px 5px;
     }
-    
+
     &[type=checkbox] {
-        vertical-align: middle;   
+        vertical-align: middle;
     }
 }
 


### PR DESCRIPTION
Even though Google+ has been discontinued by Google, there are still buttons to share to Google+ and other places Google+ is integrated into the site. This PR removes them. 