### PR TITLE
Switch from pyotp to secrets for generating backup 2FA tokens

### DIFF
--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -5,7 +5,6 @@ import secrets
 import struct
 from operator import mul
 
-import pyotp
 import webauthn
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -188,7 +187,9 @@ class Profile(models.Model):
     generate_api_token.alters_data = True
 
     def generate_scratch_codes(self):
-        codes = [pyotp.random_base32(length=16) for i in range(settings.DMOJ_SCRATCH_CODES_COUNT)]
+        def generate_scratch_code():
+            return "".join(secrets.choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567") for _ in range(16))
+        codes = [generate_scratch_code() for _ in range(settings.DMOJ_SCRATCH_CODES_COUNT)]
         self.scratch_codes = json.dumps(codes)
         self.save(update_fields=['scratch_codes'])
         return codes


### PR DESCRIPTION
pyotp recently released a new version[1] which changes the minimum
length of base32 secret generation to 32 characters.

[1]: https://github.com/pyauth/pyotp/releases/tag/v2.6.0