### PR TITLE
Don't wrap testdata case type column in select2

### DIFF
--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -11,14 +11,6 @@
     <script type="text/javascript" src="{{ static('libs/featherlight/featherlight.min.js') }}"></script>
     <script type="text/javascript">
         $(function () {
-            function update_select2() {
-                $('tbody:not(.extra-row-body) .type-column select').select2({
-                    minimumResultsForSearch: -1
-                });
-            }
-
-            update_select2();
-
             function autofill_if_exists($select, file) {
                 if (!$select.val() && ~window.valid_files.indexOf(file))
                     $select.val(file).trigger('change');
@@ -26,7 +18,6 @@
 
             var $table = $('#case-table');
             $table.on('add-row', function (e, $tr) {
-                update_select2();
                 $tr.find('input').filter('[id$=file]').each(function () {
                     var $select, val = $(this).replaceWith($select = $('<select>').attr({
                         id: $(this).attr('id'),


### PR DESCRIPTION
This causes massive slowdowns, and the fields aren't searchable anyway.

The downside is the style becomes inconsistent, but that beats the reported 30s load times for 50 cases.

And, the checker column was never wrapped to begin with, so it was already inconsistent.