### PR TITLE
Use the correct permissions for showing contest admin tab

### DIFF
--- a/templates/contest/contest-list-tabs.html
+++ b/templates/contest/contest-list-tabs.html
@@ -20,7 +20,7 @@
 {% block tabs %}
     {{ make_tab('list', 'fa-list', url('contest_list'), _('List')) }}
     {{ make_tab('calendar', 'fa-calendar', url('contest_calendar', now.year, now.month), _('Calendar')) }}
-    {% if perms.judge.change_contest %}
+    {% if perms.judge.edit_all_contest or perms.judge.edit_own_contest %}
         {{ make_tab('admin', 'fa-edit', url('admin:judge_contest_changelist'), _('Admin')) }}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
The permission `judge.change_contest` isn't used for creating contests, so it doesn't make sense to use it to determine whether to show the admin page tab or not.

This change also makes the contest admin tab logic the same as the [problem admin tab logic](https://github.com/DMOJ/online-judge/blob/master/templates/problem/problem-list-tabs.html#L4).