### PR TITLE
Show admin tabs on own profile page

### DIFF
--- a/templates/user/user-tabs.html
+++ b/templates/user/user-tabs.html
@@ -6,14 +6,13 @@
     {% if request.user.is_superuser and user.user != request.user and not user.user.is_superuser %}
         {{ make_tab('impersonate', 'fa-eye', url('impersonate-start', user.user.id), _('Impersonate')) }}
     {% endif %}
+    {% if perms.auth.change_user %}
+        {{ make_tab('edit', 'fa-edit', url('admin:auth_user_change', user.user.id), _('Admin User')) }}
+    {% endif %}
+    {% if perms.judge.change_profile %}
+        {{ make_tab('edit', 'fa-edit', url('admin:judge_profile_change', user.id), _('Admin Profile')) }}
+    {% endif %}
     {% if user.user == request.user %}
         {{ make_tab('edit', 'fa-edit', url('user_edit_profile'), _('Edit profile')) }}
-    {% else %}
-        {% if perms.auth.change_user %}
-            {{ make_tab('edit', 'fa-edit', url('admin:auth_user_change', user.user.id), _('Admin User')) }}
-        {% endif %}
-        {% if perms.judge.change_profile %}
-            {{ make_tab('edit', 'fa-edit', url('admin:judge_profile_change', user.id), _('Admin Profile')) }}
-        {% endif %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
There has been quite a number of times I've wanted to view my own profile/user on the admin site, and realized that the shortcut tabs didn't show up on my profile page, leading me to have to search up myself on the admin site and find the correct user.

I'm not sure why these tabs were hidden in the first place (maybe to reduce the number of tabs?), but I feel like showing them would be more beneficial in the long run.