### PR TITLE
Properly centre forms on login and 2fa pages

### DIFF
--- a/resources/misc.scss
+++ b/resources/misc.scss
@@ -68,3 +68,11 @@
         display: none;
     }
 }
+
+.auth-flow-form {
+    display: flex;
+    flex-flow: column wrap;
+    justify-content: center;
+    align-content: center;
+    padding-top: 5%;
+}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -2,14 +2,6 @@
 
 {% block media %}
     <style>
-        #login-panel {
-            display: inline-block;
-            position: relative;
-            margin: 5em auto auto -10em;
-            top: 40%;
-            left: 50%;
-        }
-
         h4 {
             padding-top: 1em;
         }
@@ -35,7 +27,7 @@
 {% endblock %}
 
 {% block body %}
-    <div id="login-panel">
+    <div class="auth-flow-form">
         <form action="" method="post" class="form-area">
             {% csrf_token %}
             {% if form.errors %}
@@ -61,25 +53,27 @@
             <button style="float:right;" type="submit">{{ _('Login!') }}</button>
             <input type="hidden" name="next" value="{{ next }}">
         </form>
-        <br><a href="{{ url('password_reset') }}">{{ _('Forgot your password?') }}</a>
+        <a href="{{ url('password_reset') }}">{{ _('Forgot your password?') }}</a>
 
         {% if form.has_google_auth or form.has_facebook_auth or form.has_github_auth %}
             <h4>{{ _('Or log in with...') }}</h4>
-            {% if form.has_google_auth %}
-                <a href="{{ url('social:begin', "google-oauth2") }}?next={{ next }}" class="social google-icon">
-                    <i class="fa fa-google-plus-square"></i>
-                </a>
-            {% endif %}
-            {% if form.has_facebook_auth %}
-                <a href="{{ url('social:begin', "facebook") }}?next={{ next }}" class="social facebook-icon">
-                    <i class="fa fa-facebook-square"></i>
-                </a>
-            {% endif %}
-            {% if form.has_github_auth %}
-                <a href="{{ url('social:begin', "github-secure") }}?next={{ next }}" class="social github-icon">
-                    <i class="fa fa-github-square"></i>
-                </a>
-            {% endif %}
+            <div>
+                {% if form.has_google_auth %}
+                    <a href="{{ url('social:begin', "google-oauth2") }}?next={{ next }}" class="social google-icon">
+                        <i class="fa fa-google-plus-square"></i>
+                    </a>
+                {% endif %}
+                {% if form.has_facebook_auth %}
+                    <a href="{{ url('social:begin', "facebook") }}?next={{ next }}" class="social facebook-icon">
+                        <i class="fa fa-facebook-square"></i>
+                    </a>
+                {% endif %}
+                {% if form.has_github_auth %}
+                    <a href="{{ url('social:begin', "github-secure") }}?next={{ next }}" class="social github-icon">
+                        <i class="fa fa-github-square"></i>
+                    </a>
+                {% endif %}
+            </div>
         {% endif %}
     </div>
 {% endblock %}

--- a/templates/registration/two_factor_auth.html
+++ b/templates/registration/two_factor_auth.html
@@ -2,13 +2,6 @@
 
 {% block media %}
     <style>
-        #login-panel-2fa {
-            position: relative;
-            margin: 5em auto auto -10em;
-            top: 40%;
-            left: 50%;
-        }
-
         #totp-or-scratch-code-container {
             margin: 0.5em 0;
         }
@@ -65,7 +58,7 @@
 {% endblock %}
 
 {% block body %}
-    <div id="login-panel-2fa">
+    <div class="auth-flow-form">
         <form action="" method="post" class="form-area" id="2fa-form">
             {% csrf_token %}
             {% if form.errors %}


### PR DESCRIPTION
Previously, we were using a relatively positioned `div`, and so each time the form was modified, we had to manually "center" the form by adjusting the CSS values. It also caused some issues with horizontal scrollbars showing up when there should be no scrollbar (notably on the 2fa page).

After this commit, the form should auto-centre even if there are changes, and the horizontal scrollbar no longer appears.

Before login page:
![image](https://user-images.githubusercontent.com/29607503/113057366-f0fbbf00-917a-11eb-99da-940c528f2cc1.png)

After login page:
![image](https://user-images.githubusercontent.com/29607503/113057374-f48f4600-917a-11eb-9237-6a03637773ef.png)

Before 2fa page:
![image](https://user-images.githubusercontent.com/29607503/113057401-fe18ae00-917a-11eb-811f-16f1491292c2.png)

After 2fa page:
![image](https://user-images.githubusercontent.com/29607503/113057412-01139e80-917b-11eb-917d-c32fb94196c7.png)

Note that the changes are more noticeable if the images are opened in a new tab and compared side-by-side. 
