### PR TITLE
Always show top border line on submission table

### DIFF
--- a/resources/submission.scss
+++ b/resources/submission.scss
@@ -14,6 +14,7 @@
 
 .submission-row {
     display: flex;
+    border-top: #ccc 1px solid;
     border-left: #ccc 1px solid;
     border-right: #ccc 1px solid;
     transition: background-color linear 0.2s;
@@ -22,8 +23,8 @@
         background: #F2F2F2;
     }
 
-    &:first-of-type {
-        border-top: #ccc 1px solid;
+    &:not(:empty) ~ & {
+        border-top: none;
     }
 
     > div {


### PR DESCRIPTION
This works with an arbitrary number of empty elements anywhere in the table.

Fixes #1598