### PR TITLE
Support django-recaptcha2>=1.4.0

### DIFF
--- a/judge/jinja2/social.py
+++ b/judge/jinja2/social.py
@@ -32,4 +32,6 @@ for name, template, url_func in SHARES:
 
 @registry.function
 def recaptcha_init(language=None):
-    return get_template('snowpenguin/recaptcha/recaptcha_init.html').render({'explicit': False, 'language': language})
+    from snowpenguin.django.recaptcha2.templatetags.recaptcha2 import recaptcha_common_init
+    return get_template('snowpenguin/recaptcha/recaptcha_init.html').render(
+        recaptcha_common_init(language, {'explicit': False}))


### PR DESCRIPTION
`django-recaptcha>=1.4.0` supports configuring the hostname, which eliminates the hack currently on prod to use `https://recaptcha.net` instead of `https://google.com`.

Prod is already configured to use `RECAPTCHA_PROXY_HOST = 'https://recaptcha.net'` and `django-recaptcha2` 1.4.1, but things did not break because `templates/snowpenguin/recaptcha/recaptcha_init.html` is overridden with hardcoded `https://recaptcha.net`. Once this is merged, `templates/snowpenguin/recaptcha/recaptcha_init.html` can safely be deleted.

This fixes #1559.