### PR TITLE
Limit width of registration form for mobile

### DIFF
--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -79,9 +79,6 @@
         #edit-form {
             border: unset;
             background: unset;
-            max-width: 100%;
-            width: 450px;
-            margin: 0 -10px 0 -15px;
         }
 
         #content-body {
@@ -91,7 +88,7 @@
         #center-float {
             display: inline-block;
             text-align: initial;
-            max-width: 90%;
+            max-width: 100%;
             width: 450px;
         }
 

--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -79,7 +79,7 @@
         #edit-form {
             border: unset;
             background: unset;
-            max-width: 450px;
+            max-width: 100%;
             width: 450px;
         }
 
@@ -90,7 +90,7 @@
         #center-float {
             display: inline-block;
             text-align: initial;
-            max-width: 450px;
+            max-width: 90%;
             width: 450px;
         }
 

--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -81,6 +81,7 @@
             background: unset;
             max-width: 100%;
             width: 450px;
+            margin: 0 -10px 0 -15px;
         }
 
         #content-body {


### PR DESCRIPTION
Set max-width of the registration form to 90% to avoid overflow in small screen phones. 