### PR TITLE
Add is_organization_private to automatic problem rescore check

### DIFF
--- a/judge/admin/problem.py
+++ b/judge/admin/problem.py
@@ -234,7 +234,10 @@ class ProblemAdmin(NoBatchDeleteMixin, VersionAdmin):
 
     def save_model(self, request, obj, form, change):
         super(ProblemAdmin, self).save_model(request, obj, form, change)
-        if form.changed_data and any(f in form.changed_data for f in ('is_public', 'points', 'partial')):
+        if (
+            form.changed_data and
+            any(f in form.changed_data for f in ('is_public', 'is_organization_private', 'points', 'partial'))
+        ):
             self._rescore(request, obj.id)
 
     def construct_change_message(self, request, form, *args, **kwargs):


### PR DESCRIPTION
`is_organization_private` problems are ignored when computing
a user's points, so turning a problem organization private
(and vice versa) must recompute that user's points.