### PR TITLE
Use gettext_lazy to translate title

### DIFF
--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -129,7 +129,7 @@ class UserPage(TitleMixin, UserMixin, DetailView):
 
 class CustomLoginView(LoginView):
     template_name = 'registration/login.html'
-    extra_context = {'title': _('Login')}
+    extra_context = {'title': gettext_lazy('Login')}
     authentication_form = CustomAuthenticationForm
     redirect_authenticated_user = True
 
@@ -501,7 +501,7 @@ def user_ranking_redirect(request):
 
 class UserLogoutView(TitleMixin, TemplateView):
     template_name = 'registration/logout.html'
-    title = 'You have been successfully logged out.'
+    title = gettext_lazy('You have been successfully logged out.')
 
     def post(self, request, *args, **kwargs):
         auth_logout(request)


### PR DESCRIPTION
Using `gettext` will not translate the title of the login view (I still don't know why). I used `gettext_lazy` and it works. 

Maybe there is some more place that didn't translate correctly but I haven't found any yet.