### PR TITLE
Don't set negative margin followed by padding on ticket messages

### DIFF
--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -106,8 +106,7 @@
 
         .message {
             display: flex;
-            margin-top: -40px;
-            padding-top: 55px;
+            padding-top: 15px;
         }
 
         .message .info {


### PR DESCRIPTION
This fixes an issue where part of the ticket title cannot be selected
because the first ticket message is overlapping with the title text.

Reported by @int-y1.