### PR TITLE
Set caniuse PR author to dmoj-build

### DIFF
--- a/.github/workflows/caniuse.yml
+++ b/.github/workflows/caniuse.yml
@@ -15,6 +15,7 @@ jobs:
       uses: peter-evans/create-pull-request@v2
       with:
         token: ${{ secrets.REPO_SCOPED_TOKEN }}
+        author: dmoj-build <build@dmoj.ca>
         committer: dmoj-build <build@dmoj.ca>
         title: Import latest Can I use... data
         commit-message: Import latest Can I use... data


### PR DESCRIPTION
The current behaviour is using whoever committed last on master as the author.
This is clearly a misattribution.