### PR TITLE
Add copy button on loading comment history

### DIFF
--- a/templates/comments/media-js.html
+++ b/templates/comments/media-js.html
@@ -86,7 +86,7 @@
                 }).done(function (body) {
                     $comment.find('.previous-revision').css({visibility: show_revision == 0 ? 'hidden' : ''});
                     $comment.find('.next-revision').css({visibility: show_revision == max_revision ? 'hidden' : ''});
-                    $comment.find('.content').html(body);
+                    var $content = $comment.find('.content').html(body);
 
                     var edit_text = '{{ _('edit {edits}') }}'.replace("{edits}", show_revision);
 
@@ -97,7 +97,9 @@
                     }
 
                     $comment.find('.comment-edit-text').text(' ' + edit_text + ' ');
-                    update_math($comment);
+                    update_math($content);
+                    if (window.add_code_copy_buttons)
+                        window.add_code_copy_buttons($content);
                 });
             };
 
@@ -191,6 +193,8 @@
                                 var $area = $comment.find('.comment-body').first();
                                 $area.html(data);
                                 update_math($comment);
+                                if (window.add_code_copy_buttons)
+                                    window.add_code_copy_buttons($area);
                                 var $edits = $comment.find('.comment-edits').first();
                                 $edits.text('updated');
                             }).fail(function () {

--- a/templates/common-content.html
+++ b/templates/common-content.html
@@ -24,32 +24,34 @@
                     }
                 }
 
-                var copyButton;
-                $('pre code').each(function () {
-                    $(this).parent().before($('<div>', {'class': 'copy-clipboard'})
-                        .append(copyButton = $('<span>', {
-                            'class': 'btn-clipboard',
-                            'data-clipboard-text': $(this).text(),
-                            'title': 'Click to copy'
-                        }).text('Copy')));
+                window.add_code_copy_buttons = function ($container) {
+                    $container.find('pre code').each(function () {
+                        var copyButton;
+                        $(this).parent().before($('<div>', {'class': 'copy-clipboard'})
+                            .append(copyButton = $('<span>', {
+                                'class': 'btn-clipboard',
+                                'data-clipboard-text': $(this).text(),
+                                'title': 'Click to copy'
+                            }).text('Copy')));
 
-                    $(copyButton.get(0)).mouseleave(function () {
-                        $(this).attr('class', 'btn-clipboard');
-                        $(this).removeAttr('aria-label');
+                        $(copyButton.get(0)).mouseleave(function () {
+                            $(this).attr('class', 'btn-clipboard');
+                            $(this).removeAttr('aria-label');
+                        });
+
+                        var curClipboard = new Clipboard(copyButton.get(0));
+
+                        curClipboard.on('success', function (e) {
+                            e.clearSelection();
+                            showTooltip(e.trigger, 'Copied!');
+                        });
+
+                        curClipboard.on('error', function (e) {
+                            showTooltip(e.trigger, fallbackMessage(e.action));
+                        });
                     });
-
-                    var curClipboard = new Clipboard(copyButton.get(0));
-
-                    curClipboard.on('success', function (e) {
-                        e.clearSelection();
-                        showTooltip(e.trigger, 'Copied!');
-                    });
-
-                    curClipboard.on('error', function (e) {
-                        showTooltip(e.trigger, fallbackMessage(e.action));
-                    });
-
-                });
+                }
+                window.add_code_copy_buttons($(document));
             });
         </script>
     {% endcompress %}


### PR DESCRIPTION
This commit also adds a helper function to add copy buttons for other
dynamic content in the future. This fixes #1541.

This has been tested on the test site.