### PR TITLE
Faster filtering on submission API v2 endpoint

### DIFF
--- a/judge/views/api/api_v2.py
+++ b/judge/views/api/api_v2.py
@@ -1,7 +1,7 @@
 from operator import attrgetter
 
 from django.conf import settings
-from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.db.models import Count, F, OuterRef, Prefetch, Q, Subquery
 from django.http import Http404, JsonResponse
 from django.utils import timezone
@@ -16,6 +16,43 @@ from judge.models import (
 from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.raw_sql import join_sql_subquery, use_straight_join
 from judge.views.submission import group_test_cases
+
+
+class BaseSimpleFilter:
+    def __init__(self, lookup):
+        self.lookup = lookup
+
+    def get_object(self, key):
+        raise NotImplementedError()
+
+    def to_filter(self, key):
+        try:
+            return {self.lookup: self.get_object(key)}
+        except ObjectDoesNotExist:
+            return {self.lookup: None}
+
+
+class ProfileSimpleFilter(BaseSimpleFilter):
+    def get_object(self, key):
+        return Profile.objects.get(user__username=key)
+
+
+class ProblemSimpleFilter(BaseSimpleFilter):
+    def get_object(self, key):
+        return Problem.objects.get(code=key)
+
+
+class BaseListFilter:
+    def to_filter(self, key_list):
+        raise NotImplementedError()
+
+
+class LanguageListFilter(BaseListFilter):
+    def __init__(self, lookup):
+        self.lookup = lookup
+
+    def to_filter(self, key_list):
+        return {f'{self.lookup}_id__in': Language.objects.filter(key__in=key_list).values_list('id', flat=True)}
 
 
 class APILoginRequiredException(Exception):
@@ -108,18 +145,24 @@ class APIListView(APIMixin, InfinitePaginationMixin, BaseListView):
 
         for key, filter_name in self.basic_filters:
             if key in self.request.GET:
-                # May raise ValueError or ValidationError, but is caught in APIMixin
-                queryset = queryset.filter(**{
-                    filter_name: self.request.GET.get(key),
-                })
+                if isinstance(filter_name, BaseSimpleFilter):
+                    queryset = queryset.filter(**filter_name.to_filter(self.request.GET.get(key)))
+                else:
+                    # May raise ValueError or ValidationError, but is caught in APIMixin
+                    queryset = queryset.filter(**{
+                        filter_name: self.request.GET.get(key),
+                    })
                 self.used_basic_filters.add(key)
 
         for key, filter_name in self.list_filters:
             if key in self.request.GET:
-                # May raise ValueError or ValidationError, but is caught in APIMixin
-                queryset = queryset.filter(**{
-                    filter_name + '__in': self.request.GET.getlist(key),
-                })
+                if isinstance(filter_name, BaseListFilter):
+                    queryset = queryset.filter(**filter_name.to_filter(self.request.GET.getlist(key)))
+                else:
+                    # May raise ValueError or ValidationError, but is caught in APIMixin
+                    queryset = queryset.filter(**{
+                        filter_name + '__in': self.request.GET.getlist(key),
+                    })
                 self.used_list_filters.add(key)
 
         return queryset
@@ -516,11 +559,11 @@ class APIUserDetail(APIDetailView):
 class APISubmissionList(APIListView):
     model = Submission
     basic_filters = (
-        ('user', 'user__user__username'),
-        ('problem', 'problem__code'),
+        ('user', ProfileSimpleFilter('user')),
+        ('problem', ProblemSimpleFilter('problem')),
     )
     list_filters = (
-        ('language', 'language__key'),
+        ('language', LanguageListFilter('language')),
         ('result', 'result'),
     )
 


### PR DESCRIPTION
Instead of joining the user table and looking up the username, we can
simply look up the profile ID and use the index. A similar optimization
is done for problems. Fixes #1584.

This has been tested on the test site.