### PR TITLE
Add problem visibility to APIProblemList

### DIFF
--- a/judge/views/api/api_v2.py
+++ b/judge/views/api/api_v2.py
@@ -422,6 +422,8 @@ class APIProblemList(APIListView):
             'group': problem.group.full_name,
             'points': problem.points,
             'partial': problem.partial,
+            'is_organization_private': problem.is_organization_private,
+            'is_public': problem.is_public,
         }
 
 


### PR DESCRIPTION
This is a quite needed feature for my discord bot JOMD. Assuming if we link an api token with the bot there's no way to differentiate between public problems, problems within an organization (say olympiads) and private problems. This mean accidentally leaking problems without the appropriate information.

Before the solution was to query every problem for the appropriate information, meaning we would have to send a request for every problem detail.

This pr means to add the appropriate info to the problem list api so the solution above is not needed.