### PR TITLE
Remove unneeded `profile.update_contest()` call in `ProblemSubmit`

### DIFF
--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -632,7 +632,6 @@ class ProblemSubmit(LoginRequiredMixin, ProblemMixin, TitleMixin, SingleObjectFo
 
             source = SubmissionSource(submission=self.new_submission, source=form.cleaned_data['source'])
             source.save()
-            self.request.profile.update_contest()
 
         # Save a query.
         self.new_submission.source = source


### PR DESCRIPTION
There is a middleware that calls `profile.update_contest()` (see https://github.com/DMOJ/online-judge/blob/master/judge/middleware.py#L75), so I don't think there's any need to call it here again. I think this code was a remnant of when there was no middleware and the view was a function based view (see 6847439)