### PR TITLE
Refactor implementation of contest rating

### DIFF
--- a/judge/utils/ranker.py
+++ b/judge/utils/ranker.py
@@ -12,23 +12,3 @@ def ranker(iterable, key=attrgetter('points'), rank=0):
         delta += 1
         yield rank, item
         last = key(item)
-
-
-def tie_ranker(iterable, key=attrgetter('points')):
-    rank = 0
-    delta = 1
-    last = None
-    buf = []
-    for item in iterable:
-        new = key(item)
-        if new != last:
-            for i in buf:
-                yield rank + (delta - 1) / 2.0, i
-            rank += delta
-            delta = 0
-            buf = []
-        delta += 1
-        buf.append(item)
-        last = key(item)
-    for i in buf:
-        yield rank + (delta - 1) / 2.0, i


### PR DESCRIPTION
This eliminates a raw SQL, instead implementing rating, volatility,
and times fetching with Django Subquery.

As we are now fetching the rating in the query, we can implement rating
floors and ceiling with the correct rating value, which fixes #1684.

Furthermore, ranking is now correctly computed with tiebreaker.

Co-Authored-By: kiritofeng <rogerjfu@hotmail.com>