### PR TITLE
Use correct spacing for rating column in contest rankings

### DIFF
--- a/templates/contest/ranking-table.html
+++ b/templates/contest/ranking-table.html
@@ -2,14 +2,14 @@
 
 {% block after_rank_head %}
     {% if has_rating %}
-        <th>{{ _('Rating') }}</th>
+        <th class="rating-column">{{ _('Rating') }}</th>
     {% endif %}
     <th class="organization-column">{{ _('Organization') }}</th>
 {% endblock %}
 
 {% block after_rank %}
     {% if has_rating %}
-        <td>{% if user.participation_rating %}{{ rating_number(user.participation_rating) }}{% endif %}</td>
+        <td class="rating-column">{% if user.participation_rating %}{{ rating_number(user.participation_rating) }}{% endif %}</td>
     {% endif %}
     <td class="organization-column">
         {% if user.organization %}

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -13,6 +13,10 @@
             min-width: 20em;
         }
 
+        #users-table .rating-column {
+            min-width: 3em;
+        }
+
         #users-table td {
             height: 2.5em;
         }


### PR DESCRIPTION
This avoids stuff like the following when the word for "rating" in the current language is too short:

![](https://user-images.githubusercontent.com/461885/118082723-ada48b00-b38b-11eb-8616-4c080f356cd1.png)
