### PR TITLE
Pass request as context in default flatpage template

### DIFF
--- a/templates/flatpages/default.html
+++ b/templates/flatpages/default.html
@@ -11,5 +11,5 @@
 {% endblock %}
 
 {% block body %}
-    {{ render_django(flatpage.content) }}
+    {{ render_django(flatpage.content, request=request) }}
 {% endblock %}


### PR DESCRIPTION
This used to be supported, and removing it has broken some old flatpages.