### PR TITLE
Remove unneeded rating object delete operation in `rate_contest`

### DIFF
--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -153,7 +153,6 @@ def rate_contest(contest):
     ratings = [Rating(user_id=i, contest=contest, rating=r, volatility=v, last_rated=now, participation_id=p, rank=z)
                for i, p, r, v, z in zip(user_ids, participation_ids, rating, volatility, ranking)]
     with transaction.atomic():
-        Rating.objects.filter(contest=contest).delete()
         Rating.objects.bulk_create(ratings)
 
         Profile.objects.filter(contest_history__contest=contest, contest_history__virtual=0).update(


### PR DESCRIPTION
The prerequesite for calling `rate_contest` is that
all Rating objects attached to a contest with an end time
greater than or equal to the current contest are deleted.
If they are not deleted, the annotation for `last_rating`
would be wrong.
The `Rating.objects.filter(contest=contest).delete()` operation
would delete the current contest's ratings after we have already
annotated, which means we would be using the current contest's
rating as the `last_rating`. This makes no sense, so we must
have already deleted them prior to this operation.
These Rating objects are in fact already deleted in
`Contest.rate()`, so this call is unneeded.