### PR TITLE
Atomically rate multiple contests

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -383,11 +383,12 @@ class Contest(models.Model):
         return queryset.distinct()
 
     def rate(self):
-        Rating.objects.filter(contest__end_time__range=(self.end_time, self._now)).delete()
-        for contest in Contest.objects.filter(
-            is_rated=True, end_time__range=(self.end_time, self._now),
-        ).order_by('end_time'):
-            rate_contest(contest)
+        with transaction.atomic():
+            Rating.objects.filter(contest__end_time__range=(self.end_time, self._now)).delete()
+            for contest in Contest.objects.filter(
+                is_rated=True, end_time__range=(self.end_time, self._now),
+            ).order_by('end_time'):
+                rate_contest(contest)
 
     class Meta:
         permissions = (

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -159,7 +159,6 @@ def rate_contest(contest):
         Profile.objects.filter(contest_history__contest=contest, contest_history__virtual=0).update(
             rating=Subquery(Rating.objects.filter(user=OuterRef('id'))
                             .order_by('-contest__end_time').values('rating')[:1]))
-    return old_rating, old_volatility, ranking, times_ranked, rating, volatility
 
 
 RATING_LEVELS = ['Newbie', 'Amateur', 'Expert', 'Candidate Master', 'Master', 'Grandmaster', 'Target']


### PR DESCRIPTION
This prevents data corruption when a contest that is not the most recent
is rerated, and something happens before rating is complete all contests.

Also remove the return value of `rate_contest` because it's never used.