### PR TITLE
Refactor TOTPEnableView in preparation for #1693

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -18,12 +18,16 @@ from judge.models import Contest, Language, Organization, Problem, Profile, Subm
 from judge.utils.subscription import newsletter_id
 from judge.widgets import HeavyPreviewPageDownWidget, Select2MultipleWidget, Select2Widget
 
+TOTP_CODE_LENGTH = 6
+
 two_factor_validators_by_length = {
-    6: {
-        'regex_validator': RegexValidator('^[0-9]{6}$',
-                                          _('Two-factor authentication tokens must be 6 decimal digits.')),
-        'verify': lambda code, profile: not pyotp.TOTP(profile.totp_key)
-                                                 .verify(code, valid_window=settings.DMOJ_TOTP_TOLERANCE_HALF_MINUTES),
+    TOTP_CODE_LENGTH: {
+        'regex_validator': RegexValidator(
+            f'^[0-9]{{{TOTP_CODE_LENGTH}}}$',
+            _(f'Two-factor authentication tokens must be {TOTP_CODE_LENGTH} decimal digits.'),
+        ),
+        'verify': lambda code, profile:
+            not pyotp.TOTP(profile.totp_key).verify(code, valid_window=settings.DMOJ_TOTP_TOLERANCE_HALF_MINUTES),
         'err': _('Invalid two-factor authentication token.'),
     },
     16: {
@@ -176,7 +180,6 @@ class TOTPForm(Form):
     TOLERANCE = settings.DMOJ_TOTP_TOLERANCE_HALF_MINUTES
 
     totp_or_scratch_code = NoAutoCompleteCharField(required=False)
-    webauthn_response = forms.CharField(widget=forms.HiddenInput(), required=False)
 
     def __init__(self, *args, **kwargs):
         self.profile = kwargs.pop('profile')
@@ -191,6 +194,19 @@ class TOTPForm(Form):
         validator['regex_validator'](totp_or_scratch_code)
         if validator['verify'](totp_or_scratch_code, self.profile):
             raise ValidationError(validator['err'])
+
+
+class TOTPEnableForm(TOTPForm):
+    def __init__(self, *args, **kwargs):
+        self.totp_key = kwargs.pop('totp_key')
+        super().__init__(*args, **kwargs)
+
+    def clean(self):
+        totp_validate = two_factor_validators_by_length[TOTP_CODE_LENGTH]
+        code = self.cleaned_data.get('totp_or_scratch_code')
+        totp_validate['regex_validator'](code)
+        if not pyotp.TOTP(self.totp_key).verify(code, valid_window=settings.DMOJ_TOTP_TOLERANCE_HALF_MINUTES):
+            raise ValidationError(totp_validate['err'])
 
 
 class TwoFactorLoginForm(TOTPForm):

--- a/judge/views/two_factor.py
+++ b/judge/views/two_factor.py
@@ -16,7 +16,7 @@ from django.utils.translation import gettext as _
 from django.views.generic import FormView, View
 from django.views.generic.detail import SingleObjectMixin
 
-from judge.forms import TOTPForm, TwoFactorLoginForm
+from judge.forms import TOTPEnableForm, TOTPForm, TwoFactorLoginForm
 from judge.jinja2.gravatar import gravatar
 from judge.models import WebAuthnCredential
 from judge.utils.two_factor import WebAuthnJSONEncoder, webauthn_encode
@@ -47,37 +47,44 @@ class TOTPView(TitleMixin, LoginRequiredMixin, FormView):
 
 class TOTPEnableView(TOTPView):
     title = _('Enable Two-factor Authentication')
+    form_class = TOTPEnableForm
     template_name = 'registration/totp_enable.html'
 
     def get(self, request, *args, **kwargs):
         profile = self.profile
-        if not profile.totp_key:
-            profile.totp_key = pyotp.random_base32(length=32)
-            profile.save(update_fields=['totp_key'])
+        if 'totp_enable_key' not in request.session:
+            request.session['totp_enable_key'] = pyotp.random_base32(length=32)
         if not profile.scratch_codes:
             profile.generate_scratch_codes()
         return self.render_to_response(self.get_context_data())
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['totp_key'] = self.request.session['totp_enable_key']
+        return kwargs
 
     def check_skip(self):
         return self.profile.is_totp_enabled
 
     def post(self, request, *args, **kwargs):
-        if not self.profile.totp_key:
+        if not request.session['totp_enable_key']:
             return HttpResponseBadRequest('No TOTP key generated on server side?')
         return super(TOTPEnableView, self).post(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super(TOTPEnableView, self).get_context_data(**kwargs)
-        context['totp_key'] = self.profile.totp_key
+        context['totp_key'] = self.request.session['totp_enable_key']
         context['scratch_codes'] = json.loads(self.profile.scratch_codes)
-        context['qr_code'] = self.render_qr_code(self.request.user.username, self.profile.totp_key)
+        context['qr_code'] = self.render_qr_code(self.request.user.username, context['totp_key'])
         return context
 
     def form_valid(self, form):
         self.profile.is_totp_enabled = True
-        self.profile.save()
+        self.profile.totp_key = self.request.session['totp_enable_key']
+        self.profile.save(update_fields=['is_totp_enabled', 'totp_key'])
         # Make sure users don't get prompted to enter code right after enabling
         self.request.session['2fa_passed'] = True
+        del self.request.session['totp_enable_key']
         return self.next_page()
 
     @classmethod

--- a/templates/registration/totp_enable.html
+++ b/templates/registration/totp_enable.html
@@ -43,6 +43,10 @@
             image-rendering: crisp-edges;
         }
 
+        code.totp-code {
+            user-select: all;
+        }
+
         .scratch-codes {
             white-space: pre-line;
         }


### PR DESCRIPTION
This will pave the way for #1693.

Changes:

* the new TOTP key in `request.session`, allowing key changes without destroying the current key
* use a special `TOTPEnableForm` to reject scratch codes when enabling TOTP
* make TOTP code easily selectable and copy without whitespace

This was actually tested on a test site.