### PR TITLE
Display better message on editorial 404

### DIFF
--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -128,6 +128,11 @@ class ProblemSolution(SolvedProblemMixin, ProblemMixin, TitleMixin, CommentedDet
     def get_comment_page(self):
         return 's:' + self.object.code
 
+    def no_such_problem(self):
+        code = self.kwargs.get(self.slug_url_kwarg, None)
+        return generic_message(self.request, _('No such editorial'),
+                               _('Could not find an editorial with the code "%s".') % code, status=404)
+
 
 class ProblemRaw(ProblemMixin, TitleMixin, TemplateResponseMixin, SingleObjectMixin, View):
     context_object_name = 'problem'


### PR DESCRIPTION
This fixes #1709.

Preview:
![](https://user-images.githubusercontent.com/461885/120879858-709b7500-c594-11eb-89f0-aba124d56a86.png)
