### PR TITLE
Allow WebAuthn devices to be managed in admin

### DIFF
--- a/judge/admin/profile.py
+++ b/judge/admin/profile.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext, gettext_lazy as _, ungettext
 from reversion.admin import VersionAdmin
 
 from django_ace import AceWidget
-from judge.models import Profile
+from judge.models import Profile, WebAuthnCredential
 from judge.utils.views import NoBatchDeleteMixin
 from judge.widgets import AdminMartorWidget, AdminSelect2Widget
 
@@ -44,6 +44,15 @@ class TimezoneFilter(admin.SimpleListFilter):
         return queryset.filter(timezone=self.value())
 
 
+class WebAuthnInline(admin.TabularInline):
+    model = WebAuthnCredential
+    readonly_fields = ('cred_id', 'public_key', 'counter')
+    extra = 0
+
+    def has_add_permission(self, request):
+        return False
+
+
 class ProfileAdmin(NoBatchDeleteMixin, VersionAdmin):
     fields = ('user', 'display_rank', 'about', 'organizations', 'timezone', 'language', 'ace_theme',
               'math_engine', 'last_access', 'ip', 'mute', 'is_unlisted', 'notes', 'is_totp_enabled', 'user_script',
@@ -58,6 +67,7 @@ class ProfileAdmin(NoBatchDeleteMixin, VersionAdmin):
     actions_on_top = True
     actions_on_bottom = True
     form = ProfileForm
+    inlines = [WebAuthnInline]
 
     def get_queryset(self, request):
         return super(ProfileAdmin, self).get_queryset(request).select_related('user')

--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -263,6 +263,13 @@ class WebAuthnCredential(models.Model):
             rp_id=settings.WEBAUTHN_RP_ID,
         )
 
+    def __str__(self):
+        return f'WebAuthn credential: {self.name}'
+
+    class Meta:
+        verbose_name = _('WebAuthn credential')
+        verbose_name_plural = _('WebAuthn credentials')
+
 
 class OrganizationRequest(models.Model):
     user = models.ForeignKey(Profile, verbose_name=_('user'), related_name='requests', on_delete=models.CASCADE)

--- a/judge/views/two_factor.py
+++ b/judge/views/two_factor.py
@@ -221,10 +221,6 @@ class WebAuthnDeleteView(SingleObjectMixin, WebAuthnView):
             return HttpResponseBadRequest(_('Staff may not disable 2FA'))
         credential.delete()
 
-        if count <= 1:
-            request.profile.is_webauthn_enabled = False
-            request.profile.save(update_fields=['is_webauthn_enabled'])
-
         return HttpResponse()
 
 


### PR DESCRIPTION
This fixes #1698. Note that we cannot add WebAuthn devices for the user, so
that part is not and will never be implemented.

Setting is_webauthn_enabled to False when removing all WebAuthn devices is
moved to a signal so that it also works when deleting credentials in the admin.