### PR TITLE
Make TOTP enable/disable views mobile friendly

### DIFF
--- a/templates/registration/totp_disable.html
+++ b/templates/registration/totp_disable.html
@@ -16,13 +16,6 @@
             padding-top: 0.5em;
         }
 
-        #center-float {
-            position: relative;
-            margin: 0 auto auto -28.5em;
-            left: 50%;
-            width: 700px;
-        }
-
         #totp-disable-form {
             border: unset;
             background: unset;
@@ -32,7 +25,7 @@
 {% endblock %}
 
 {% block body %}
-    <div id="center-float">
+    <div class="auth-flow-form" style="padding-top: 0;">
         <form id="totp-disable-form" action="" method="post" class="form-area">
             {% csrf_token %}
             <div class="block-header">{{ _('To protect your account, you must first authenticate before you can disable Two Factor Authentication.') }}</div>

--- a/templates/registration/totp_enable.html
+++ b/templates/registration/totp_enable.html
@@ -16,13 +16,6 @@
             padding-top: 0.5em;
         }
 
-        #center-float {
-            position: relative;
-            margin: 0 auto auto -28.5em;
-            left: 50%;
-            width: 700px;
-        }
-
         #totp-enable-form {
             border: none;
             background: none;
@@ -72,7 +65,7 @@
 {% endblock %}
 
 {% block body %}
-    <div id="center-float">
+    <div class="auth-flow-form" style="padding-top: 0;">
         <form id="totp-enable-form" action="" method="post" class="form-area">
             {% csrf_token %}
 


### PR DESCRIPTION
The views were practically unusable on mobile before without forcing desktop mode.

Before (on a small width screen):
![image](https://user-images.githubusercontent.com/29607503/120895586-a3bd2300-c5eb-11eb-9e24-cc5d35f3400f.png)
![image](https://user-images.githubusercontent.com/29607503/120895609-c64f3c00-c5eb-11eb-9250-0db18b057c59.png)

Note: you cannot scroll to the left in either of the views.

After:
![image](https://user-images.githubusercontent.com/29607503/120895635-eb43af00-c5eb-11eb-9f67-4777bfffbe98.png)
![image](https://user-images.githubusercontent.com/29607503/120895657-044c6000-c5ec-11eb-9efe-e9454d8af3e7.png)

The views on a larger screen are almost identical. The only changes are that the form is now properly centred and this:
Before:
![image](https://user-images.githubusercontent.com/29607503/120895693-2b0a9680-c5ec-11eb-8075-a42953f423fc.png)
After:
![image](https://user-images.githubusercontent.com/29607503/120895687-234af200-c5ec-11eb-887f-c114f13a375d.png)

Note that in the after screenshot, the text still wraps at 700px (not sure why it wraps early in the before screenshot).