### PR TITLE
Ensure `edit_own_problem` is a prerequisite for `edit_all_problem`

### DIFF
--- a/judge/models/tests/test_problem.py
+++ b/judge/models/tests/test_problem.py
@@ -13,6 +13,14 @@ class ProblemTestCase(CommonDataMixin, TestCase):
     def setUpTestData(self):
         super().setUpTestData()
 
+        self.users.update({
+            'staff_problem_edit_only_all': create_user(
+                username='staff_problem_edit_only_all',
+                is_staff=True,
+                user_permissions=('edit_all_problem',),
+            ),
+        })
+
         create_problem_type(name='type')
 
         self.basic_problem = create_problem(


### PR DESCRIPTION
`judge.edit_own_problem` is already a required permission for admin-related tasks, so if a user has only `judge.edit_all_problem` without `judge.edit_own_problem`, they'll get a lot of links to 400/404 pages.

Not sure why you would give `judge.edit_all_problem` without `judge.edit_own_problem` in the first place, but we should probably ensure everything is consistent.