### PR TITLE
Add word wrap to case feedback on submission status

### DIFF
--- a/resources/submission.scss
+++ b/resources/submission.scss
@@ -294,6 +294,10 @@ label[for="language"], label[for="status"] {
     td.case-output + td.case-ext-feedback {
         width: 50%;
     }
+
+    .case-output {
+        word-wrap: anywhere;
+    }
 }
 
 .case-AC {


### PR DESCRIPTION
This prevents giant rows of checkmarks created by the linecount checker
from overflowing the screen and pushing the results off-screen.