### PR TITLE
Remove unused `malformed_packet` method

### DIFF
--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -245,10 +245,6 @@ class JudgeHandler(ZlibPacketHandler):
         if self.name:
             logger.warning('Judge seems dead: %s: %s', self.name, self._working)
 
-    def malformed_packet(self, exception):
-        logger.exception('Judge sent malformed packet: %s', self.name)
-        super(JudgeHandler, self).malformed_packet(exception)
-
     def on_submission_processing(self, packet):
         _ensure_connection()
 


### PR DESCRIPTION
This method is never used and the parent class does not even have a `malformed_packet`. Probably (?) related to 22cbce731.