### PR TITLE
Remove unused ticket CSS "messages" class

### DIFF
--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -319,7 +319,7 @@
 {% block body %}
     <div class="container">
         <div class="ticket-messages">
-            <main id="messages" class="messages">
+            <main id="messages">
                 {% for message in ticket_messages %}
                     {% include "ticket/message.html" %}
                 {% endfor %}


### PR DESCRIPTION
This class is never used, and also conflicts with other styles
for "messages".

For example, there is padding for list items when there shouldn't be: https://github.com/DMOJ/online-judge/blob/master/resources/widgets.scss#L492

Before:
![image](https://user-images.githubusercontent.com/29607503/122684628-77e99200-d1d4-11eb-96d0-cb2fee72b63d.png)

After (what it looks like in the preview):
![image](https://user-images.githubusercontent.com/29607503/122684626-7324de00-d1d4-11eb-8680-34281d9ec439.png)
