### PR TITLE
Add consistency to participation in /contest

### DIFF
--- a/judge/views/api/api_v2.py
+++ b/judge/views/api/api_v2.py
@@ -265,6 +265,8 @@ class APIContestDetail(APIDetailView):
                 username=F('user__user__username'),
                 old_rating=Subquery(old_ratings_subquery.values('rating')[:1]),
                 new_rating=Subquery(new_ratings_subquery.values('rating')[:1]),
+                old_volatility=Subquery(old_ratings_subquery.values('volatility')[:1]),
+                new_volatility=Subquery(new_ratings_subquery.values('volatility')[:1]),
             )
             .order_by('-score', 'cumtime', 'tiebreaker')
         )
@@ -318,6 +320,8 @@ class APIContestDetail(APIDetailView):
                     'tiebreaker': participation.tiebreaker,
                     'old_rating': participation.old_rating,
                     'new_rating': participation.new_rating,
+                    'old_volatility': participation.old_volatility,
+                    'new_volatility': participation.new_volatility,
                     'is_disqualified': participation.is_disqualified,
                     'solutions': contest.format.get_problem_breakdown(participation, problems),
                 } for participation in participations


### PR DESCRIPTION
TODOs
`/contest`
- [X] old_volatility
- [X] new_volatility
- [ ] ~virtual_participation_number~ (Always 0)

`/participations`
- [ ] old_rating
- [ ] new_rating
- [ ] old_volatility
- [ ] new_volatility
- [ ] solutions ? (Out of context if placed in api)

`/user`
- [ ] user ? (Redundant)
- [ ] start_time
- [ ] end_time
- [ ] tiebreaker
- [ ] old_rating
- [ ] new_rating
- [ ] is_disqualified
- [ ] solutions
- [ ] old_volatility
- [ ] new_volatility
- [ ] virtual_participation_number (Always 0)

Also, a fix needs to be implemented for #1742 or else the same error will propagate to these proposed changes and cause confusion

~Perhaps increase mccc15s by a microsecond~
