### PR TITLE
Migrate rating system from Topcoder to Elo-MMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See it live at [dmoj.ca](https://dmoj.ca/)!
    * Supports ICPC/IOI/AtCoder/ECOO formats out-of-the box
    * **System testing** supported
    * **Hidden scoreboards** and **virtual participation**
-   * Topcoder-style **rating**
+   * [Elo-MMR](https://arxiv.org/abs/2101.00400)-style **rating**
    * **Plagiarism detection** via [Stanford MOSS](https://theory.stanford.edu/~aiken/moss/)
    * Restricting contest access to particular organizations or users
 * Rich problem statements, with support for **LaTeX math and diagrams**

--- a/judge/migrations/0123_contest_rating_elo_mmr.py
+++ b/judge/migrations/0123_contest_rating_elo_mmr.py
@@ -1,0 +1,195 @@
+from django.db import migrations, models
+from operator import attrgetter
+
+
+def tie_ranker(iterable, key=attrgetter('points')):
+    rank = 0
+    delta = 1
+    last = None
+    buf = []
+    for item in iterable:
+        new = key(item)
+        if new != last:
+            for _ in buf:
+                yield rank + (delta - 1) / 2.0
+            rank += delta
+            delta = 0
+            buf = []
+        delta += 1
+        buf.append(item)
+        last = key(item)
+    for _ in buf:
+        yield rank + (delta - 1) / 2.0
+
+
+def rational_approximation(t):
+    # Abramowitz and Stegun formula 26.2.23.
+    # The absolute value of the error should be less than 4.5 e-4.
+    c = [2.515517, 0.802853, 0.010328]
+    d = [1.432788, 0.189269, 0.001308]
+    numerator = (c[2] * t + c[1]) * t + c[0]
+    denominator = ((d[2] * t + d[1]) * t + d[0]) * t + 1.0
+    return t - numerator / denominator
+
+
+def normal_CDF_inverse(p):
+    assert 0.0 < p < 1
+
+    # See article above for explanation of this section.
+    if p < 0.5:
+        # F^-1(p) = - G^-1(p)
+        return -rational_approximation(math.sqrt(-2.0 * math.log(p)))
+    else:
+        # F^-1(p) = G^-1(1-p)
+        return rational_approximation(math.sqrt(-2.0 * math.log(1.0 - p)))
+
+
+def WP(RA, RB, VA, VB):
+    return (math.erf((RB - RA) / math.sqrt(2 * (VA * VA + VB * VB))) + 1) / 2.0
+
+
+def recalculate_ratings(old_rating, old_volatility, actual_rank, times_rated, is_disqualified):
+    # actual_rank: 1 is first place, N is last place
+    # if there are ties, use the average of places (if places 2, 3, 4, 5 tie, use 3.5 for all of them)
+
+    N = len(old_rating)
+    new_rating = old_rating[:]
+    new_volatility = old_volatility[:]
+    if N <= 1:
+        return new_rating, new_volatility
+
+    ranking = list(range(N))
+    ranking.sort(key=old_rating.__getitem__, reverse=True)
+
+    ave_rating = float(sum(old_rating)) / N
+    sum1 = sum(i * i for i in old_volatility) / N
+    sum2 = sum((i - ave_rating) ** 2 for i in old_rating) / (N - 1)
+    CF = math.sqrt(sum1 + sum2)
+
+    for i in range(N):
+        ERank = 0.5
+        for j in range(N):
+            ERank += WP(old_rating[i], old_rating[j], old_volatility[i], old_volatility[j])
+
+        EPerf = -normal_CDF_inverse((ERank - 0.5) / N)
+        APerf = -normal_CDF_inverse((actual_rank[i] - 0.5) / N)
+        PerfAs = old_rating[i] + CF * (APerf - EPerf)
+        Weight = 1.0 / (1 - (0.42 / (times_rated[i] + 1) + 0.18)) - 1.0
+        if old_rating[i] > 2500:
+            Weight *= 0.8
+        elif old_rating[i] >= 2000:
+            Weight *= 0.9
+
+        Cap = 150.0 + 1500.0 / (times_rated[i] + 2)
+
+        new_rating[i] = (old_rating[i] + Weight * PerfAs) / (1.0 + Weight)
+
+        if abs(old_rating[i] - new_rating[i]) > Cap:
+            if old_rating[i] < new_rating[i]:
+                new_rating[i] = old_rating[i] + Cap
+            else:
+                new_rating[i] = old_rating[i] - Cap
+
+        if times_rated[i] == 0:
+            new_volatility[i] = 385
+        else:
+            new_volatility[i] = math.sqrt(((new_rating[i] - old_rating[i]) ** 2) / Weight +
+                                          (old_volatility[i] ** 2) / (Weight + 1))
+
+        if is_disqualified[i]:
+            # DQed users can manipulate TopCoder ratings to get higher volatility in order to increase their rating
+            # later on, prohibit this by ensuring their volatility never increases in this situation
+            new_volatility[i] = min(new_volatility[i], old_volatility[i])
+
+    # try to keep the sum of ratings constant
+    adjust = float(sum(old_rating) - sum(new_rating)) / N
+    new_rating = list(map(adjust.__add__, new_rating))
+    # inflate a little if we have to so people who placed first don't lose rating
+    best_rank = min(actual_rank)
+    for i in range(N):
+        if abs(actual_rank[i] - best_rank) <= 1e-3 and new_rating[i] < old_rating[i] + 1:
+            new_rating[i] = old_rating[i] + 1
+    return list(map(int, map(round, new_rating))), list(map(int, map(round, new_volatility)))
+
+
+def rate_contest(contest, Rating, Profile):
+    rating_subquery = Rating.objects.filter(user=OuterRef('user'))
+    rating_sorted = rating_subquery.order_by('-contest__end_time')
+    users = contest.users.order_by('is_disqualified', '-score', 'cumtime', 'tiebreaker') \
+        .annotate(submissions=Count('submission'),
+                  last_rating=Coalesce(Subquery(rating_sorted.values('rating')[:1]), 1200),
+                  volatility=Coalesce(Subquery(rating_sorted.values('volatility')[:1]), 535),
+                  times=Coalesce(Subquery(rating_subquery.order_by().values('user_id')
+                                          .annotate(count=Count('id')).values('count')), 0)) \
+        .exclude(user_id__in=contest.rate_exclude.all()) \
+        .filter(virtual=0).values('id', 'user_id', 'score', 'cumtime', 'tiebreaker', 'is_disqualified',
+                                  'last_rating', 'volatility', 'times')
+    if not contest.rate_all:
+        users = users.filter(submissions__gt=0)
+    if contest.rating_floor is not None:
+        users = users.exclude(last_rating__lt=contest.rating_floor)
+    if contest.rating_ceiling is not None:
+        users = users.exclude(last_rating__gt=contest.rating_ceiling)
+
+    users = list(users)
+    participation_ids = list(map(itemgetter('id'), users))
+    user_ids = list(map(itemgetter('user_id'), users))
+    is_disqualified = list(map(itemgetter('is_disqualified'), users))
+    ranking = list(tie_ranker(users, key=itemgetter('score', 'cumtime', 'tiebreaker')))
+    old_rating = list(map(itemgetter('last_rating'), users))
+    old_volatility = list(map(itemgetter('volatility'), users))
+    times_ranked = list(map(itemgetter('times'), users))
+    rating, volatility = recalculate_ratings(old_rating, old_volatility, ranking, times_ranked, is_disqualified)
+
+    now = timezone.now()
+    ratings = [Rating(user_id=i, contest=contest, rating=r, volatility=v, last_rated=now, participation_id=p, rank=z)
+               for i, p, r, v, z in zip(user_ids, participation_ids, rating, volatility, ranking)]
+    with transaction.atomic():
+        Rating.objects.bulk_create(ratings)
+
+        Profile.objects.filter(contest_history__contest=contest, contest_history__virtual=0).update(
+            rating=Subquery(Rating.objects.filter(user=OuterRef('id'))
+                            .order_by('-contest__end_time').values('rating')[:1]))
+
+
+def rate_tc(apps, schema_editor):
+    Contest = apps.get_model('judge', 'Contest')
+    Rating = apps.get_model('judge', 'Rating')
+    Profile = apps.get_model('judge', 'Profile')
+
+    # copy of rate_all_view
+    with connection.cursor() as cursor:
+        cursor.execute('TRUNCATE TABLE `%s`' % Rating._meta.db_table)
+    Profile.objects.update(rating=None)
+    for contest in Contest.objects.filter(is_rated=True, end_time__lte=timezone.now()).order_by('end_time'):
+        rate_contest(contest, Rating, Profile)
+
+
+def rate_elo_mmr(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0122_username_display_override'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrations.RunPython.noop, rate_tc, atomic=True),
+        migrations.AddField(
+            model_name='rating',
+            name='mean',
+            field=models.FloatField(verbose_name='raw rating'),
+        ),
+        migrations.AddField(
+            model_name='rating',
+            name='performance',
+            field=models.FloatField(verbose_name='contest performance'),
+        ),
+        migrations.RemoveField(
+            model_name='rating',
+            name='volatility',
+        ),
+        migrations.RunPython(rate_elo_mmr, migrations.RunPython.noop, atomic=True),
+    ]

--- a/judge/migrations/0123_contest_rating_elo_mmr.py
+++ b/judge/migrations/0123_contest_rating_elo_mmr.py
@@ -1,10 +1,10 @@
 import math
+from operator import attrgetter, itemgetter
 
 from django.db import migrations, models
 from django.db.models import Count, OuterRef, Subquery
 from django.db.models.functions import Coalesce
 from django.utils import timezone
-from operator import attrgetter, itemgetter
 
 
 def tie_ranker(iterable, key=attrgetter('points')):

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -549,7 +549,8 @@ class Rating(models.Model):
                                          related_name='rating', on_delete=CASCADE)
     rank = models.IntegerField(verbose_name=_('rank'))
     rating = models.IntegerField(verbose_name=_('rating'))
-    volatility = models.IntegerField(verbose_name=_('volatility'))
+    mean = models.FloatField(verbose_name=_('raw rating'))
+    performance = models.FloatField(verbose_name=_('contest performance'))
     last_rated = models.DateTimeField(db_index=True, verbose_name=_('last rated'))
 
     class Meta:

--- a/judge/models/tests/test_profile.py
+++ b/judge/models/tests/test_profile.py
@@ -115,14 +115,14 @@ class ProfileTestCase(CommonDataMixin, TestCase):
             'rating rate-none abcdef',
         )
         self.assertEqual(
-            Profile.get_user_css_class(display_rank='admin', rating=1200, rating_colors=True),
+            Profile.get_user_css_class(display_rank='admin', rating=1300, rating_colors=True),
             'rating rate-expert admin',
         )
         self.assertEqual(
-            Profile.get_user_css_class(display_rank=1111, rating=1199, rating_colors=True),
+            Profile.get_user_css_class(display_rank=1111, rating=1299, rating_colors=True),
             'rating rate-amateur 1111',
         )
         self.assertEqual(
-            Profile.get_user_css_class(display_rank='random', rating=1199, rating_colors=False),
+            Profile.get_user_css_class(display_rank='random', rating=1299, rating_colors=False),
             'random',
         )

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -96,7 +96,6 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
                 y_tg -= 1. / (TANH_C * delta[j])
             # Otherwise, this is a tie that counts as half a win, as per Elo-MMR.
         new_p[i] = solve(tanh_terms, y_tg, bounds=bounds)
-        historical_p[i] = [new_p[i]] + historical_p[i]
 
     # Fill all indices between i and j, inclusive. Use the fact that new_p is non-increasing.
     def divconq(i, j):
@@ -120,7 +119,7 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
             tanh_terms = []
             w_prev = 1.
             w_sum = 0.
-            for j, h in enumerate(historical_p[i]):
+            for j, h in enumerate([new_p[i]] + historical_p[i]):
                 gamma2 = (VAR_PER_CONTEST if j > 0 else 0)
                 h_var = get_var(times_ranked[i] + 1 - j)
                 k = h_var / (h_var + gamma2)

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -9,13 +9,14 @@ from django.utils import timezone
 
 
 BETA2 = 328.33 ** 2
-VAR_INIT = 350. ** 2 * (BETA2 / 212**2)
-VAR_PER_CONTEST = 1219.047619 * (BETA2 / 212**2)
-VAR_LIM = ((VAR_PER_CONTEST ** 2 + 4 * BETA2 * VAR_PER_CONTEST) ** .5 - VAR_PER_CONTEST) / 2
 MEAN_INIT = 1500.
-SD_INIT = VAR_INIT ** .5
+VAR_INIT = 350**2 * (BETA2 / 212**2)
+SD_INIT = math.sqrt(VAR_INIT)
 VALID_RANGE = MEAN_INIT - 20 * SD_INIT, MEAN_INIT + 20 * SD_INIT
-TANH_C = 3 ** .5 / math.pi
+VAR_PER_CONTEST = 1219.047619 * (BETA2 / 212**2)
+VAR_LIM = (math.sqrt(VAR_PER_CONTEST**2 + 4 * BETA2 * VAR_PER_CONTEST) - VAR_PER_CONTEST) / 2
+SD_LIM = math.sqrt(VAR_LIM)
+TANH_C = math.sqrt(3) / math.pi
 
 
 def eval_tanhs(tanh_terms, x):
@@ -67,7 +68,7 @@ def tie_ranker(iterable, key=attrgetter('points')):
         yield rank + (delta - 1) / 2.0
 
 
-def get_var(times_ranked, cache):
+def get_var(times_ranked, cache=[VAR_INIT]):
     while times_ranked >= len(cache):
         next_var = 1. / (1. / (cache[-1] + VAR_PER_CONTEST) + 1. / BETA2)
         cache.append(next_var)
@@ -76,9 +77,8 @@ def get_var(times_ranked, cache):
 
 def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
     n = len(ranking)
-    cache = [VAR_INIT]
 
-    delta = [(get_var(t, cache) + VAR_PER_CONTEST + BETA2) ** .5 for t in times_ranked]
+    delta = [math.sqrt(get_var(t) + VAR_PER_CONTEST + BETA2) for t in times_ranked]
 
     new_p = [0.] * n
     new_mean = [0.] * n
@@ -122,20 +122,20 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
             w_sum = 0.
             for j, h in enumerate(historical_p[i]):
                 gamma2 = (VAR_PER_CONTEST if j > 0 else 0)
-                h_var = get_var(times_ranked[i] + 1 - j, cache)
+                h_var = get_var(times_ranked[i] + 1 - j)
                 k = h_var / (h_var + gamma2)
                 w = w_prev * k**2
                 # Future optimization: If j is around 20, then w < 1e-3 and it is possible to break early.
-                tanh_terms.append((h, BETA2 ** .5 * TANH_C, w))
+                tanh_terms.append((h, math.sqrt(BETA2) * TANH_C, w))
                 w_prev = w
                 w_sum += w / BETA2
-            w0 = 1. / get_var(times_ranked[i] + 1, cache) - w_sum
+            w0 = 1. / get_var(times_ranked[i] + 1) - w_sum
             p0 = eval_tanhs(tanh_terms[1:], old_mean[i]) / w0 + old_mean[i]
             new_mean[i] = solve(tanh_terms, w0 * p0, lin_factor=w0)
 
     # Display a slightly lower rating to incentivize participation.
     # As times_ranked increases, new_rating converges to new_mean.
-    new_rating = [round(m - (get_var(t + 1, cache) ** .5 - VAR_LIM ** .5)) for m, t in zip(new_mean, times_ranked)]
+    new_rating = [round(m - (math.sqrt(get_var(t + 1)) - SD_LIM)) for m, t in zip(new_mean, times_ranked)]
 
     return new_rating, new_mean, new_p
 

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -34,12 +34,16 @@ def solve(tanh_terms, y_tg, lin_factor=0, bounds=VALID_RANGE):
             L, Ly = x, y
         else:
             return x
+    # Use linear interpolation to be slightly more accurate.
     if Ly is None:
         Ly = lin_factor * L + eval_tanhs(tanh_terms, L)
+    if y_tg <= Ly:
+        return L
     if Ry is None:
         Ry = lin_factor * R + eval_tanhs(tanh_terms, R)
-    # Use linear interpolation to be slightly more accurate.
-    ratio = (y_tg-Ly) / (Ry-Ly) if Ly < y_tg < Ry else 0.5
+    if y_tg >= Ry:
+        return R
+    ratio = (y_tg-Ly) / (Ry-Ly)
     return L*(1-ratio) + R*ratio
 
 

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 
 BETA2 = 328.33 ** 2
+RATING_INIT = 1200      # Newcomer's rating when applying the rating floor/ceiling
 MEAN_INIT = 1500.
 VAR_INIT = 350**2 * (BETA2 / 212**2)
 SD_INIT = sqrt(VAR_INIT)
@@ -145,7 +146,7 @@ def rate_contest(contest):
     rating_sorted = rating_subquery.order_by('-contest__end_time')
     users = contest.users.order_by('is_disqualified', '-score', 'cumtime', 'tiebreaker') \
         .annotate(submissions=Count('submission'),
-                  last_rating=Coalesce(Subquery(rating_sorted.values('rating')[:1]), MEAN_INIT),
+                  last_rating=Coalesce(Subquery(rating_sorted.values('rating')[:1]), RATING_INIT),
                   last_mean=Coalesce(Subquery(rating_sorted.values('mean')[:1]), MEAN_INIT),
                   times=Coalesce(Subquery(rating_subquery.order_by().values('user_id')
                                           .annotate(count=Count('id')).values('count')), 0)) \

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -162,8 +162,7 @@ def rate_contest(contest):
 
 
 RATING_LEVELS = ['Newbie', 'Amateur', 'Expert', 'Candidate Master', 'Master', 'Grandmaster', 'Target']
-# TODO: adjust RATING_VALUES later
-RATING_VALUES = [1000, 1200, 1500, 1800, 2200, 3000]
+RATING_VALUES = [1100, 1400, 1700, 2000, 2400, 3000]
 RATING_CLASS = ['rate-newbie', 'rate-amateur', 'rate-expert', 'rate-candidate-master',
                 'rate-master', 'rate-grandmaster', 'rate-target']
 

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -1,4 +1,4 @@
-import math
+from math import pi, sqrt, tanh
 from bisect import bisect
 from operator import attrgetter, itemgetter
 
@@ -11,16 +11,16 @@ from django.utils import timezone
 BETA2 = 328.33 ** 2
 MEAN_INIT = 1500.
 VAR_INIT = 350**2 * (BETA2 / 212**2)
-SD_INIT = math.sqrt(VAR_INIT)
+SD_INIT = sqrt(VAR_INIT)
 VALID_RANGE = MEAN_INIT - 20 * SD_INIT, MEAN_INIT + 20 * SD_INIT
 VAR_PER_CONTEST = 1219.047619 * (BETA2 / 212**2)
-VAR_LIM = (math.sqrt(VAR_PER_CONTEST**2 + 4 * BETA2 * VAR_PER_CONTEST) - VAR_PER_CONTEST) / 2
-SD_LIM = math.sqrt(VAR_LIM)
-TANH_C = math.sqrt(3) / math.pi
+VAR_LIM = (sqrt(VAR_PER_CONTEST**2 + 4 * BETA2 * VAR_PER_CONTEST) - VAR_PER_CONTEST) / 2
+SD_LIM = sqrt(VAR_LIM)
+TANH_C = sqrt(3) / pi
 
 
 def eval_tanhs(tanh_terms, x):
-    return sum((wt / sd) * math.tanh((x - mu) / (2 * sd)) for mu, sd, wt in tanh_terms)
+    return sum((wt / sd) * tanh((x - mu) / (2 * sd)) for mu, sd, wt in tanh_terms)
 
 
 def solve(tanh_terms, y_tg, lin_factor=0, bounds=VALID_RANGE):
@@ -78,7 +78,7 @@ def get_var(times_ranked, cache=[VAR_INIT]):
 def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
     n = len(ranking)
 
-    delta = [math.sqrt(get_var(t) + VAR_PER_CONTEST + BETA2) for t in times_ranked]
+    delta = [sqrt(get_var(t) + VAR_PER_CONTEST + BETA2) for t in times_ranked]
 
     new_p = [0.] * n
     new_mean = [0.] * n
@@ -126,7 +126,7 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
                 k = h_var / (h_var + gamma2)
                 w = w_prev * k**2
                 # Future optimization: If j is around 20, then w < 1e-3 and it is possible to break early.
-                tanh_terms.append((h, math.sqrt(BETA2) * TANH_C, w))
+                tanh_terms.append((h, sqrt(BETA2) * TANH_C, w))
                 w_prev = w
                 w_sum += w / BETA2
             w0 = 1. / get_var(times_ranked[i] + 1) - w_sum
@@ -135,7 +135,7 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
 
     # Display a slightly lower rating to incentivize participation.
     # As times_ranked increases, new_rating converges to new_mean.
-    new_rating = [round(m - (math.sqrt(get_var(t + 1)) - SD_LIM)) for m, t in zip(new_mean, times_ranked)]
+    new_rating = [round(m - (sqrt(get_var(t + 1)) - SD_LIM)) for m, t in zip(new_mean, times_ranked)]
 
     return new_rating, new_mean, new_p
 

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -8,6 +8,37 @@ from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 
+BETA2 = 102400.
+VAR_INIT = 350. ** 2 * (BETA2 / 212**2)
+VAR_PER_CONTEST = 1219.047619 * (BETA2 / 212**2)
+VAR_LIM = ((VAR_PER_CONTEST**2 + 4*BETA2*VAR_PER_CONTEST) ** .5 - VAR_PER_CONTEST) / 2
+MEAN_INIT = 1500.
+VALID_RANGE = MEAN_INIT - 20*VAR_INIT, MEAN_INIT + 20*VAR_INIT
+TANH_C = 3 ** .5 / math.pi
+
+
+def eval_tanhs(tanh_terms, x):
+    return sum((wt / (TANH_C * sd)) * math.tanh((x - mu) / (2 * TANH_C * sd)) for mu, sd, wt in tanh_terms)
+
+
+def eval_tanhs_grad(tanh_terms, x):
+    return sum(0.5 * wt * (TANH_C * sd * math.cosh((x - mu) / (2 * TANH_C * sd))) ** -2 for mu, sd, wt in tanh_terms)
+
+
+def solve(tanh_terms, y_tg=0, lin_factor=0, bounds=VALID_RANGE):
+    L,R = bounds
+    while R-L > 1e-5*VAR_INIT:
+        x = 0.5 * (L + R)
+        y = lin_factor * x + eval_tanhs(tanh_terms, x)
+        if y > y_tg:
+            R = x
+        elif y < y_tg:
+            L = x
+        else:
+            return x
+    return (L + R) / 2
+
+
 def tie_ranker(iterable, key=attrgetter('points')):
     rank = 0
     delta = 1
@@ -28,94 +59,58 @@ def tie_ranker(iterable, key=attrgetter('points')):
         yield rank + (delta - 1) / 2.0
 
 
-def rational_approximation(t):
-    # Abramowitz and Stegun formula 26.2.23.
-    # The absolute value of the error should be less than 4.5 e-4.
-    c = [2.515517, 0.802853, 0.010328]
-    d = [1.432788, 0.189269, 0.001308]
-    numerator = (c[2] * t + c[1]) * t + c[0]
-    denominator = ((d[2] * t + d[1]) * t + d[0]) * t + 1.0
-    return t - numerator / denominator
+def get_var(times_ranked, cache):
+    while times_ranked >= len(cache):
+        next_var = 1. / (1. / (cache[-1] + VAR_PER_CONTEST) + 1. / BETA2)
+        cache.append(next_var)
+    return cache[times_ranked]
 
 
-def normal_CDF_inverse(p):
-    assert 0.0 < p < 1
+def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
+    n = len(ranking)
+    cache = [VAR_INIT]
 
-    # See article above for explanation of this section.
-    if p < 0.5:
-        # F^-1(p) = - G^-1(p)
-        return -rational_approximation(math.sqrt(-2.0 * math.log(p)))
-    else:
-        # F^-1(p) = G^-1(1-p)
-        return rational_approximation(math.sqrt(-2.0 * math.log(1.0 - p)))
+    delta = [(get_var(t, cache) + VAR_PER_CONTEST + BETA2) ** .5 for t in times_ranked]
 
+    new_p = [0.] * n
+    new_mean = [0.] * n
+    new_rating = [0] * n
 
-def WP(RA, RB, VA, VB):
-    return (math.erf((RB - RA) / math.sqrt(2 * (VA * VA + VB * VB))) + 1) / 2.0
+    # Calculate performances.
+    for i, r in enumerate(ranking):
+        tanh_terms = []
+        y_tg = 0
+        for j, s in enumerate(ranking):
+            tanh_terms.append((old_mean[j], delta[j], 1))
+            if s > r:       # j loses to i
+                y_tg += 1. / (TANH_C * delta[j])
+            elif s < r:     # j beats i
+                y_tg -= 1. / (TANH_C * delta[j])
+            # Otherwise, this is a tie that counts as half a win, as per Elo-MMR.
+        new_p[i] = round(solve(tanh_terms, y_tg))
+        historical_p[i] = [new_p[i]] + historical_p[i]
 
+    # Calculate mean and rating.
+    for i, r in enumerate(ranking):
+        tanh_terms = []
+        w_prev = 1.
+        w_sum = 0.
+        for j, h in enumerate(historical_p[i]):
+            gamma2 = (VAR_PER_CONTEST if j > 0 else 0)
+            h_var = get_var(times_ranked[i]+1-j, cache)
+            k = h_var / (h_var + gamma2)
+            w = w_prev * k**2
+            # Note: If j is around 20, then w < 1e-3 and it is possible to break early.
+            #if w < 1e-3: break
+            tanh_terms.append((h, BETA2 ** .5, w))
+            w_prev = w
+            w_sum += w / BETA2
+        w0 = 1. / get_var(times_ranked[i]+1, cache) - w_sum
+        p0 = eval_tanhs(tanh_terms[1:], old_mean[i]) / w0 + old_mean[i]
+        new_mean[i] = solve(tanh_terms, w0*p0, lin_factor=w0)
+        new_rating[i] = round(new_mean[i] - 2 * (get_var(times_ranked[i]+1, cache)**.5 - VAR_LIM**.5))
 
-def recalculate_ratings(old_rating, old_volatility, actual_rank, times_rated, is_disqualified):
-    # actual_rank: 1 is first place, N is last place
-    # if there are ties, use the average of places (if places 2, 3, 4, 5 tie, use 3.5 for all of them)
-
-    N = len(old_rating)
-    new_rating = old_rating[:]
-    new_volatility = old_volatility[:]
-    if N <= 1:
-        return new_rating, new_volatility
-
-    ranking = list(range(N))
-    ranking.sort(key=old_rating.__getitem__, reverse=True)
-
-    ave_rating = float(sum(old_rating)) / N
-    sum1 = sum(i * i for i in old_volatility) / N
-    sum2 = sum((i - ave_rating) ** 2 for i in old_rating) / (N - 1)
-    CF = math.sqrt(sum1 + sum2)
-
-    for i in range(N):
-        ERank = 0.5
-        for j in range(N):
-            ERank += WP(old_rating[i], old_rating[j], old_volatility[i], old_volatility[j])
-
-        EPerf = -normal_CDF_inverse((ERank - 0.5) / N)
-        APerf = -normal_CDF_inverse((actual_rank[i] - 0.5) / N)
-        PerfAs = old_rating[i] + CF * (APerf - EPerf)
-        Weight = 1.0 / (1 - (0.42 / (times_rated[i] + 1) + 0.18)) - 1.0
-        if old_rating[i] > 2500:
-            Weight *= 0.8
-        elif old_rating[i] >= 2000:
-            Weight *= 0.9
-
-        Cap = 150.0 + 1500.0 / (times_rated[i] + 2)
-
-        new_rating[i] = (old_rating[i] + Weight * PerfAs) / (1.0 + Weight)
-
-        if abs(old_rating[i] - new_rating[i]) > Cap:
-            if old_rating[i] < new_rating[i]:
-                new_rating[i] = old_rating[i] + Cap
-            else:
-                new_rating[i] = old_rating[i] - Cap
-
-        if times_rated[i] == 0:
-            new_volatility[i] = 385
-        else:
-            new_volatility[i] = math.sqrt(((new_rating[i] - old_rating[i]) ** 2) / Weight +
-                                          (old_volatility[i] ** 2) / (Weight + 1))
-
-        if is_disqualified[i]:
-            # DQed users can manipulate TopCoder ratings to get higher volatility in order to increase their rating
-            # later on, prohibit this by ensuring their volatility never increases in this situation
-            new_volatility[i] = min(new_volatility[i], old_volatility[i])
-
-    # try to keep the sum of ratings constant
-    adjust = float(sum(old_rating) - sum(new_rating)) / N
-    new_rating = list(map(adjust.__add__, new_rating))
-    # inflate a little if we have to so people who placed first don't lose rating
-    best_rank = min(actual_rank)
-    for i in range(N):
-        if abs(actual_rank[i] - best_rank) <= 1e-3 and new_rating[i] < old_rating[i] + 1:
-            new_rating[i] = old_rating[i] + 1
-    return list(map(int, map(round, new_rating))), list(map(int, map(round, new_volatility)))
+    return new_rating, new_mean, new_p
 
 
 def rate_contest(contest):
@@ -125,13 +120,11 @@ def rate_contest(contest):
     rating_sorted = rating_subquery.order_by('-contest__end_time')
     users = contest.users.order_by('is_disqualified', '-score', 'cumtime', 'tiebreaker') \
         .annotate(submissions=Count('submission'),
-                  last_rating=Coalesce(Subquery(rating_sorted.values('rating')[:1]), 1200),
-                  volatility=Coalesce(Subquery(rating_sorted.values('volatility')[:1]), 535),
+                  last_mean=Coalesce(Subquery(rating_sorted.values('mean')[:1]), MEAN_INIT),
                   times=Coalesce(Subquery(rating_subquery.order_by().values('user_id')
                                           .annotate(count=Count('id')).values('count')), 0)) \
         .exclude(user_id__in=contest.rate_exclude.all()) \
-        .filter(virtual=0).values('id', 'user_id', 'score', 'cumtime', 'tiebreaker', 'is_disqualified',
-                                  'last_rating', 'volatility', 'times')
+        .filter(virtual=0).values('id', 'user_id', 'score', 'cumtime', 'tiebreaker', 'last_mean', 'times')
     if not contest.rate_all:
         users = users.filter(submissions__gt=0)
     if contest.rating_floor is not None:
@@ -142,16 +135,24 @@ def rate_contest(contest):
     users = list(users)
     participation_ids = list(map(itemgetter('id'), users))
     user_ids = list(map(itemgetter('user_id'), users))
-    is_disqualified = list(map(itemgetter('is_disqualified'), users))
     ranking = list(tie_ranker(users, key=itemgetter('score', 'cumtime', 'tiebreaker')))
-    old_rating = list(map(itemgetter('last_rating'), users))
-    old_volatility = list(map(itemgetter('volatility'), users))
+    old_mean = list(map(itemgetter('last_mean'), users))
     times_ranked = list(map(itemgetter('times'), users))
-    rating, volatility = recalculate_ratings(old_rating, old_volatility, ranking, times_ranked, is_disqualified)
+    historical_p = [[] for _ in users]
+
+    user_id_to_idx = {uid: i for i, uid in enumerate(user_ids)}
+    for h in Rating.objects.filter(user_id__in=user_ids) \
+            .order_by('-contest__end_time') \
+            .values('user_id', 'performance'):
+        idx = user_id_to_idx[h['user_id']]
+        historical_p[idx].append(h['performance'])
+
+    rating, mean, performance = recalculate_ratings(ranking, old_mean, times_ranked, historical_p)
 
     now = timezone.now()
-    ratings = [Rating(user_id=i, contest=contest, rating=r, volatility=v, last_rated=now, participation_id=p, rank=z)
-               for i, p, r, v, z in zip(user_ids, participation_ids, rating, volatility, ranking)]
+    ratings = [Rating(user_id=i, contest=contest, rating=r, mean=m, performance=perf,
+                      last_rated=now, participation_id=pid, rank=z)
+               for i, pid, r, m, perf, z in zip(user_ids, participation_ids, rating, mean, performance, ranking)]
     with transaction.atomic():
         Rating.objects.bulk_create(ratings)
 
@@ -161,6 +162,7 @@ def rate_contest(contest):
 
 
 RATING_LEVELS = ['Newbie', 'Amateur', 'Expert', 'Candidate Master', 'Master', 'Grandmaster', 'Target']
+# TODO: adjust RATING_VALUES later
 RATING_VALUES = [1000, 1200, 1500, 1800, 2200, 3000]
 RATING_CLASS = ['rate-newbie', 'rate-amateur', 'rate-expert', 'rate-candidate-master',
                 'rate-master', 'rate-grandmaster', 'rate-target']

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -87,7 +87,7 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
             elif s < r:     # j beats i
                 y_tg -= 1. / (TANH_C * delta[j])
             # Otherwise, this is a tie that counts as half a win, as per Elo-MMR.
-        new_p[i] = round(solve(tanh_terms, y_tg))
+        new_p[i] = solve(tanh_terms, y_tg)
         historical_p[i] = [new_p[i]] + historical_p[i]
 
     # Calculate mean and rating.

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -19,7 +19,7 @@ TANH_C = 3 ** .5 / math.pi
 
 
 def eval_tanhs(tanh_terms, x):
-    return sum((wt / (TANH_C * sd)) * math.tanh((x - mu) / (2 * TANH_C * sd)) for mu, sd, wt in tanh_terms)
+    return sum((wt / sd) * math.tanh((x - mu) / (2 * sd)) for mu, sd, wt in tanh_terms)
 
 
 def solve(tanh_terms, y_tg, lin_factor=0, bounds=VALID_RANGE):
@@ -85,7 +85,7 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
         tanh_terms = []
         y_tg = 0
         for j, s in enumerate(ranking):
-            tanh_terms.append((old_mean[j], delta[j], 1))
+            tanh_terms.append((old_mean[j], delta[j] * TANH_C, 1))
             if s > r:       # j loses to i
                 y_tg += 1. / (TANH_C * delta[j])
             elif s < r:     # j beats i
@@ -123,7 +123,7 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
                 w = w_prev * k**2
                 # Note: If j is around 20, then w < 1e-3 and it is possible to break early.
                 #if w < 1e-3: break
-                tanh_terms.append((h, BETA2 ** .5, w))
+                tanh_terms.append((h, BETA2 ** .5 * TANH_C, w))
                 w_prev = w
                 w_sum += w / BETA2
             w0 = 1. / get_var(times_ranked[i]+1, cache) - w_sum

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -8,7 +8,7 @@ from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 
-BETA2 = 102400.
+BETA2 = 320. ** 2
 VAR_INIT = 350. ** 2 * (BETA2 / 212**2)
 VAR_PER_CONTEST = 1219.047619 * (BETA2 / 212**2)
 VAR_LIM = ((VAR_PER_CONTEST**2 + 4*BETA2*VAR_PER_CONTEST) ** .5 - VAR_PER_CONTEST) / 2
@@ -108,7 +108,10 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
         w0 = 1. / get_var(times_ranked[i]+1, cache) - w_sum
         p0 = eval_tanhs(tanh_terms[1:], old_mean[i]) / w0 + old_mean[i]
         new_mean[i] = solve(tanh_terms, w0*p0, lin_factor=w0)
-        new_rating[i] = round(new_mean[i] - 2 * (get_var(times_ranked[i]+1, cache)**.5 - VAR_LIM**.5))
+
+        # Display a slightly lower rating to incentivize participation.
+        # As times_ranked increases, new_rating converges to new_mean.
+        new_rating[i] = round(new_mean[i] - (get_var(times_ranked[i]+1, cache)**.5 - VAR_LIM**.5))
 
     return new_rating, new_mean, new_p
 

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -1,5 +1,5 @@
-from math import pi, sqrt, tanh
 from bisect import bisect
+from math import pi, sqrt, tanh
 from operator import attrgetter, itemgetter
 
 from django.db import transaction

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -186,7 +186,7 @@ def rate_contest(contest):
 
 
 RATING_LEVELS = ['Newbie', 'Amateur', 'Expert', 'Candidate Master', 'Master', 'Grandmaster', 'Target']
-RATING_VALUES = [1100, 1400, 1700, 2000, 2400, 3000]
+RATING_VALUES = [1000, 1300, 1600, 1900, 2400, 3000]
 RATING_CLASS = ['rate-newbie', 'rate-amateur', 'rate-expert', 'rate-candidate-master',
                 'rate-master', 'rate-grandmaster', 'rate-target']
 

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -23,17 +23,24 @@ def eval_tanhs(tanh_terms, x):
 
 
 def solve(tanh_terms, y_tg, lin_factor=0, bounds=VALID_RANGE):
-    L,R = bounds
-    while R-L > 1e-5*SD_INIT:
+    L, R = bounds
+    Ly, Ry = None, None
+    while R-L > 2:
         x = (L+R) / 2
         y = lin_factor * x + eval_tanhs(tanh_terms, x)
         if y > y_tg:
-            R = x
+            R, Ry = x, y
         elif y < y_tg:
-            L = x
+            L, Ly = x, y
         else:
             return x
-    return (L+R) / 2
+    if Ly is None:
+        Ly = lin_factor * L + eval_tanhs(tanh_terms, L)
+    if Ry is None:
+        Ry = lin_factor * R + eval_tanhs(tanh_terms, R)
+    # Use linear interpolation to be slightly more accurate.
+    ratio = (y_tg-Ly) / (Ry-Ly) if Ly < y_tg < Ry else 0.5
+    return L*(1-ratio) + R*ratio
 
 
 def tie_ranker(iterable, key=attrgetter('points')):

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -122,16 +122,16 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
             w_sum = 0.
             for j, h in enumerate(historical_p[i]):
                 gamma2 = (VAR_PER_CONTEST if j > 0 else 0)
-                h_var = get_var(times_ranked[i]+1-j, cache)
+                h_var = get_var(times_ranked[i] + 1 - j, cache)
                 k = h_var / (h_var + gamma2)
                 w = w_prev * k**2
                 # Future optimization: If j is around 20, then w < 1e-3 and it is possible to break early.
                 tanh_terms.append((h, BETA2 ** .5 * TANH_C, w))
                 w_prev = w
                 w_sum += w / BETA2
-            w0 = 1. / get_var(times_ranked[i]+1, cache) - w_sum
+            w0 = 1. / get_var(times_ranked[i] + 1, cache) - w_sum
             p0 = eval_tanhs(tanh_terms[1:], old_mean[i]) / w0 + old_mean[i]
-            new_mean[i] = solve(tanh_terms, w0*p0, lin_factor=w0)
+            new_mean[i] = solve(tanh_terms, w0 * p0, lin_factor=w0)
 
     # Display a slightly lower rating to incentivize participation.
     # As times_ranked increases, new_rating converges to new_mean.

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -11,10 +11,10 @@ from django.utils import timezone
 BETA2 = 328.33 ** 2
 VAR_INIT = 350. ** 2 * (BETA2 / 212**2)
 VAR_PER_CONTEST = 1219.047619 * (BETA2 / 212**2)
-VAR_LIM = ((VAR_PER_CONTEST**2 + 4*BETA2*VAR_PER_CONTEST) ** .5 - VAR_PER_CONTEST) / 2
+VAR_LIM = ((VAR_PER_CONTEST ** 2 + 4 * BETA2 * VAR_PER_CONTEST) ** .5 - VAR_PER_CONTEST) / 2
 MEAN_INIT = 1500.
 SD_INIT = VAR_INIT ** .5
-VALID_RANGE = MEAN_INIT - 20*SD_INIT, MEAN_INIT + 20*SD_INIT
+VALID_RANGE = MEAN_INIT - 20 * SD_INIT, MEAN_INIT + 20 * SD_INIT
 TANH_C = 3 ** .5 / math.pi
 
 
@@ -25,8 +25,8 @@ def eval_tanhs(tanh_terms, x):
 def solve(tanh_terms, y_tg, lin_factor=0, bounds=VALID_RANGE):
     L, R = bounds
     Ly, Ry = None, None
-    while R-L > 2:
-        x = (L+R) / 2
+    while R - L > 2:
+        x = (L + R) / 2
         y = lin_factor * x + eval_tanhs(tanh_terms, x)
         if y > y_tg:
             R, Ry = x, y
@@ -43,8 +43,8 @@ def solve(tanh_terms, y_tg, lin_factor=0, bounds=VALID_RANGE):
         Ry = lin_factor * R + eval_tanhs(tanh_terms, R)
     if y_tg >= Ry:
         return R
-    ratio = (y_tg-Ly) / (Ry-Ly)
-    return L*(1-ratio) + R*ratio
+    ratio = (y_tg - Ly) / (Ry - Ly)
+    return L * (1 - ratio) + R * ratio
 
 
 def tie_ranker(iterable, key=attrgetter('points')):
@@ -100,8 +100,8 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
 
     # Fill all indices between i and j, inclusive. Use the fact that new_p is non-increasing.
     def divconq(i, j):
-        if j-i > 1:
-            k = (i+j) // 2
+        if j - i > 1:
+            k = (i + j) // 2
             solve_idx(k, bounds=(new_p[j], new_p[i]))
             divconq(i, k)
             divconq(k, j)
@@ -112,8 +112,8 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
     else:
         # Calculate performance.
         solve_idx(0)
-        solve_idx(n-1)
-        divconq(0, n-1)
+        solve_idx(n - 1)
+        divconq(0, n - 1)
 
         # Calculate mean.
         for i, r in enumerate(ranking):
@@ -125,8 +125,7 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
                 h_var = get_var(times_ranked[i]+1-j, cache)
                 k = h_var / (h_var + gamma2)
                 w = w_prev * k**2
-                # Note: If j is around 20, then w < 1e-3 and it is possible to break early.
-                #if w < 1e-3: break
+                # Future optimization: If j is around 20, then w < 1e-3 and it is possible to break early.
                 tanh_terms.append((h, BETA2 ** .5 * TANH_C, w))
                 w_prev = w
                 w_sum += w / BETA2
@@ -136,7 +135,7 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
 
     # Display a slightly lower rating to incentivize participation.
     # As times_ranked increases, new_rating converges to new_mean.
-    new_rating = [round(m - (get_var(t+1, cache)**.5 - VAR_LIM**.5)) for m, t in zip(new_mean, times_ranked)]
+    new_rating = [round(m - (get_var(t + 1, cache) ** .5 - VAR_LIM ** .5)) for m, t in zip(new_mean, times_ranked)]
 
     return new_rating, new_mean, new_p
 

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -134,7 +134,7 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p):
 
     # Display a slightly lower rating to incentivize participation.
     # As times_ranked increases, new_rating converges to new_mean.
-    new_rating = [round(m - (sqrt(get_var(t + 1)) - SD_LIM)) for m, t in zip(new_mean, times_ranked)]
+    new_rating = [max(1, round(m - (sqrt(get_var(t + 1)) - SD_LIM))) for m, t in zip(new_mean, times_ranked)]
 
     return new_rating, new_mean, new_p
 

--- a/judge/views/api/api_v1.py
+++ b/judge/views/api/api_v1.py
@@ -151,16 +151,15 @@ def api_v1_user_info(request, user):
     participations = ContestParticipation.objects.filter(user=profile, virtual=0, contest__is_visible=True,
                                                          contest__is_private=False,
                                                          contest__is_organization_private=False)
-    for contest_key, rating, volatility in participations.values_list('contest__key', 'rating__rating',
-                                                                      'rating__volatility'):
+    for contest_key, rating, performance in participations.values_list('contest__key', 'rating__rating',
+                                                                       'rating__performance'):
         contest_history[contest_key] = {
             'rating': rating,
-            'volatility': volatility,
+            'performance': round(performance),
         }
 
     resp['contests'] = {
         'current_rating': last_rating.rating if last_rating else None,
-        'volatility': last_rating.volatility if last_rating else None,
         'history': contest_history,
     }
 

--- a/judge/views/api/api_v1.py
+++ b/judge/views/api/api_v1.py
@@ -151,11 +151,13 @@ def api_v1_user_info(request, user):
     participations = ContestParticipation.objects.filter(user=profile, virtual=0, contest__is_visible=True,
                                                          contest__is_private=False,
                                                          contest__is_organization_private=False)
-    for contest_key, rating, performance in participations.values_list('contest__key', 'rating__rating',
-                                                                       'rating__performance'):
+    for contest_key, rating, mean, performance in participations.values_list(
+        'contest__key', 'rating__rating', 'rating__mean', 'rating__performance'
+    ):
         contest_history[contest_key] = {
             'rating': rating,
-            'performance': round(performance),
+            'raw_rating': mean,
+            'performance': performance,
         }
 
     resp['contests'] = {

--- a/judge/views/api/api_v1.py
+++ b/judge/views/api/api_v1.py
@@ -152,7 +152,7 @@ def api_v1_user_info(request, user):
                                                          contest__is_private=False,
                                                          contest__is_organization_private=False)
     for contest_key, rating, mean, performance in participations.values_list(
-        'contest__key', 'rating__rating', 'rating__mean', 'rating__performance'
+        'contest__key', 'rating__rating', 'rating__mean', 'rating__performance',
     ):
         contest_history[contest_key] = {
             'rating': rating,

--- a/judge/views/api/api_v2.py
+++ b/judge/views/api/api_v2.py
@@ -536,15 +536,16 @@ class APIUserDetail(APIDetailView):
             )
             .order_by('contest__end_time')
         )
-        for contest_key, score, cumtime, rating, performance in participations.values_list(
-            'contest__key', 'score', 'cumtime', 'rating__rating', 'rating__performance',
+        for contest_key, score, cumtime, rating, mean, performance in participations.values_list(
+            'contest__key', 'score', 'cumtime', 'rating__rating', 'rating__mean', 'rating__performance',
         ):
             contest_history.append({
                 'key': contest_key,
                 'score': score,
                 'cumulative_time': cumtime,
                 'rating': rating,
-                'performance': round(performance),
+                'raw_rating': mean,
+                'performance': performance,
             })
 
         return {

--- a/judge/views/api/api_v2.py
+++ b/judge/views/api/api_v2.py
@@ -488,7 +488,6 @@ class APIUserList(APIListView):
             .annotate(
                 username=F('user__username'),
                 latest_rating=Subquery(latest_rating_subquery.values('rating')[:1]),
-                latest_volatility=Subquery(latest_rating_subquery.values('volatility')[:1]),
             )
             .order_by('id')
             .only('id', 'points', 'performance_points', 'problem_count', 'display_rank')
@@ -503,7 +502,6 @@ class APIUserList(APIListView):
             'problem_count': profile.problem_count,
             'rank': profile.display_rank,
             'rating': profile.latest_rating,
-            'volatility': profile.latest_volatility,
         }
 
 
@@ -538,15 +536,15 @@ class APIUserDetail(APIDetailView):
             )
             .order_by('contest__end_time')
         )
-        for contest_key, score, cumtime, rating, volatility in participations.values_list(
-            'contest__key', 'score', 'cumtime', 'rating__rating', 'rating__volatility',
+        for contest_key, score, cumtime, rating, performance in participations.values_list(
+            'contest__key', 'score', 'cumtime', 'rating__rating', 'rating__performance',
         ):
             contest_history.append({
                 'key': contest_key,
                 'score': score,
                 'cumulative_time': cumtime,
                 'rating': rating,
-                'volatility': volatility,
+                'performance': round(performance),
             })
 
         return {
@@ -558,7 +556,6 @@ class APIUserDetail(APIDetailView):
             'solved_problems': solved_problems,
             'rank': profile.display_rank,
             'rating': last_rating.rating if last_rating is not None else None,
-            'volatility': last_rating.volatility if last_rating is not None else None,
             'organizations': list(profile.organizations.values_list('id', flat=True)),
             'contests': contest_history,
         }

--- a/templates/user/user-about.html
+++ b/templates/user/user-about.html
@@ -402,26 +402,26 @@
                             },
                             {
                                 begin: 1000,
-                                end: 1200,
+                                end: 1300,
                                 color: 'rgb(0, 169, 0, 0.4)'
                             },
                             {
-                                begin: 1200,
-                                end: 1500,
+                                begin: 1300,
+                                end: 1600,
                                 color: 'rgb(0, 0, 255, 0.4)'
                             },
                             {
-                                begin: 1500,
-                                end: 1800,
+                                begin: 1600,
+                                end: 1900,
                                 color: 'rgb(128, 0, 128, 0.37)'
                             },
                             {
-                                begin: 1800,
-                                end: 2200,
+                                begin: 1900,
+                                end: 2400,
                                 color: 'rgb(255, 177, 0, 0.4)'
                             },
                             {
-                                begin: 2200,
+                                begin: 2400,
                                 end: 3000,
                                 color: 'rgb(238, 0, 0, 0.4)'
                             },

--- a/templates/user/user-base.html
+++ b/templates/user/user-base.html
@@ -74,7 +74,6 @@
                     <div><b class="semibold">{{ _('Rank by rating:') }}</b> #{{ rating_rank }}</div>
                 {% endif %}
                 <div><b class="semibold">{{ _('Rating:') }}</b> {{ rating_number(rating) }}</div>
-                <div><b class="semibold">{{ _('Volatility:') }}</b> {{ rating.volatility }}</div>
                 <div><b class="semibold">{{ _('Min. rating:') }}</b> {{ rating_number(min_rating) }}</div>
                 <div><b class="semibold">{{ _('Max rating:') }}</b> {{ rating_number(max_rating) }}</div>
             {% endif %}


### PR DESCRIPTION
[Elo-MMR](https://arxiv.org/abs/2101.00400) is a rating system that has more desirable properties than Topcoder's rating system. For example, Elo-MMR converges faster, prevents users from [farming volatility](https://codeforces.com/blog/entry/87848), and has a more reasonable performance calculation.

Change in the rating curve (ratings rounded to the nearest 100x+50): ![ratingcurve](https://user-images.githubusercontent.com/14223529/129460372-50a46bc4-acb0-4140-8b16-73b6d0ef2d35.PNG)

Change in each user's rating (i.e. users can expect their rating to increase by +100): 
![ratingdelta](https://user-images.githubusercontent.com/14223529/129460462-0f44a46f-34d7-4a03-9209-7c8a1c05a385.PNG)

Due to the expected +100 rating increase, I modified the rating cutoffs:
- Old: `RATING_VALUES = [1000, 1200, 1500, 1800, 2200, 3000]`
- New: `RATING_VALUES = [1000, 1300, 1600, 1900, 2400, 3000]`

Change in performance (on my virtual machine):
- It takes 8 seconds to rate all 111 contests using Topcoder.
- It takes **12** seconds to rate all 111 contests using Elo-MMR. The biggest bottlenecks are `recalculate_ratings()` (**4.5** seconds), and the query for `historical_p` (**1.5** seconds).