### PR TITLE
For DQ'ed contest participations, set cumtime to zero unconditionally.

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -379,7 +379,8 @@ class ContestParticipation(models.Model):
             self.contest.format.update_participation(self)
             if self.is_disqualified:
                 self.score = -9999
-                self.save(update_fields=['score'])
+                self.cumtime = 0
+                self.save(update_fields=['score', 'cumtime'])
     recompute_results.alters_data = True
 
     def set_disqualified(self, disqualified):


### PR DESCRIPTION
Disqualified participations preserve the old `cumtime` value which results in not all disqualified participations sharing the same rank. Having all of these be equal should force disqualified participations to share the same rank, which is a more intuitive ranking.