### PR TITLE
For DQ'ed contest participations, set tiebreaker to zero unconditionally.

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -433,7 +433,8 @@ class ContestParticipation(models.Model):
             if self.is_disqualified:
                 self.score = -9999
                 self.cumtime = 0
-                self.save(update_fields=['score', 'cumtime'])
+                self.tiebreaker = 0
+                self.save(update_fields=['score', 'cumtime', 'tiebreaker'])
     recompute_results.alters_data = True
 
     def set_disqualified(self, disqualified):


### PR DESCRIPTION
Disqualified participations preserve the old `tiebreaker` value which results in not all disqualified participations sharing the same rank. Having all of these be equal should force disqualified participations to share the same rank, which is a more intuitive ranking.