### PR TITLE
Fix `li` tag in contest short form display

### DIFF
--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -148,7 +148,7 @@
                                 {% endif %}
                             </li>
                         </ul>
-                    <li>
+                    </li>
                     <li>
                         {{ _('The contest format is **%(format)s**.', format=contest.format.name)|markdown('default') }}
                         <ul>


### PR DESCRIPTION
When it renders correctly with the CSS and it was only caught in prod because the CSS wasn't rebuilt...

(Maybe we should include some kind of HTML + Jinja linter in the build)