### PR TITLE
Use CSPRNG for judge keys

### DIFF
--- a/judge/admin/runtime.py
+++ b/judge/admin/runtime.py
@@ -54,12 +54,9 @@ class GenerateKeyTextInput(TextInput):
 <script type="text/javascript">
 django.jQuery(document).ready(function ($) {{
     $('#id_{0}_regen').click(function () {{
-        var length = 100,
-            charset = "abcdefghijklnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`~!@#$%^&*()_+-=|[]{{}};:,<>./?",
-            key = "";
-        for (var i = 0, n = charset.length; i < length; ++i) {{
-            key += charset.charAt(Math.floor(Math.random() * n));
-        }}
+        var rand = new Uint8Array(75);
+        window.crypto.getRandomValues(rand);
+        var key = btoa(String.fromCharCode.apply(null, rand));
         $('#id_{0}').val(key);
     }});
 }});


### PR DESCRIPTION
Fixes https://github.com/DMOJ/online-judge/issues/1175. Makes https://github.com/DMOJ/online-judge/pull/1176 redundant.

This code was borrowed from [Google](https://cloud.google.com/network-connectivity/docs/vpn/how-to/generating-pre-shared-key#javascript). In this case, 75 random bytes are encoded to 100 base64 characters.