### PR TITLE
Implement hardcore 2FA mode

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -36,6 +36,8 @@ SITE_LONG_NAME = 'DMOJ: Modern Online Judge'
 SITE_ADMIN_EMAIL = False
 
 DMOJ_REQUIRE_STAFF_2FA = True
+# Display warnings that admins will not perform 2FA recovery.
+DMOJ_2FA_HARDCORE = False
 
 # Set to 1 to use HTTPS if request was made to https://
 # Set to 2 to always use HTTPS for links

--- a/judge/views/two_factor.py
+++ b/judge/views/two_factor.py
@@ -78,6 +78,7 @@ class TOTPEnableView(TOTPView):
         context['scratch_codes'] = [] if self.is_refresh else json.loads(self.profile.scratch_codes)
         context['qr_code'] = self.render_qr_code(self.request.user.username, context['totp_key'])
         context['is_refresh'] = self.is_refresh
+        context['is_hardcore'] = settings.DMOJ_2FA_HARDCORE
         return context
 
     def form_valid(self, form):
@@ -251,3 +252,8 @@ class TwoFactorLoginView(SuccessURLAllowedHostsMixin, TOTPView):
     def form_valid(self, form):
         self.request.session['2fa_passed'] = True
         return self.next_page()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['is_hardcore'] = settings.DMOJ_2FA_HARDCORE
+        return context

--- a/templates/registration/totp_enable.html
+++ b/templates/registration/totp_enable.html
@@ -103,6 +103,16 @@
                         {{ _('These codes will never be shown again after you enable two-factor authentication.') }}</label>
                     <pre><code><span class="fullwidth">{{ scratch_codes|join('\n') }}</span></code></pre>
                 </div>
+                {% if is_hardcore %}
+                    <div class="alert alert-danger">
+                        <b>{{ _('Important') }}</b>:
+                        {% trans trimmed site_name=SITE_NAME %}
+                            If you lose your authentication device and are unable to use your scratch codes,
+                            {{ site_name }} admins will NOT be able to recover your account.
+                            Please keep your scratch codes safe!
+                        {% endtrans %}
+                    </div>
+                {% endif %}
             {% endif %}
         </form>
     </div>

--- a/templates/registration/two_factor_auth.html
+++ b/templates/registration/two_factor_auth.html
@@ -94,6 +94,8 @@
                 <button style="float:right;" type="submit">{{ _('Use scratch code') }}</button>
             {% endif %}
         </form>
-        <p class="totp-or-scratch-code-panel-message">{{ _('If you lost your authentication device and are unable to use your scratch codes, please contact us at %(email)s.', email=SITE_ADMIN_EMAIL)|urlize }}</p>
+        {% if not is_hardcore %}
+            <p class="totp-or-scratch-code-panel-message">{{ _('If you lost your authentication device and are unable to use your scratch codes, please contact us at %(email)s.', email=SITE_ADMIN_EMAIL)|urlize }}</p>
+        {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
Example UI:

![2FA enable](https://user-images.githubusercontent.com/461885/132108938-b590f41e-1f6b-4689-bfca-bcfe0ca91f4d.png)

Also, the message on the 2FA page prompting to contact admins when losing both scratch codes and second factor is removed in this mode.

Fixes #1761.