### PR TITLE
Fix join/spectate button in contest listing

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -87,6 +87,7 @@ class ContestList(QueryStringSortMixin, DiggPaginatorMixin, TitleMixin, ContestL
     def get_context_data(self, **kwargs):
         context = super(ContestList, self).get_context_data(**kwargs)
         present, active, future = [], [], []
+        finished = set()
         for contest in self._get_queryset().exclude(end_time__lt=self._now):
             if contest.start_time > self._now:
                 future.append(contest)
@@ -99,7 +100,9 @@ class ContestList(QueryStringSortMixin, DiggPaginatorMixin, TitleMixin, ContestL
                     .select_related('contest') \
                     .prefetch_related('contest__authors', 'contest__curators', 'contest__testers') \
                     .annotate(key=F('contest__key')):
-                if not participation.ended:
+                if participation.ended:
+                    finished.add(participation.contest.key)
+                else:
                     active.append(participation)
                     present.remove(participation.contest)
 
@@ -109,6 +112,7 @@ class ContestList(QueryStringSortMixin, DiggPaginatorMixin, TitleMixin, ContestL
         context['active_participations'] = active
         context['current_contests'] = present
         context['future_contests'] = future
+        context['finished_contests'] = finished
         context['now'] = self._now
         context['first_page_href'] = '.'
         context['page_suffix'] = '#past-contests'

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -124,7 +124,7 @@
 {% macro contest_join(contest, request) %}
     {% if not request.in_contest %}
         <td>
-            {% if request.profile in contest.authors.all() or request.profile in contest.curators.all() or request.profile in contest.testers.all() %}
+            {% if request.profile in contest.authors.all() or request.profile in contest.curators.all() or request.profile in contest.testers.all() or contest.has_completed_contest(request.user) %}
                 <form action="{{ url('contest_join', contest.key) }}" method="post">
                     {% csrf_token %}
                     <input type="submit" class="unselectable button full participate-button"

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -121,10 +121,10 @@
     {% endif %}
 {% endmacro %}
 
-{% macro contest_join(contest, request) %}
+{% macro contest_join(contest, request, finished_contests) %}
     {% if not request.in_contest %}
         <td>
-            {% if request.profile in contest.authors.all() or request.profile in contest.curators.all() or request.profile in contest.testers.all() or contest.has_completed_contest(request.user) %}
+            {% if contest.key in finished_contests or request.profile in contest.authors.all() or request.profile in contest.curators.all() or request.profile in contest.testers.all() %}
                 <form action="{{ url('contest_join', contest.key) }}" method="post">
                     {% csrf_token %}
                     <input type="submit" class="unselectable button full participate-button"
@@ -176,7 +176,7 @@
                             <td>
                                 {{ user_count(contest, request.user) }}
                             </td>
-                            {{ contest_join(contest, request) }}
+                            {{ contest_join(contest, request, finished_contests) }}
                         </tr>
                     {% endwith %}
                 {% endfor %}
@@ -215,7 +215,7 @@
                         <td>
                             {{ user_count(contest, request.user) }}
                         </td>
-                        {{ contest_join(contest, request) }}
+                        {{ contest_join(contest, request, finished_contests) }}
                     </tr>
                 {% endfor %}
                 </tbody>


### PR DESCRIPTION
Fixes #544.

Fix the contest listing button for normal users (i.e. user not involved in making the contest). The behaviour is now:

- Didn't start contest: `Join`
- In contest: (column is omitted)
- In contest and left, but the timer didn't count to 0 yet: `Join`
- Timer counted to 0: `Spectate`
- While spectating: (column is omitted)
- Done spectating: `Spectate`