### PR TITLE
Fix ticket message styling, add relative dates and admin button

### DIFF
--- a/templates/ticket/message.html
+++ b/templates/ticket/message.html
@@ -7,9 +7,13 @@
     </div>
     <div class="detail">
         <div class="header">
-            <div class="relative-time"></div>
-            <div class="message-date">{{ message.time|date('DATE_FORMAT') }}</div>
-            <div class="message-time">{{ message.time|time('TIME_FORMAT') }}</div>
+            <span class="time">{{ relative_time(message.time, abs=_('messaged on {time}'), rel=_('messaged {time}')) }}</span>
+            <span class="operation">
+                {% if perms.judge.change_ticket and perms.judge.change_ticketmessage %}
+                    <a href="{{ url('admin:judge_ticket_change', ticket.id) }}"
+                       title="{{ _('Admin') }}"><i class="fa fa-cog fa-fw"></i></a>
+                {% endif %}
+            </span>
         </div>
         <div class="content content-description">
             {{ message.body|markdown('ticket', MATH_ENGINE)|reference|str|safe }}

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -51,6 +51,10 @@
             border-radius: 5px;
         }
 
+        .info-box .fa {
+            color: #777;
+        }
+
         .info-title {
             padding: 2px 5px;
             font-weight: 600;
@@ -123,10 +127,6 @@
             margin: 0 auto;
         }
 
-        .message .message-date, .message .message-time {
-            display: inline-block;
-        }
-
         .message .detail {
             border: 1px #999 solid;
             border-radius: 5px;
@@ -139,8 +139,19 @@
             color: #777;
             border-bottom: 1px solid #999;
             border-radius: 5px 5px 0 0;
-            padding: 2px 7px;
+            padding: 2px 5px;
             text-align: right;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+        }
+
+        .message .operation {
+            flex: auto;
+        }
+
+        .message .operation .fa {
+            color: #777;
         }
 
         .message .content {


### PR DESCRIPTION
This will pave the way for #1606. It also makes the ticket message header a bit more consistent with the comment header.

Before:
![image](https://user-images.githubusercontent.com/29607503/135699747-df412b09-9df7-4e75-96c4-89cff5de3305.png)

After:
![image](https://user-images.githubusercontent.com/29607503/135699727-41ea86fe-46a8-4e8d-ad72-c9851116fa47.png)
