### PR TITLE
Replace force_text with force_str

### DIFF
--- a/django_2_2_pymysql_patch.py
+++ b/django_2_2_pymysql_patch.py
@@ -1,5 +1,5 @@
 import django
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 if (2, 2) <= django.VERSION < (3,):
     # Django 2.2.x is incompatible with PyMySQL.
@@ -12,6 +12,6 @@ if (2, 2) <= django.VERSION < (3,):
         # attribute where the exact query sent to the database is saved.
         # See MySQLdb/cursors.py in the source distribution.
         # MySQLdb returns string, PyMySQL bytes.
-        return force_text(getattr(cursor, '_executed', None), errors='replace')
+        return force_str(getattr(cursor, '_executed', None), errors='replace')
 
     DatabaseOperations.last_executed_query = last_executed_query

--- a/judge/widgets/pagedown.py
+++ b/judge/widgets/pagedown.py
@@ -1,7 +1,7 @@
 from django.contrib.admin import widgets as admin_widgets
 from django.forms.utils import flatatt
 from django.template.loader import get_template
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import conditional_escape
 
 from judge.widgets.mixins import CompressorWidgetMixin
@@ -74,7 +74,7 @@ else:
         def get_template_context(self, attrs, value):
             return {
                 'attrs': flatatt(attrs),
-                'body': conditional_escape(force_text(value)),
+                'body': conditional_escape(force_str(value)),
                 'id': attrs['id'],
                 'show_preview': self.show_preview,
                 'preview_url': self.preview_url,


### PR DESCRIPTION
These two are aliases on Python 3.x and Django 3.x is deprecating the `force_text`.