### PR TITLE
Change style of unrated username

### DIFF
--- a/resources/ranks.scss
+++ b/resources/ranks.scss
@@ -61,7 +61,7 @@ svg.rate-box {
 }
 
 .rate-none, .rate-none a {
-    color: black;
+    color: #999;
     font-weight: normal;
 }
 


### PR DESCRIPTION
Closes #1546. This style makes an unrated username look like an unbolded newbie.

![Capture](https://user-images.githubusercontent.com/14223529/135950283-73b8fa84-f349-4a05-a1e7-bd10ede47842.png)

- Left side: Unrated username in the leaderboards.
- Middle: Unrated username in a problem statement.
- Right side: Unrated username in the authors list.