### PR TITLE
Move to MathJax 3.2.0

### DIFF
--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -150,6 +150,7 @@ class ProblemRaw(ProblemMixin, TitleMixin, TemplateResponseMixin, SingleObjectMi
         context['problem_name'] = self.object.name
         context['url'] = self.request.build_absolute_uri()
         context['description'] = self.object.description
+        context['math_engine'] = self.request.profile.math_engine
         return context
 
     def get(self, request, *args, **kwargs):

--- a/judge/widgets/pagedown.py
+++ b/judge/widgets/pagedown.py
@@ -45,7 +45,7 @@ else:
         class Media:
             js = [
                 'mathjax_config.js',
-                'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML',
+                'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-chtml.min.js',
                 'pagedown_math.js',
             ]
 

--- a/resources/dmmd-preview.js
+++ b/resources/dmmd-preview.js
@@ -36,11 +36,11 @@ $(function () {
                                 success: function () {
                                     $.ajax({
                                         type: 'GET',
-                                        url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_HTML',
+                                        url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-chtml.min.js',
                                         dataType: 'script',
                                         cache: true,
                                         success: function () {
-                                            MathJax.Hub.Queue(function () {
+                                            MathJax.typesetPromise([$content[0]]).then(() => {
                                                 $content.find('.tex-image').hide();
                                                 $content.find('.tex-text').show();
                                             });
@@ -49,7 +49,7 @@ $(function () {
                                 }
                             });
                         } else {
-                            MathJax.Hub.Queue(['Typeset', MathJax.Hub, $content[0]], function () {
+                            MathJax.typesetPromise([$content[0]]).then(() => {
                                 $content.find('.tex-image').hide();
                                 $content.find('.tex-text').show();
                             });

--- a/resources/martor-mathjax.js
+++ b/resources/martor-mathjax.js
@@ -1,7 +1,7 @@
 jQuery(function ($) {
     $(document).on('martor:preview', function (e, $content) {
         function update_math() {
-            MathJax.Hub.Queue(['Typeset', MathJax.Hub, $content[0]], function () {
+            MathJax.typesetPromise([$content[0]]).then(() => {
                 $content.find('.tex-image').hide();
                 $content.find('.tex-text').show();
             });
@@ -16,10 +16,10 @@ jQuery(function ($) {
                     dataType: 'script',
                     cache: true,
                     success: function () {
-                        window.MathJax.skipStartupTypeset = true;
+                        window.MathJax.startup = {typeset: false};
                         $.ajax({
                             type: 'GET',
-                            url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_HTML',
+                            url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-chtml.min.js',
                             dataType: 'script',
                             cache: true,
                             success: update_math

--- a/resources/mathjax_config.js
+++ b/resources/mathjax_config.js
@@ -1,10 +1,11 @@
 window.MathJax = {
-    messageStyle: 'none',
-    tex2jax: {
+    tex: {
         inlineMath: [
             ['~', '~'],
             ['\\(', '\\)']
         ]
     },
-    showMathMenu: false
+    options: {
+        enableMenu: false
+    }
 };

--- a/resources/pagedown_math.js
+++ b/resources/pagedown_math.js
@@ -2,10 +2,12 @@ function mathjax_pagedown($) {
     if ('MathJax' in window) {
         $.each(window.editors, function (id, editor) {
             var preview = $('div.wmd-preview#' + id + '_wmd_preview')[0];
-            editor.hooks.chain('onPreviewRefresh', function () {
-                MathJax.Hub.Queue(["Typeset", MathJax.Hub, preview]);
-            });
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub, preview]);
+            if (preview) {
+                editor.hooks.chain('onPreviewRefresh', function () {
+                    MathJax.typeset([preview]);
+                });
+                MathJax.typeset([preview]);
+            }
         });
     }
 }

--- a/templates/comments/media-js.html
+++ b/templates/comments/media-js.html
@@ -1,33 +1,6 @@
 <script src="{{ static('libs/featherlight/featherlight.min.js') }}" type="text/javascript"></script>
 {% compress js %}
     {{ comment_form.media.js }}
-    {% if not REQUIRE_JAX %}
-        <script type="text/javascript">
-            $(function () {
-                $('#id_body').keypress(function () {
-                    if (!("MathJax" in window)) {
-                        $.ajax({
-                            type: "GET",
-                            url: '{{ static('mathjax_config.js') }}',
-                            dataType: "script",
-                            cache: true,
-                            success: function () {
-                                $.ajax({
-                                    type: "GET",
-                                    url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config=TeX-AMS_HTML',
-                                    dataType: "script",
-                                    cache: true,
-                                    success: function () {
-                                        mathjax_pagedown($);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            });
-        </script>
-    {% endif %}
     <script type="text/javascript">
         $(document).ready(function () {
             window.reply_comment = function (parent) {
@@ -55,7 +28,7 @@
             function update_math($comment) {
                 if ('MathJax' in window) {
                     var $body = $comment.find('.comment-body');
-                    MathJax.Hub.Queue(['Typeset', MathJax.Hub, $body[0]], function () {
+                    MathJax.typesetPromise([$body[0]]).then(() => {
                         $body.find('.tex-image').hide();
                         $body.find('.tex-text').show();
                     });
@@ -174,9 +147,9 @@
                             if ('MathJax' in window) {
                                 var preview = $('.featherlight div.wmd-preview')[0];
                                 window.editors[$wmd.attr('id')].hooks.chain('onPreviewRefresh', function () {
-                                    MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
+                                    MathJax.typesetPromise([preview]);
                                 });
-                                MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
+                                MathJax.typesetPromise([preview]);
                             }
                         }
                     }

--- a/templates/mathjax-load.html
+++ b/templates/mathjax-load.html
@@ -1,12 +1,8 @@
 <script type="text/javascript" src="{{ static('mathjax_config.js') }}"></script>
-<script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_HTML"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-chtml.min.js"></script>
 <script type="text/javascript">
-    window.reload_mathjax = function () {
-        MathJax.Hub.queue.Push(function () {
-            $('.tex-image').hide();
-            $('.tex-text').show();
-        });
-    };
-    window.reload_mathjax();
+    MathJax.typesetPromise().then(() => {
+        $('.tex-image').hide();
+        $('.tex-text').show();
+    });
 </script>

--- a/templates/problem/raw.html
+++ b/templates/problem/raw.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="pygment-github.css" type="text/css">
+    <link rel="stylesheet" href="{{ static('style.css') }}">
+    <link rel="stylesheet" href="{{ static('pygment-github.css') }}" type="text/css">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <style>
         html {
@@ -79,18 +79,11 @@
 </div>
 <hr style="clear: both;">
 <div class="content-description printing">
-    {{ description|markdown(problem.markdown_style, 'tex' if math_engine == 'jax' else math_engine)|reference|absolutify(url)|str|safe }}
+    {{ description|markdown(problem.markdown_style, 'tex' if REQUIRE_JAX else math_engine)|reference|absolutify(url)|str|safe }}
 </div>
-{% if math_engine == 'jax' %}
-    <script type="text/javascript" src="mathjax_config.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_HTML"></script>
-    <script type="text/javascript">
-        MathJax.Hub.Register.StartupHook("End", function () {
-            if (typeof window.callPhantom === 'function')
-                window.callPhantom({'action': 'snapshot'});
-            document.body.classList.add('math-loaded');
-        });
-    </script>
+{% if REQUIRE_JAX %}
+    <script type="text/javascript" src="{{ static('mathjax_config.js') }}"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-chtml.min.js"></script>
 {% endif %}
 </body>
 </html>

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -407,3 +407,9 @@
         </aside>
     </div>
 {% endblock %}
+
+{% block bodyend %}
+    {% if REQUIRE_JAX %}
+        {% include "mathjax-load.html" %}
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Closes #1760. Tested the following math engines:

- Leave as LaTeX
- SVG with PNG fallback (but I can't set up mathoid to test this properly)
- MathML only
- MathJax with SVG/PNG fallback

… on the following pages:

- `/problem/aplusb`
  - Statement renders on page load
  - New comment editor behaves well
  - Editor to modify existing comment behaves well
- `/problem/aplusb/raw`
- `/ticket/2`
- `/admin/judge/problem/1/change/`
  - Problem body editor behaves well

Couldn't test the problem pdf generator. I'm going to pretend it didn't break.