### PR TITLE
Avoid PyPI webauthn 1.x for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,6 @@ sqlparse
 lupa
 martor @ git+git://github.com/DMOJ/martor.git
 netaddr
-webauthn
+webauthn<1
 bleach
 django-admin-sortable2


### PR DESCRIPTION
The 1.0.0 release uses things that are not in Python 3.7, which we run
on prod.