### PR TITLE
Properly prevent multiple form submissions

### DIFF
--- a/resources/common.js
+++ b/resources/common.js
@@ -247,10 +247,7 @@ $(function () {
 
     $('form').submit(function (evt) {
         // Prevent multiple submissions of forms, see #565, #1776
-        $(this).submit(function() {
-            return false;
-        });
-        return true;
+        $("button[type=submit], input[type=submit]").prop('disabled', true);
     });
 });
 


### PR DESCRIPTION
Due to my bad in #1777, the Random Problem button was not able to click more than once time.

This PR comes with another way to prevent multiple form submissions. Instead of disabling the submit function, it disables submit buttons (button & input with type=submit). This also prevents multiple submissions via pressing the enter key (as I mentioned in #1776)

Because random button using `a` to submit the form so it will be fine.