### PR TITLE
Fix race condition in PDF math rendering

### DIFF
--- a/judge/pdf_problems.py
+++ b/judge/pdf_problems.py
@@ -230,7 +230,7 @@ const puppeteer = require('puppeteer');
 puppeteer.launch().then(browser => Promise.resolve()
     .then(async () => {
         const page = await browser.newPage();
-        await page.goto(param.input, { waitUntil: 'load' });
+        await page.goto(param.input, { waitUntil: 'networkidle0' });
         await page.waitForSelector('.math-loaded', { timeout: 15000 });
         await page.pdf({
             path: param.output,


### PR DESCRIPTION
`networkidle0` existed [since v0.13.0](https://github.com/puppeteer/puppeteer/blame/v0.13.0/docs/api.md#L791).

Some background:
- MathJax didn't provide a way to tell if the math fonts have fully loaded.
  - For example, MathJax's `typesetPromise` creates the DOM elements without any knowledge of fonts.
- Puppeteer creates the PDF too early, so the math may not have a font yet.