### PR TITLE
Correctly redirect organization user page with wrong slug

### DIFF
--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -59,7 +59,8 @@ class OrganizationDetailView(OrganizationMixin, DetailView):
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
         if self.object.slug != kwargs['slug']:
-            return HttpResponsePermanentRedirect(reverse('organization_home', args=(self.object.id, self.object.slug)))
+            return HttpResponsePermanentRedirect(reverse(
+                request.resolver_match.url_name, args=(self.object.id, self.object.slug)))
         context = self.get_context_data(object=self.object)
         return self.render_to_response(context)
 


### PR DESCRIPTION
Before, if the slug is wrong, the user list redirects to the
organization home page. This commit changes it to redirect to the
correct page.