### PR TITLE
Day of week text change to resolve translation errors

### DIFF
--- a/templates/user/user-about.html
+++ b/templates/user/user-about.html
@@ -86,7 +86,7 @@
                     </tr>
                     <tr id="submission-6">
                         <th class="submission-date-col info-text">
-                            {{ _('Satday') }}
+                            {{ _('Saturday') }}
                         </th>
                     </tr>
                 </table>

--- a/templates/user/user-about.html
+++ b/templates/user/user-about.html
@@ -56,37 +56,37 @@
                 <table id="submission-activity-table">
                     <tr id="submission-0">
                         <th class="submission-date-col info-text">
-                            {{ _('Sun') }}
+                            {{ _('Sunday') }}
                         </th>
                     </tr>
                     <tr id="submission-1">
                         <th class="submission-date-col info-text">
-                            {{ _('Mon') }}
+                            {{ _('Monday') }}
                         </th>
                     </tr>
                     <tr id="submission-2">
                         <th class="submission-date-col info-text">
-                            {{ _('Tues') }}
+                            {{ _('Tuesday') }}
                         </th>
                     </tr>
                     <tr id="submission-3">
                         <th class="submission-date-col info-text">
-                            {{ _('Wed') }}
+                            {{ _('Wedday') }}
                         </th>
                     </tr>
                     <tr id="submission-4">
                         <th class="submission-date-col info-text">
-                            {{ _('Thurs') }}
+                            {{ _('Thursday') }}
                         </th>
                     </tr>
                     <tr id="submission-5">
                         <th class="submission-date-col info-text">
-                            {{ _('Fri') }}
+                            {{ _('Friday') }}
                         </th>
                     </tr>
                     <tr id="submission-6">
                         <th class="submission-date-col info-text">
-                            {{ _('Sat') }}
+                            {{ _('Satday') }}
                         </th>
                     </tr>
                 </table>

--- a/templates/user/user-about.html
+++ b/templates/user/user-about.html
@@ -71,7 +71,7 @@
                     </tr>
                     <tr id="submission-3">
                         <th class="submission-date-col info-text">
-                            {{ _('Wedday') }}
+                            {{ _('Wednesday') }}
                         </th>
                     </tr>
                     <tr id="submission-4">


### PR DESCRIPTION
In many langueges, translation error occurs in the user problem history box.
In particular, Tuesday and Thursday are problems that are not translated into their native language.

1. Tuesday, Thursday translation error
- català (ca)
- Deutsch (de)
- español (es)
- français (fr)
- Hrvatski (hr)
- Magyar (hu)
- 한국어 (ko)
- Português (pt)
- Română (ro)
- Русский (ru)
- srpski (latinica) (sr-latn)
- Türkçe (tr)
- 繁體中文 (zh-hant)

2. Friday, Saturday translation error
- Tiếng Việt (vi)