### PR TITLE
Full hidden scoreboard & Post-window own scoreboard

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -57,10 +57,12 @@ class Contest(models.Model):
     SCOREBOARD_VISIBLE = 'V'
     SCOREBOARD_AFTER_CONTEST = 'C'
     SCOREBOARD_AFTER_PARTICIPATION = 'P'
+    SCOREBOARD_HIDDEN = 'H'
     SCOREBOARD_VISIBILITY = (
         (SCOREBOARD_VISIBLE, _('Visible')),
         (SCOREBOARD_AFTER_CONTEST, _('Hidden for duration of contest')),
         (SCOREBOARD_AFTER_PARTICIPATION, _('Hidden for duration of participation')),
+        (SCOREBOARD_HIDDEN, _('Hidden permanently')),
     )
     key = models.CharField(max_length=20, verbose_name=_('contest id'), unique=True,
                            validators=[RegexValidator('^[a-z0-9]+$', _('Contest id must be ^[a-z0-9]+$'))])
@@ -234,7 +236,7 @@ class Contest(models.Model):
         if (self.scoreboard_visibility in (self.SCOREBOARD_AFTER_CONTEST, self.SCOREBOARD_AFTER_PARTICIPATION) and
                 not self.ended):
             return False
-        return True
+        return self.scoreboard_visibility != self.SCOREBOARD_HIDDEN
 
     @property
     def contest_window_length(self):

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -203,7 +203,7 @@ class Contest(models.Model):
             return True
         if not self.can_join:
             return False
-        if not self.show_scoreboard and not self.is_in_contest(user):
+        if not self.show_scoreboard and not self.is_in_contest(user) and not self.has_completed_contest(user):
             return False
         return True
 

--- a/judge/models/tests/test_contest.py
+++ b/judge/models/tests/test_contest.py
@@ -108,6 +108,18 @@ class ContestTestCase(CommonDataMixin, TestCase):
             testers=('non_staff_tester',),
         )
 
+        self.full_hidden_scoreboard_contest = create_contest(
+            key='full_hidden_board',
+            start_time=_now - timezone.timedelta(days=100),
+            end_time=_now - timezone.timedelta(days=1),
+            time_limit=timezone.timedelta(days=1),
+            is_visible=True,
+            scoreboard_visibility=Contest.SCOREBOARD_HIDDEN,
+            authors=('non_staff_author',),
+            curators=('staff_contest_edit_own',),
+            testers=('non_staff_tester',),
+        )
+
         for contest_key in ('contest_scoreboard', 'particip_scoreboard', 'visible_scoreboard'):
             create_contest_participation(
                 contest=contest_key,
@@ -135,6 +147,13 @@ class ContestTestCase(CommonDataMixin, TestCase):
             user='normal',
             real_start=_now + timezone.timedelta(days=101),
             virtual=ContestParticipation.SPECTATE,
+        )
+
+        create_contest_participation(
+            contest='full_hidden_board',
+            user='normal_after_window',
+            real_start=_now - timezone.timedelta(days=5),
+            virtual=ContestParticipation.LIVE,
         )
 
         self.users['normal'].profile.current_contest = create_contest_participation(
@@ -438,6 +457,32 @@ class ContestTestCase(CommonDataMixin, TestCase):
             },
         }
         self._test_object_methods_with_users(self.visible_scoreboard_contest, data)
+
+    def test_full_hidden_scoreboard_contest_methods(self):
+        data = {
+            'superuser': {
+                'can_see_full_scoreboard': self.assertTrue,
+            },
+            'non_staff_tester': {
+                'can_see_full_scoreboard': self.assertFalse,
+            },
+            'non_staff_author': {
+                'can_see_full_scoreboard': self.assertTrue,
+            },
+            'staff_contest_edit_own': {
+                'can_see_full_scoreboard': self.assertTrue,
+            },
+            'staff_contest_edit_all': {
+                'can_see_full_scoreboard': self.assertTrue,
+            },
+            'normal': {
+                'can_see_full_scoreboard': self.assertFalse,
+            },
+            'normal_after_window': {
+                'can_see_full_scoreboard': self.assertFalse,
+            },
+        }
+        self._test_object_methods_with_users(self.full_hidden_scoreboard_contest, data)
 
     def test_private_contest_methods(self):
         with self.assertRaises(Contest.PrivateContest):

--- a/judge/models/tests/test_contest.py
+++ b/judge/models/tests/test_contest.py
@@ -391,7 +391,7 @@ class ContestTestCase(CommonDataMixin, TestCase):
                 'has_completed_contest': self.assertFalse,
             },
             'normal_after_window': {
-                'can_see_own_scoreboard': self.assertFalse,
+                'can_see_own_scoreboard': self.assertTrue,
                 'can_see_full_scoreboard': self.assertFalse,
                 'has_completed_contest': self.assertTrue,
             },
@@ -461,24 +461,31 @@ class ContestTestCase(CommonDataMixin, TestCase):
     def test_full_hidden_scoreboard_contest_methods(self):
         data = {
             'superuser': {
+                'can_see_own_scoreboard': self.assertTrue,
                 'can_see_full_scoreboard': self.assertTrue,
             },
             'non_staff_tester': {
+                'can_see_own_scoreboard': self.assertFalse,
                 'can_see_full_scoreboard': self.assertFalse,
             },
             'non_staff_author': {
+                'can_see_own_scoreboard': self.assertTrue,
                 'can_see_full_scoreboard': self.assertTrue,
             },
             'staff_contest_edit_own': {
+                'can_see_own_scoreboard': self.assertTrue,
                 'can_see_full_scoreboard': self.assertTrue,
             },
             'staff_contest_edit_all': {
+                'can_see_own_scoreboard': self.assertTrue,
                 'can_see_full_scoreboard': self.assertTrue,
             },
             'normal': {
+                'can_see_own_scoreboard': self.assertFalse,
                 'can_see_full_scoreboard': self.assertFalse,
             },
             'normal_after_window': {
+                'can_see_own_scoreboard': self.assertTrue,
                 'can_see_full_scoreboard': self.assertFalse,
             },
         }

--- a/judge/views/api/api_v2.py
+++ b/judge/views/api/api_v2.py
@@ -285,7 +285,8 @@ class APIContestDetail(APIDetailView):
             'rating_floor': contest.rating_floor,
             'rating_ceiling': contest.rating_ceiling,
             'hidden_scoreboard': contest.scoreboard_visibility in (contest.SCOREBOARD_AFTER_CONTEST,
-                                                                   contest.SCOREBOARD_AFTER_PARTICIPATION),
+                                                                   contest.SCOREBOARD_AFTER_PARTICIPATION,
+                                                                   contest.SCOREBOARD_HIDDEN),
             'scoreboard_visibility': contest.scoreboard_visibility,
             'is_organization_private': contest.is_organization_private,
             'organizations': list(

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -419,8 +419,11 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         else:
             context['hot_problems'] = None
             context['point_start'], context['point_end'], context['point_values'] = 0, 0, {}
-            context['hide_contest_scoreboard'] = self.contest.scoreboard_visibility in \
-                (self.contest.SCOREBOARD_AFTER_CONTEST, self.contest.SCOREBOARD_AFTER_PARTICIPATION)
+            context['hide_contest_scoreboard'] = self.contest.scoreboard_visibility in (
+                self.contest.SCOREBOARD_AFTER_CONTEST,
+                self.contest.SCOREBOARD_AFTER_PARTICIPATION,
+                self.contest.SCOREBOARD_HIDDEN,
+            )
         return context
 
     def get_noui_slider_points(self):

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -251,7 +251,11 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
                 contest_queryset = Contest.objects.filter(Q(authors=self.request.profile) |
                                                           Q(curators=self.request.profile) |
                                                           Q(scoreboard_visibility=Contest.SCOREBOARD_VISIBLE) |
-                                                          Q(end_time__lt=timezone.now())).distinct()
+                                                          Q(end_time__lt=timezone.now()), scoreboard_visibility__in=(
+                                                          Contest.SCOREBOARD_AFTER_PARTICIPATION,
+                                                          Contest.SCOREBOARD_AFTER_CONTEST,
+                                                          )) \
+                                                  .distinct()
                 queryset = queryset.filter(Q(user=self.request.profile) |
                                            Q(contest_object__in=contest_queryset) |
                                            Q(contest_object__isnull=True))

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -164,6 +164,8 @@
                             {{ _('The scoreboard will be **hidden** until your window is over.')|markdown('default') }}
                         {% elif contest.scoreboard_visibility == contest.SCOREBOARD_AFTER_CONTEST %}
                             {{ _('The scoreboard will be **hidden** for the entire duration of the contest.')|markdown('default') }}
+                        {% elif contest.scoreboard_visibility == contest.SCOREBOARD_HIDDEN %}
+                            {{ _('The scoreboard will be **hidden**, even after the contest is over.')|markdown('default') }}
                         {% endif %}
                     </li>
                     {% if contest.access_code %}


### PR DESCRIPTION
This adds support for a fully-hidden scoreboard type, i.e., one that is hidden even after the contest finishes.

In such a case, it is expected that it would be nice for users to be able to see their own participation, so the second commit allows users to see their own scoreboard if they have completed the contest.