### PR TITLE
Add editorial column and filtering

### DIFF
--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -10,13 +10,13 @@ from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import transaction
-from django.db.models import Count, F, Prefetch, Q
+from django.db.models import Case, Count, F, IntegerField, Prefetch, Q, Sum, When
 from django.db.utils import ProgrammingError
 from django.http import Http404, HttpResponse, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.template.loader import get_template
 from django.urls import reverse
-from django.utils import translation
+from django.utils import timezone, translation
 from django.utils.functional import cached_property
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
@@ -370,6 +370,13 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
                                         .values_list('problem__id', flat=True))
         if self.show_types:
             queryset = queryset.prefetch_related('types')
+        queryset = queryset.annotate(has_public_editorial=Sum(Case(
+            When(solution__is_public=True, solution__publish_on__lte=timezone.now(), then=1),
+            default=0,
+            output_field=IntegerField(),
+        )))
+        if self.has_public_editorial:
+            queryset = queryset.filter(solution__is_public=True, solution__publish_on__lte=timezone.now())
         if self.category is not None:
             queryset = queryset.filter(group__id=self.category)
         if self.selected_types:
@@ -400,6 +407,7 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         context = super(ProblemList, self).get_context_data(**kwargs)
         context['hide_solved'] = 0 if self.in_contest else int(self.hide_solved)
         context['show_types'] = 0 if self.in_contest else int(self.show_types)
+        context['has_public_editorial'] = 0 if self.in_contest else int(self.has_public_editorial)
         context['full_text'] = 0 if self.in_contest else int(self.full_text)
         context['category'] = self.category
         context['categories'] = ProblemGroup.objects.all()
@@ -451,6 +459,7 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         self.hide_solved = self.GET_with_session(request, 'hide_solved')
         self.show_types = self.GET_with_session(request, 'show_types')
         self.full_text = self.GET_with_session(request, 'full_text')
+        self.has_public_editorial = self.GET_with_session(request, 'has_public_editorial')
 
         self.search_query = None
         self.category = None

--- a/resources/problem.scss
+++ b/resources/problem.scss
@@ -37,6 +37,12 @@
         }
     }
 
+    th {
+        &.editorial {
+            padding: 4px 10px;
+        }
+    }
+
     tr {
         transition: background-color linear 0.2s;
 
@@ -149,6 +155,14 @@ ul.problem-list {
 
 .attempted-problem-color {
     color: orange;
+}
+
+.has-editorial-color {
+    color: #44AD41;
+}
+
+.no-editorial-color {
+    color: #DE2121;
 }
 
 .submissions-left {

--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -232,6 +232,9 @@
                         <th class="ac-rate">
                             <a href="{{ sort_links.ac_rate }}">{{ _('AC %%') }}{{ sort_order.ac_rate }}</a>
                         </th>
+                        <th class="editorial">
+                            {{ _('Editorial') }}
+                        </th>
                         <th class="users">
                             <a href="{{ sort_links.user_count }}">{{ _('Users') }}{{ sort_order.user_count }}</a>
                         </th>
@@ -286,6 +289,15 @@
                         <td class="p">{{ problem.points|floatformat }}{% if problem.partial %}p{% endif %}</td>
                         {% if not request.in_contest %}
                             <td class="ac-rate">{{ problem.ac_rate|floatformat(1) }}%</td>
+                            {% if problem.has_public_editorial %}
+                                <td editorial="1">
+                                    <i class="has-editorial-color fa fa-check-circle"></i>
+                                </td>
+                            {% else %}
+                                <td editorial="0">
+                                    <i class="no-editorial-color fa fa-minus-circle"></i>
+                                </td>
+                            {% endif %}
                         {% endif %}
                         <td class="users">
                             <a href="{{ url('ranked_submissions', problem.code) }}">

--- a/templates/problem/search-form.html
+++ b/templates/problem/search-form.html
@@ -22,6 +22,11 @@
                 </div>
             {% endif %}
             <div>
+                <input id="has_public_editorial" type="checkbox" name="has_public_editorial" value="1"
+                        {% if has_public_editorial %} checked{% endif %}>
+                <label for="has_public_editorial">{{ _('Has editorial') }}</label>
+            </div>
+            <div>
                 <input id="show_types" type="checkbox" name="show_types" value="1"
                         {% if show_types %} checked{% endif %}>
                 <label for="show_types">{{ _('Show problem types') }}</label>


### PR DESCRIPTION
The problem page now has an editorial column. The search form can now be 
used to only show problems with an editorial.

The only extraneous change is adding a method to `Problem`, 
`has_public_editorial`.

Here's some screenshots of the UI I get locally:

Editorial Column, plus sorting:

![image](https://user-images.githubusercontent.com/41458184/155030590-4241524c-d960-414e-b571-7f7d62bec185.png)

Filtering:

![image](https://user-images.githubusercontent.com/41458184/155030653-9bd59d0f-be8f-4aeb-894b-565706d563b7.png)
