### PR TITLE
fix submission visibility in contests

### DIFF
--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -251,10 +251,10 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
                 contest_queryset = Contest.objects.filter(Q(authors=self.request.profile) |
                                                           Q(curators=self.request.profile) |
                                                           Q(scoreboard_visibility=Contest.SCOREBOARD_VISIBLE) |
-                                                          Q(end_time__lt=timezone.now()), scoreboard_visibility__in=(
-                                                          Contest.SCOREBOARD_AFTER_PARTICIPATION,
-                                                          Contest.SCOREBOARD_AFTER_CONTEST,
-                                                          )) \
+                                                          Q(end_time__lt=timezone.now(), scoreboard_visibility__in=(
+                                                            Contest.SCOREBOARD_AFTER_PARTICIPATION,
+                                                            Contest.SCOREBOARD_AFTER_CONTEST,
+                                                            ))) \
                                                   .distinct()
                 queryset = queryset.filter(Q(user=self.request.profile) |
                                            Q(contest_object__in=contest_queryset) |


### PR DESCRIPTION
After #1843, because of a misplaced bracket, users can't see submissions from contests with visible scoreboards.