### PR TITLE
remove types column code in contest

### DIFF
--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -203,9 +203,6 @@
                         {% endif %}
                         <th class="problem">{{ _('Problem') }}</th>
                         <th class="category">{{ _('Category') }}</th>
-                        {% if show_types %}
-                            <th>{{ _('Types') }}</th>
-                        {% endif %}
                         <th class="points">{{ _('Points') }}</th>
                         <th class="users">{{ _('Users') }}</th>
                     {% else %}


### PR DESCRIPTION
Types are forcibly muted in contest anyway, so this code never runs. There's no sense having it at all.