### PR TITLE
shrink editorial column

### DIFF
--- a/resources/problem.scss
+++ b/resources/problem.scss
@@ -37,12 +37,6 @@
         }
     }
 
-    th {
-        &.editorial {
-            padding: 4px 10px;
-        }
-    }
-
     tr {
         transition: background-color linear 0.2s;
 


### PR DESCRIPTION
Old CSS caused it to be kind of large.

![master](https://user-images.githubusercontent.com/41458184/155623160-f931ec5d-03cc-4c56-9ca5-0327a56416b0.png)
![new](https://user-images.githubusercontent.com/41458184/155623127-1e60e562-83f3-4959-a2b5-1d67c24d786e.png)
