### PR TITLE
RFC: Don't strip whitespace from submissions

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -124,7 +124,7 @@ class DownloadDataForm(Form):
 
 
 class ProblemSubmitForm(ModelForm):
-    source = CharField(max_length=65536, widget=AceWidget(theme='twilight', no_ace_media=True))
+    source = CharField(max_length=65536, widget=AceWidget(theme='twilight', no_ace_media=True), strip=False)
     judge = ChoiceField(choices=(), widget=forms.HiddenInput(), required=False)
 
     def __init__(self, *args, judge_choices=(), **kwargs):


### PR DESCRIPTION
This could be beneficial to `TEXT` submissions and would have been useful for certain languages that required line numbers to be indented and aligned. However, this is a significant behaviour change and deserves some scrutiny.