### PR TITLE
Compare i18n changes with correct branch

### DIFF
--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -64,12 +64,13 @@ jobs:
     - name: Remove useless changes
       run: |
         set -eu
+        i18n_head=$(git rev-parse --verify -q origin/update-i18n || echo "HEAD")
         while IFS= read -r -d $'\0' file; do
           if git diff -s --exit-code "$file"; then
             continue
           fi
 
-          if git diff origin/update-i18n -- "$file" | tail -n +5 2>/dev/null | grep -qP '^[-+](?!"PO-Revision-Date:|"POT-Creation-Date:)'; then
+          if git diff $(i18n_head) -- "$file" | tail -n +5 2>/dev/null | grep -qP '^[-+](?!"PO-Revision-Date:|"POT-Creation-Date:)'; then
             echo "Changed: $file"
           else
             echo "No material change: $file"

--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -70,7 +70,7 @@ jobs:
             continue
           fi
 
-          if git diff $(i18n_head) -- "$file" | tail -n +5 2>/dev/null | grep -qP '^[-+](?!"PO-Revision-Date:|"POT-Creation-Date:)'; then
+          if git diff $i18n_head -- "$file" | tail -n +5 2>/dev/null | grep -qP '^[-+](?!"PO-Revision-Date:|"POT-Creation-Date:)'; then
             echo "Changed: $file"
           else
             echo "No material change: $file"

--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -69,7 +69,7 @@ jobs:
             continue
           fi
 
-          if git diff "$file" | tail -n +5 2>/dev/null | grep -qP '^[-+](?!"PO-Revision-Date:|"POT-Creation-Date:)'; then
+          if git diff origin/update-i18n -- "$file" | tail -n +5 2>/dev/null | grep -qP '^[-+](?!"PO-Revision-Date:|"POT-Creation-Date:)'; then
             echo "Changed: $file"
           else
             echo "No material change: $file"

--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -70,7 +70,7 @@ jobs:
             continue
           fi
 
-          if git diff $i18n_head -- "$file" | tail -n +5 2>/dev/null | grep -qP '^[-+](?!"PO-Revision-Date:|"POT-Creation-Date:)'; then
+          if git diff "$i18n_head" -- "$file" | tail -n +5 2>/dev/null | grep -qP '^[-+](?!"PO-Revision-Date:|"POT-Creation-Date:)'; then
             echo "Changed: $file"
           else
             echo "No material change: $file"


### PR DESCRIPTION
I suspect this workflow compares with `master`. This led to meaningless changes such as
https://github.com/DMOJ/online-judge/compare/6b6f3d1..f47a6ab