### PR TITLE
Update Ruby key in language fixture

### DIFF
--- a/judge/fixtures/language_all.json
+++ b/judge/fixtures/language_all.json
@@ -259,8 +259,8 @@
     "model": "judge.language",
     "pk": 21,
     "fields": {
-        "key": "RUBY2",
-        "name": "Ruby 2",
+        "key": "RUBY",
+        "name": "Ruby",
         "short_name": "",
         "common_name": "Ruby",
         "ace": "ruby",


### PR DESCRIPTION
There is also an instance of `RUBY2` in a migration (https://github.com/DMOJ/online-judge/blob/master/judge/migrations/0112_language_extensions.py#L57), but I'm not sure if we should be updating old migrations.