### PR TITLE
Fix comment editor's buttons on narrow screens

### DIFF
--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -78,10 +78,8 @@ a {
 }
 
 .comment-post-wrapper {
-    div {
-        padding-bottom: 2px;
-        padding-right: 10px;
-    }
+    padding-bottom: 2px;
+    padding-right: 10px;
 
     input, textarea {
         min-width: 100%;

--- a/resources/pagedown_widget.css
+++ b/resources/pagedown_widget.css
@@ -24,19 +24,14 @@
 }
 
 .wmd-button-row {
-    position: relative;
-    margin: 10px 5px 5px;
+    margin: 5px;
     padding: 0;
-    height: 20px;
-    overflow-x: auto;
-    overflow-y: hidden;
+    line-height: 0;
 }
 
 .wmd-spacer {
-    width: 1px;
+    width: 15px;
     height: 20px;
-    margin-left: 14px;
-    position: absolute;
     display: inline-block;
     list-style: none;
 }
@@ -46,7 +41,6 @@
     height: 20px;
     padding-left: 2px;
     padding-right: 3px;
-    position: absolute;
     display: inline-block;
     list-style: none;
     cursor: pointer;
@@ -57,18 +51,6 @@
     width: 20px;
     height: 20px;
     display: inline-block;
-}
-
-.wmd-spacer1 {
-    left: 50px;
-}
-
-.wmd-spacer2 {
-    left: 175px;
-}
-
-.wmd-spacer3 {
-    left: 300px;
 }
 
 .wmd-prompt-background {


### PR DESCRIPTION
Screenshot (left is old, right is new):

![Capture](https://user-images.githubusercontent.com/14223529/160263502-5d62475d-58a6-47b5-b621-c26367914733.PNG)

This change affects all comment editors on the site. This includes:
- Blog page, contest page, problem page, editorial page
- Edit comment popup
- Edit profile, edit organization
- Opening a ticket, responding to a ticket

Side note: `/resources/pagedown/Markdown.Editor.js` still adds a `left: <integer>px` style to each button, but `left` no longer has any effect.