### PR TITLE
Import Markup from MarkupSafe instead of jinja2

### DIFF
--- a/judge/jinja2/markdown/__init__.py
+++ b/judge/jinja2/markdown/__init__.py
@@ -6,9 +6,9 @@ from urllib.parse import urlparse
 import mistune
 from bleach.sanitizer import Cleaner
 from django.conf import settings
-from jinja2 import Markup
 from lxml import html
 from lxml.etree import ParserError, XMLSyntaxError
+from markupsafe import Markup
 
 from judge.highlight_code import highlight_code
 from judge.jinja2.markdown.lazy_load import lazy_load as lazy_load_processor

--- a/judge/jinja2/spaceless.py
+++ b/judge/jinja2/spaceless.py
@@ -1,7 +1,8 @@
 import re
 
-from jinja2 import Markup, nodes
+from jinja2 import nodes
 from jinja2.ext import Extension
+from markupsafe import Markup
 
 
 class SpacelessExtension(Extension):


### PR DESCRIPTION
From the changelog:
```
Version 3.1.0
Released 2022-03-24
...
Markup and escape should be imported from MarkupSafe.
```
`MarkupSafe` is already a dependency for `jinja2`, so no new dependencies need to be added here.

