### PR TITLE
Fix i18n issues in models

### DIFF
--- a/judge/admin/problem.py
+++ b/judge/admin/problem.py
@@ -17,7 +17,7 @@ from judge.widgets import AdminHeavySelect2MultipleWidget, AdminMartorWidget, Ad
 
 
 class ProblemForm(ModelForm):
-    change_message = forms.CharField(max_length=256, label='Edit reason', required=False)
+    change_message = forms.CharField(max_length=256, label=_('Edit reason'), required=False)
 
     def __init__(self, *args, **kwargs):
         super(ProblemForm, self).__init__(*args, **kwargs)

--- a/judge/models/comment.py
+++ b/judge/models/comment.py
@@ -200,6 +200,8 @@ class CommentLock(models.Model):
         permissions = (
             ('override_comment_lock', _('Override comment lock')),
         )
+        verbose_name = _('comment lock')
+        verbose_name_plural = _('comment locks')
 
     def __str__(self):
         return str(self.page)

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -67,20 +67,23 @@ class Contest(models.Model):
     key = models.CharField(max_length=20, verbose_name=_('contest id'), unique=True,
                            validators=[RegexValidator('^[a-z0-9]+$', _('Contest id must be ^[a-z0-9]+$'))])
     name = models.CharField(max_length=100, verbose_name=_('contest name'), db_index=True)
-    authors = models.ManyToManyField(Profile, help_text=_('These users will be able to edit the contest.'),
+    authors = models.ManyToManyField(Profile, verbose_name=_('authors'),
+                                     help_text=_('These users will be able to edit the contest.'),
                                      related_name='authored_contests')
-    curators = models.ManyToManyField(Profile, help_text=_('These users will be able to edit the contest, '
-                                                           'but will not be listed as authors.'),
+    curators = models.ManyToManyField(Profile, verbose_name=_('curators'),
+                                      help_text=_('These users will be able to edit the contest, '
+                                                  'but will not be listed as authors.'),
                                       related_name='curated_contests', blank=True)
-    testers = models.ManyToManyField(Profile, help_text=_('These users will be able to view the contest, '
-                                                          'but not edit it.'),
+    testers = models.ManyToManyField(Profile, verbose_name=_('testers'),
+                                     help_text=_('These users will be able to view the contest, but not edit it.'),
                                      blank=True, related_name='tested_contests')
     tester_see_scoreboard = models.BooleanField(verbose_name=_('testers see scoreboard'), default=False,
                                                 help_text=_('If testers can see the scoreboard.'))
     tester_see_submissions = models.BooleanField(verbose_name=_('testers see submissions'), default=False,
                                                  help_text=_('If testers can see in-contest submissions.'))
-    spectators = models.ManyToManyField(Profile, help_text=_('These users will be able to spectate the contest, '
-                                                             'but not see the problems ahead of time.'),
+    spectators = models.ManyToManyField(Profile, verbose_name=_('spectators'),
+                                        help_text=_('These users will be able to spectate the contest, '
+                                                    'but not see the problems ahead of time.'),
                                         blank=True, related_name='spectated_contests')
     description = models.TextField(verbose_name=_('description'), blank=True)
     problems = models.ManyToManyField(Problem, verbose_name=_('problems'), through='ContestProblem')
@@ -583,7 +586,8 @@ class ContestProblem(models.Model):
     order = models.PositiveIntegerField(db_index=True, verbose_name=_('order'))
     output_prefix_override = models.IntegerField(verbose_name=_('output prefix length override'),
                                                  default=0, null=True, blank=True)
-    max_submissions = models.IntegerField(help_text=_('Maximum number of submissions for this problem, '
+    max_submissions = models.IntegerField(verbose_name=_('max submissions'),
+                                          help_text=_('Maximum number of submissions for this problem, '
                                                       'or leave blank for no limit.'),
                                           default=None, null=True, blank=True,
                                           validators=[MinValueOrNoneValidator(1, _('Why include a problem you '

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -148,7 +148,7 @@ class Problem(models.Model):
                                                            '(e.g. 64mb = 65536 kilobytes).'),
                                                validators=[MinValueValidator(settings.DMOJ_PROBLEM_MIN_MEMORY_LIMIT),
                                                            MaxValueValidator(settings.DMOJ_PROBLEM_MAX_MEMORY_LIMIT)])
-    short_circuit = models.BooleanField(default=False)
+    short_circuit = models.BooleanField(verbose_name=_('short circuit'), default=False)
     points = models.FloatField(verbose_name=_('points'),
                                help_text=_('Points awarded for problem completion. '
                                            "Points are displayed with a 'p' suffix if partial."),
@@ -163,7 +163,7 @@ class Problem(models.Model):
                                 help_text=_("Doesn't have magic ability to auto-publish due to backward compatibility"))
     banned_users = models.ManyToManyField(Profile, verbose_name=_('personae non gratae'), blank=True,
                                           help_text=_('Bans the selected users from submitting to this problem.'))
-    license = models.ForeignKey(License, null=True, blank=True, on_delete=SET_NULL,
+    license = models.ForeignKey(License, null=True, blank=True, on_delete=SET_NULL, verbose_name=_('license'),
                                 help_text=_('The license under which this problem is published.'))
     og_image = models.CharField(verbose_name=_('OpenGraph image'), max_length=150, blank=True)
     summary = models.TextField(blank=True, verbose_name=_('problem summary'),
@@ -484,6 +484,10 @@ class ProblemClarification(models.Model):
     problem = models.ForeignKey(Problem, verbose_name=_('clarified problem'), on_delete=CASCADE)
     description = models.TextField(verbose_name=_('clarification body'), validators=[disallowed_characters_validator])
     date = models.DateTimeField(verbose_name=_('clarification timestamp'), auto_now_add=True)
+
+    class Meta:
+        verbose_name = _('problem clarification')
+        verbose_name_plural = _('problem clarifications')
 
 
 class LanguageLimit(models.Model):

--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -154,7 +154,7 @@ class Profile(models.Model):
     points = models.FloatField(default=0, db_index=True)
     performance_points = models.FloatField(default=0, db_index=True)
     problem_count = models.IntegerField(default=0, db_index=True)
-    ace_theme = models.CharField(max_length=30, choices=ACE_THEMES, default='github')
+    ace_theme = models.CharField(max_length=30, verbose_name=_('Ace theme'), choices=ACE_THEMES, default='github')
     last_access = models.DateTimeField(verbose_name=_('last access time'), default=now)
     ip = models.GenericIPAddressField(verbose_name=_('last IP'), blank=True, null=True)
     organizations = SortedManyToManyField(Organization, verbose_name=_('organization'), blank=True,

--- a/judge/models/runtime.py
+++ b/judge/models/runtime.py
@@ -121,7 +121,8 @@ class RuntimeVersion(models.Model):
 
 
 class Judge(models.Model):
-    name = models.CharField(max_length=50, help_text=_('Server name, hostname-style'), unique=True)
+    name = models.CharField(max_length=50, verbose_name=_('judge name'), help_text=_('Server name, hostname-style'),
+                            unique=True)
     created = models.DateTimeField(auto_now_add=True, verbose_name=_('time of creation'))
     auth_key = models.CharField(max_length=100, help_text=_('A key to authenticate this judge'),
                                 verbose_name=_('authentication key'))

--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -64,8 +64,8 @@ class Submission(models.Model):
         'AB': _('Aborted'),
     }
 
-    user = models.ForeignKey(Profile, on_delete=models.CASCADE)
-    problem = models.ForeignKey(Problem, on_delete=models.CASCADE)
+    user = models.ForeignKey(Profile, verbose_name=_('user'), on_delete=models.CASCADE)
+    problem = models.ForeignKey(Problem, verbose_name=_('problem'), on_delete=models.CASCADE)
     date = models.DateTimeField(verbose_name=_('submission time'), auto_now_add=True, db_index=True)
     time = models.FloatField(verbose_name=_('execution time'), null=True, db_index=True)
     memory = models.FloatField(verbose_name=_('memory usage'), null=True)
@@ -239,6 +239,10 @@ class SubmissionSource(models.Model):
 
     def __str__(self):
         return 'Source of %s' % self.submission
+
+    class Meta:
+        verbose_name = _('submission source')
+        verbose_name_plural = _('submission sources')
 
 
 @revisions.register()

--- a/judge/models/ticket.py
+++ b/judge/models/ticket.py
@@ -21,6 +21,10 @@ class Ticket(models.Model):
     linked_item = GenericForeignKey()
     is_open = models.BooleanField(verbose_name=_('is ticket open?'), default=True)
 
+    class Meta:
+        verbose_name = _('ticket')
+        verbose_name_plural = _('tickets')
+
 
 class TicketMessage(models.Model):
     ticket = models.ForeignKey(Ticket, verbose_name=_('ticket'), related_name='messages',
@@ -29,3 +33,7 @@ class TicketMessage(models.Model):
                              on_delete=models.CASCADE)
     body = models.TextField(verbose_name=_('message body'))
     time = models.DateTimeField(verbose_name=_('message time'), auto_now_add=True)
+
+    class Meta:
+        verbose_name = _('ticket message')
+        verbose_name_plural = _('ticket messages')


### PR DESCRIPTION
How these i18n issues were detected:
```py
from django.core.management.base import BaseCommand
from django.utils.translation import gettext_lazy as _

from django.apps import apps


class Command(BaseCommand):
    help = 'get all fields missing verbose_name'

    def handle(self, *args, **options):
        goodtype = type(_('yes'))
        for model in apps.get_models():
            if not model._meta.db_table.startswith('judge_'):
                continue
            msg = []
            # meta verbose_name
            if type(model._meta.verbose_name) != goodtype:
                msg.append('class verbose_name')
            if type(model._meta.verbose_name_plural) != goodtype:
                msg.append('class verbose_name_plural')
            # field verbose_name
            for field in model._meta.get_fields():
                if not hasattr(field, 'verbose_name'):
                    continue
                if field.name == 'id':
                    continue
                if type(field._verbose_name) != goodtype:
                    msg.append(f'{type(field._verbose_name)} {field.name}')
            # done
            if msg:
                print(model)
                for s in msg:
                    print(s)
                print()
```

This still outputs some i18n issues, but I couldn't find them in the frontend.