### PR TITLE
updatemessages: either commit all files or no files

### DIFF
--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -79,7 +79,6 @@ jobs:
             changed=1
           else
             echo "No material change: $file"
-            git checkout "$file" > /dev/null 2>&1
           fi
         done < <(git ls-files -z 'locale/*/LC_MESSAGES/*.po')
 


### PR DESCRIPTION
`updatemessages`'s latest commit https://github.com/DMOJ/online-judge/commit/565ad8001219cb0efda6233444b071b8a56c6552 had 3 changed files:

- 2 were `el`. Line 82 had no effect because these files were new.
- 1 was `fr`. Someone added a `fr` translation so this is ok.

All other translations were checkout'd. This made the pr incomplete.

Delete the checkout. If every translation had no material change, the `reset --hard` would handle it.

(Note: It's possible to wrap line 82 in a `if git diff "$file" | tail -n +5 2>/dev/null | grep -qP '^[-+](?!"PO-Revision-Date:|"POT-Creation-Date:)'; then`. I thought this was too ugly.)