### PR TITLE
Migrate to bleach 5.0.0

### DIFF
--- a/judge/jinja2/markdown/__init__.py
+++ b/judge/jinja2/markdown/__init__.py
@@ -4,6 +4,7 @@ from html import unescape
 from urllib.parse import urlparse
 
 import mistune
+from bleach.css_sanitizer import CSSSanitizer
 from bleach.sanitizer import Cleaner
 from django.conf import settings
 from lxml import html
@@ -117,8 +118,9 @@ def get_cleaner(name, params):
     if name in cleaner_cache:
         return cleaner_cache[name]
 
-    if params.get('styles') is True:
-        params['styles'] = all_styles
+    styles = params.pop('styles', None)
+    if styles:
+        params['css_sanitizer'] = CSSSanitizer(allowed_css_properties=all_styles if styles is True else styles)
 
     if params.pop('mathml', False):
         params['tags'] = params.get('tags', []) + mathml_tags

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ lupa
 martor @ git+https://github.com/DMOJ/martor.git
 netaddr
 webauthn<1
-bleach<5
+bleach[css]
 django-admin-sortable2<2
 icalendar
 # This is a celery dependency whose latest major version is breaking everything.


### PR DESCRIPTION
This breaks `bleach<5`. Upgrade bleach with `pip install --upgrade -r requirements.txt`.

Make bleach work with [this annoying commit](https://github.com/mozilla/bleach/commit/cb6dca73d0d15f8c26acb28e7cc53482526bbe1b).