### PR TITLE
Fix i18n on content titles

### DIFF
--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -29,25 +29,19 @@ admin.autodiscover()
 register_patterns = [
     path('activate/complete/',
          TitledTemplateView.as_view(template_name='registration/activation_complete.html',
-                                    title='Activation Successful!'),
+                                    title=_('Activation Successful!')),
          name='registration_activation_complete'),
-    # Let use <str:activation_key>,
-    # because a bad activation key should still get to the view;
-    # that way it can return a sensible "invalid key" message instead of a
-    # confusing 404.
-    path('activate/<str:activation_key>/',
-         ActivationView.as_view(title='Activation key invalid'),
-         name='registration_activate'),
-    path('register/',
-         RegistrationView.as_view(title='Register'),
-         name='registration_register'),
+    # Let's use <str:activation_key>, because a bad activation key should still get to the view;
+    # that way, it can return a sensible "invalid key" message instead of a confusing 404.
+    path('activate/<str:activation_key>/', ActivationView.as_view(), name='registration_activate'),
+    path('register/', RegistrationView.as_view(), name='registration_register'),
     path('register/complete/',
          TitledTemplateView.as_view(template_name='registration/registration_complete.html',
-                                    title='Registration Completed'),
+                                    title=_('Registration Completed')),
          name='registration_complete'),
     path('register/closed/',
          TitledTemplateView.as_view(template_name='registration/registration_closed.html',
-                                    title='Registration not allowed'),
+                                    title=_('Registration Not Allowed')),
          name='registration_disallowed'),
     path('login/', user.CustomLoginView.as_view(), name='auth_login'),
     path('logout/', user.UserLogoutView.as_view(), name='auth_logout'),

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -280,7 +280,7 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
 
 
 class ContestClone(ContestMixin, PermissionRequiredMixin, TitleMixin, SingleObjectFormView):
-    title = _('Clone Contest')
+    title = gettext_lazy('Clone Contest')
     template_name = 'contest/clone.html'
     form_class = ContestCloneForm
     permission_required = 'judge.clone_contest'

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -696,7 +696,7 @@ class ProblemSubmit(LoginRequiredMixin, ProblemMixin, TitleMixin, SingleObjectFo
 
 
 class ProblemClone(ProblemMixin, PermissionRequiredMixin, TitleMixin, SingleObjectFormView):
-    title = _('Clone Problem')
+    title = gettext_lazy('Clone Problem')
     template_name = 'problem/clone.html'
     form_class = ProblemCloneForm
     permission_required = 'judge.clone_problem'

--- a/judge/views/register.py
+++ b/judge/views/register.py
@@ -53,7 +53,7 @@ class CustomRegistrationForm(RegistrationForm):
 
 
 class RegistrationView(OldRegistrationView):
-    title = _('Registration')
+    title = _('Register')
     form_class = CustomRegistrationForm
     template_name = 'registration/registration_form.html'
 
@@ -91,7 +91,7 @@ class RegistrationView(OldRegistrationView):
 
 
 class ActivationView(OldActivationView):
-    title = _('Registration')
+    title = _('Activation Key Invalid')
     template_name = 'registration/activate.html'
 
     def get_context_data(self, **kwargs):

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -393,7 +393,7 @@ class AllUserSubmissions(ConditionalUserTabMixin, UserMixin, SubmissionsListBase
 
     def get_content_title(self):
         if self.is_own:
-            return mark_safe(escape(_('All my submissions')))
+            return _('All my submissions')
         return mark_safe(escape(_('All submissions by %s')) % (
             format_html('<a href="{1}">{0}</a>', self.profile.display_name,
                         reverse('user_page', args=[self.username])),

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -393,9 +393,11 @@ class AllUserSubmissions(ConditionalUserTabMixin, UserMixin, SubmissionsListBase
 
     def get_content_title(self):
         if self.is_own:
-            return format_html('All my submissions')
-        return format_html('All submissions by <a href="{1}">{0}</a>', self.profile.display_name,
-                           reverse('user_page', args=[self.username]))
+            return mark_safe(escape(_('All my submissions')))
+        return mark_safe(escape(_('All submissions by %s')) % (
+            format_html('<a href="{1}">{0}</a>', self.profile.display_name,
+                        reverse('user_page', args=[self.username])),
+        ))
 
     def get_my_submissions_page(self):
         if self.request.user.is_authenticated:
@@ -423,8 +425,10 @@ class ProblemSubmissionsBase(SubmissionsListBase):
         return _('All submissions for %s') % self.problem_name
 
     def get_content_title(self):
-        return format_html('All submissions for <a href="{1}">{0}</a>', self.problem_name,
-                           reverse('problem_detail', args=[self.problem.code]))
+        return mark_safe(escape(_('All submissions for %s')) % (
+            format_html('<a href="{1}">{0}</a>', self.problem_name,
+                        reverse('problem_detail', args=[self.problem.code])),
+        ))
 
     def access_check_contest(self, request):
         if self.in_contest and not self.contest.can_see_own_scoreboard(request.user):
@@ -489,12 +493,16 @@ class UserProblemSubmissions(ConditionalUserTabMixin, UserMixin, ProblemSubmissi
 
     def get_content_title(self):
         if self.request.user.is_authenticated and self.request.profile == self.profile:
-            return format_html("""My submissions for <a href="{3}">{2}</a>""",
-                               self.username, reverse('user_page', args=[self.username]),
-                               self.problem_name, reverse('problem_detail', args=[self.problem.code]))
-        return format_html("""<a href="{1}">{0}</a>'s submissions for <a href="{3}">{2}</a>""",
-                           self.profile.display_name, reverse('user_page', args=[self.username]),
-                           self.problem_name, reverse('problem_detail', args=[self.problem.code]))
+            return mark_safe(escape(_('My submissions for %(problem)s')) % {
+                'problem': format_html('<a href="{1}">{0}</a>', self.problem_name,
+                                       reverse('problem_detail', args=[self.problem.code])),
+            })
+        return mark_safe(escape(_("%(user)s's submissions for %(problem)s")) % {
+            'user': format_html('<a href="{1}">{0}</a>', self.profile.display_name,
+                                reverse('user_page', args=[self.username])),
+            'problem': format_html('<a href="{1}">{0}</a>', self.problem_name,
+                                   reverse('problem_detail', args=[self.problem.code])),
+        })
 
     def get_context_data(self, **kwargs):
         context = super(UserProblemSubmissions, self).get_context_data(**kwargs)

--- a/judge/views/two_factor.py
+++ b/judge/views/two_factor.py
@@ -12,7 +12,7 @@ from django.contrib.auth.views import SuccessURLAllowedHostsMixin
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.utils.http import is_safe_url
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 from django.views.generic import FormView, View
 from django.views.generic.detail import SingleObjectMixin
 
@@ -46,7 +46,7 @@ class TOTPView(TitleMixin, LoginRequiredMixin, FormView):
 
 
 class TOTPEnableView(TOTPView):
-    title = _('Enable Two-factor Authentication')
+    title = gettext_lazy('Enable Two-factor Authentication')
     form_class = TOTPEnableForm
     template_name = 'registration/totp_enable.html'
     is_refresh = False
@@ -106,7 +106,7 @@ class TOTPEnableView(TOTPView):
 
 
 class TOTPRefreshView(TOTPEnableView):
-    title = _('Refresh Two-factor Authentication')
+    title = gettext_lazy('Refresh Two-factor Authentication')
     is_refresh = True
 
     def check_skip(self):
@@ -114,7 +114,7 @@ class TOTPRefreshView(TOTPEnableView):
 
 
 class TOTPDisableView(TOTPView):
-    title = _('Disable Two-factor Authentication')
+    title = gettext_lazy('Disable Two-factor Authentication')
     template_name = 'registration/totp_disable.html'
 
     def check_skip(self):
@@ -227,7 +227,7 @@ class WebAuthnDeleteView(SingleObjectMixin, WebAuthnView):
 
 class TwoFactorLoginView(SuccessURLAllowedHostsMixin, TOTPView):
     form_class = TwoFactorLoginForm
-    title = _('Perform Two-factor Authentication')
+    title = gettext_lazy('Perform Two-factor Authentication')
     template_name = 'registration/two_factor_auth.html'
 
     def get_form_kwargs(self):


### PR DESCRIPTION
Fixes the content title for these pages. (Assume `admin` is logged in, `d` is another user, `aplusb` is a problem, and `neverheld` is a contest.)
```
/accounts/activate/complete/
/accounts/activate/badkey/
/accounts/register/ (for logged-out users)
/accounts/register/complete/
/accounts/register/closed/

/contest/neverheld/clone
/problem/aplusb/clone
/user/admin/submissions/
/user/d/submissions/
/problem/aplusb/submissions/
/problem/aplusb/submissions/admin/
/problem/aplusb/submissions/d/

/accounts/2fa/enable/
/accounts/2fa/refresh/
/accounts/2fa/disable/
/accounts/2fa/
```