### PR TITLE
Remove html tags in i18n translations

### DIFF
--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,17 +1,15 @@
 <span style="display:block;margin: 0 2px;padding: 1em;border: 3px solid #FFDE05;background-color: #000;border-radius: 6px;font-size: .95em;color: #444;margin-bottom:0.75em">
 <div style="display:table;margin-left:2em"><img src="https://avatars1.githubusercontent.com/u/6934864?v=3&s=101" style="display:inline;vertical-align: middle">
-<h1 style="font-size:4em;display:inline;vertical-align: middle"><a href="//{{ domain }}" style="text-decoration:none;color:gray"><span style="color: #FFDE05">DM::</span>OJ</a>
+<h1 style="font-size:4em;display:inline;vertical-align: middle"><a href="{{ protocol }}://{{ domain }}" style="text-decoration:none;color:gray"><span style="color: #FFDE05">DM::</span>OJ</a>
       </h1>
 </div>
 </span>
 <div style="display:block;margin: 0 2px;padding: 1em;border: 3px solid #2980B9;background-color: #f8f8f8;border-radius: 6px;font-size: .95em;color: #444;">
 
-{% trans username=user.get_username() %}
-<b>Forgot your password on the {{ site_name }}? Don't worry!</b><br><br>
-To reset the password for your account "{{ username }}", click the button below.
-{% endtrans %}
+<b>{{ _("Forgot your password on the %(site_name)s? Don't worry!", site_name=site_name) }}</b><br><br>
+{{ _('To reset the password for your account "%(username)s", click the button below.', username=user.get_username()) }}
 <p align="center">
-<a href="{{ protocol }}://{{ domain }}{{ url('password_reset_confirm', uidb64=uid, token=token) }}" style="cursor: pointer;display:block;text-align: center;padding: 4px 2px 5px;color: white;border: 1px solid #666;border-radius: 1px;background: #2980b9;background: linear-gradient(180deg, #00aee0, #2980b9);text-decoration: none;line-height:2em;font-size:1em;width:12em;">Reset password</a>
+<a href="{{ protocol }}://{{ domain }}{{ url('password_reset_confirm', uidb64=uid, token=token) }}" style="cursor: pointer;display:block;text-align: center;padding: 4px 2px 5px;color: white;border: 1px solid #666;border-radius: 1px;background: #2980b9;background: linear-gradient(180deg, #00aee0, #2980b9);text-decoration: none;line-height:2em;font-size:1em;width:12em;">{{ _('Reset Password') }}</a>
 </p>
 {% if SITE_ADMIN_EMAIL %}
 {{ _('See you soon! If you have problems resetting your email, feel free to shoot us an email at') }} <a href="mailto:{{ SITE_ADMIN_EMAIL }}">{{ SITE_ADMIN_EMAIL }}</a>

--- a/templates/submission/internal-error-message.html
+++ b/templates/submission/internal-error-message.html
@@ -1,9 +1,8 @@
 <h3 style="color:red;font-weight:bold">
     {% if request.user == submission.user.user %}
-        {% trans trimmed %}
-            An internal error occurred while grading, and the {{ SITE_NAME }} administrators have been notified.<br>
-            In the meantime, try resubmitting in a few seconds.
-        {% endtrans %}
+        {{ _('An internal error occurred while grading, and the %(site_name)s administrators have been notified.', site_name=SITE_NAME) }}
+        <br>
+        {{ _('In the meantime, try resubmitting in a few seconds.') }}
     {% else %}
         {{ _('An internal error occurred while grading.') }}
     {% endif %}


### PR DESCRIPTION
The (newer) reset email looks like this:
```html
<span style="display:block;margin: 0 2px;padding: 1em;border: 3px solid #FFDE05;background-color: #000;border-radius: 6px;font-size: .95em;color: #444;margin-bottom:0.75em">
<div style="display:table;margin-left:2em"><img src="https://avatars1.githubusercontent.com/u/6934864?v=3&s=101" style="display:inline;vertical-align: middle">
<h1 style="font-size:4em;display:inline;vertical-align: middle"><a href="http://localhost:8081" style="text-decoration:none;color:gray"><span style="color: #FFDE05">DM::</span>OJ</a>
      </h1>
</div>
</span>
<div style="display:block;margin: 0 2px;padding: 1em;border: 3px solid #2980B9;background-color: #f8f8f8;border-radius: 6px;font-size: .95em;color: #444;">

<b>Forgot your password on the DMOJ: Modern Online Judge? Don&#39;t worry!</b><br><br>
To reset the password for your account &quot;admin&quot;, click the button below.
<p align="center">
<a href="http://localhost:8081/accounts/password/reset/confirm/MQ-60s-b85dbd13f9d265762557/" style="cursor: pointer;display:block;text-align: center;padding: 4px 2px 5px;color: white;border: 1px solid #666;border-radius: 1px;background: #2980b9;background: linear-gradient(180deg, #00aee0, #2980b9);text-decoration: none;line-height:2em;font-size:1em;width:12em;">Reset Password</a>
</p>
See you soon!
</div>
```

Side note: The password reset email needs further fixes, but let's not worry about those problems for now.

![Capture](https://user-images.githubusercontent.com/14223529/163661979-65e4a2ab-d611-403e-ad25-4aabc12adada.PNG)