### PR TITLE
Remove useless "set title"

### DIFF
--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -49,7 +49,7 @@ class Submission(models.Model):
     USER_DISPLAY_CODES = {
         'AC': _('Accepted'),
         'WA': _('Wrong Answer'),
-        'SC': 'Short Circuited',
+        'SC': _('Short Circuited'),
         'TLE': _('Time Limit Exceeded'),
         'MLE': _('Memory Limit Exceeded'),
         'OLE': _('Output Limit Exceeded'),

--- a/judge/views/stats.py
+++ b/judge/views/stats.py
@@ -25,7 +25,7 @@ def language_data(request, language_count=Language.objects.annotate(count=Count(
     other_count = sum(map(itemgetter('count'), languages[num_languages:]))
 
     return JsonResponse({
-        'labels': list(map(itemgetter('name'), languages[:num_languages])) + ['Other'],
+        'labels': list(map(itemgetter('name'), languages[:num_languages])) + [_('Other')],
         'datasets': [
             {
                 'backgroundColor': chart_colors[:num_languages] + ['#FDB45C'],

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -50,7 +50,6 @@
 
 {% block title_row %}
     {% set tab = 'list' %}
-    {% set title = 'Contests' %}
     {% include "contest/contest-list-tabs.html" %}
 {% endblock %}
 

--- a/templates/organization/list.html
+++ b/templates/organization/list.html
@@ -12,7 +12,6 @@
 
 {% block title_row %}
     {% set tab = 'organizations' %}
-    {% set title = _('Organizations') %}
     {% include "user/user-list-tabs.html" %}
 {% endblock %}
 

--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -163,7 +163,6 @@
 
 {% block title_row %}
     {% set tab = 'list' %}
-    {% set title = 'Problems' %}
     {% include "problem/problem-list-tabs.html" %}
 {% endblock %}
 

--- a/templates/stats/base.html
+++ b/templates/stats/base.html
@@ -10,7 +10,6 @@
 
 {% block title_row %}
     {% set tab = 'language' %}
-    {% set title = 'Statistics' %}
     {% include "stats/tabs.html" %}
 {% endblock %}
 

--- a/templates/user/list.html
+++ b/templates/user/list.html
@@ -17,7 +17,6 @@
 
 {% block title_row %}
     {% set tab = 'list' %}
-    {% set title = 'Leaderboard' %}
     {% include "user/user-list-tabs.html" %}
 {% endblock %}
 


### PR DESCRIPTION
Remove uses of `set title` that break i18n. Affected pages:
```
/contests/
/organizations/
/problems/
/stats/language/
/users/
```