### PR TITLE
Clean up css for content columns

### DIFF
--- a/resources/content-description.scss
+++ b/resources/content-description.scss
@@ -18,8 +18,7 @@
     }
 
     #content-left {
-        flex: 86%;
-        width: 100%;
+        flex: 5;
 
         &.split-common-content {
             width: 70%;
@@ -31,9 +30,8 @@
     }
 
     #content-right {
-        flex: 14%;
+        flex: 1;
         max-width: 12.5em;
-        min-width: 8em;
         padding-left: 1.5em;
         padding-top: 1em;
 

--- a/resources/problem.scss
+++ b/resources/problem.scss
@@ -74,7 +74,6 @@
 
 #content-right {
     &.problems {
-        flex: 26.5%;
         max-width: unset;
         padding-top: 0;
     }
@@ -82,7 +81,7 @@
 
 #content-left {
     &.problems {
-        flex: 73.5%;
+        flex: 3;
     }
 }
 

--- a/resources/submission.scss
+++ b/resources/submission.scss
@@ -134,13 +134,7 @@ label[for="language"], label[for="status"] {
     border-right: 1px solid white;
 }
 
-#content-left.submission {
-    flex: 70%;
-}
-
 #content-right.submission {
-    flex: 12%;
-    min-width: initial;
     max-width: 100%;
     padding-top: 0;
 }
@@ -160,18 +154,6 @@ label[for="language"], label[for="status"] {
         .fa {
             display: inline-block;
         }
-    }
-
-    #fake-info-float {
-        display: none;
-    }
-
-    #statistics-table {
-        display: none;
-    }
-
-    #content-left.submission {
-        flex: 100%;
     }
 
     #content-right.submission {

--- a/resources/users.scss
+++ b/resources/users.scss
@@ -1,11 +1,5 @@
 @import "vars";
 
-#content-left {
-    &.users {
-        flex: unset;
-    }
-}
-
 td.user-name {
     padding-left: 2em;
     text-align: left;


### PR DESCRIPTION
Fixes #1243 (actually, removing just `min-width: 8em;` fixed the issue).

![Capture](https://user-images.githubusercontent.com/14223529/164536007-d7a33d52-bf30-466a-9054-785bdfdbc567.PNG)

Also, clean up the weird flexbox css. This affects all pages that use `content-left` and `content-right`:
```
/contest/<contest>/ranking/
/contest/<contest>/rank/<problem>/
/contest/<contest>/submissions/<user>/
/organization/<int>-<slug>
/organization/<int>-<slug>/users
/problems/
/problem/<problem>
/submissions/
/submissions/user/<user>/
/users/
```