### PR TITLE
Disallow voting on own comments

### DIFF
--- a/judge/migrations/0132_no_self_vote.py
+++ b/judge/migrations/0132_no_self_vote.py
@@ -11,11 +11,11 @@ def delete_self_votes(apps, schema_editor):
     Comment.objects.update(
         score=Subquery(
             Comment.objects.filter(
-                id=OuterRef('id')
+                id=OuterRef('id'),
             ).annotate(
-                foo=Coalesce(Sum('votes__score'), 0)
-            ).values('foo')[:1]
-        )
+                newscore=Coalesce(Sum('votes__score'), 0),
+            ).values('newscore')[:1],
+        ),
     )
 
 

--- a/judge/migrations/0132_no_self_vote.py
+++ b/judge/migrations/0132_no_self_vote.py
@@ -12,9 +12,9 @@ def delete_self_votes(apps, schema_editor):
         score=Subquery(
             Comment.objects.filter(
                 id=OuterRef('id'),
-            ).annotate(
+            ).order_by().annotate(
                 newscore=Coalesce(Sum('votes__score'), 0),
-            ).values('newscore')[:1],
+            ).values('newscore'),
         ),
     )
 

--- a/judge/migrations/0132_no_self_vote.py
+++ b/judge/migrations/0132_no_self_vote.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+from django.db.models import F, OuterRef, Subquery, Sum
+from django.db.models.functions import Coalesce
+
+
+def delete_self_votes(apps, schema_editor):
+    Comment = apps.get_model('judge', 'Comment')
+    CommentVote = apps.get_model('judge', 'CommentVote')
+
+    CommentVote.objects.filter(voter=F('comment__author')).delete()
+    Comment.objects.update(
+        score=Subquery(
+            Comment.objects.filter(
+                id=OuterRef('id')
+            ).annotate(
+                foo=Coalesce(Sum('votes__score'), 0)
+            ).values('foo')[:1]
+        )
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0131_spectate_contests'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_self_votes, migrations.RunPython.noop),
+    ]

--- a/judge/views/comment.py
+++ b/judge/views/comment.py
@@ -43,9 +43,14 @@ def vote_comment(request, delta):
         comment_id = int(request.POST['id'])
     except ValueError:
         return HttpResponseBadRequest()
-    else:
-        if not Comment.objects.filter(id=comment_id, hidden=False).exists():
-            return HttpResponseNotFound(_('Comment not found.'), content_type='text/plain')
+
+    comment = Comment.objects.filter(id=comment_id, hidden=False).first()
+
+    if not comment:
+        return HttpResponseNotFound(_('Comment not found.'), content_type='text/plain')
+
+    if comment.author == request.profile:
+        return HttpResponseBadRequest(_('You cannot vote on your own comments.'), content_type='text/plain')
 
     vote = CommentVote()
     vote.comment_id = comment_id


### PR DESCRIPTION
Fixes #1517. New self-votes cannot be created. The migration deletes all self-votes, and recalculates all comment scores.