### PR TITLE
Fix countdown space

### DIFF
--- a/templates/time-remaining-fragment.html
+++ b/templates/time-remaining-fragment.html
@@ -1,3 +1,1 @@
-<span data-secs="{{ countdown|seconds }}" class="time-remaining">
-    {{ countdown|timedelta("localized") }}
-</span>
+<span data-secs="{{ countdown|seconds }}" class="time-remaining">{{ countdown|timedelta("localized") }}</span>


### PR DESCRIPTION
During the first second of page load, the countdown says `Starting in 365384 days 23:01:56 .`

The new HTML fragment is:
```html
<span class="time">Starting in <span data-secs="31569260516.83524" class="time-remaining">365384 days 23:01:56</span>.</span>
```