### PR TITLE
Clean up i18n in __str__

### DIFF
--- a/judge/models/comment.py
+++ b/judge/models/comment.py
@@ -166,7 +166,7 @@ class Comment(MPTTModel):
         return '%s#comment-%d' % (self.link, self.id)
 
     def __str__(self):
-        return _('%(comment_id)s by %(user)s') % {'comment_id': self.page, 'user': self.author.user.username}
+        return _('%(page)s by %(user)s') % {'page': self.page, 'user': self.author.user.username}
 
         # Only use this when queried with
         # .prefetch_related(Prefetch('votes', queryset=CommentVote.objects.filter(voter_id=profile_id)))

--- a/judge/models/comment.py
+++ b/judge/models/comment.py
@@ -166,7 +166,7 @@ class Comment(MPTTModel):
         return '%s#comment-%d' % (self.link, self.id)
 
     def __str__(self):
-        return '%(page)s by %(user)s' % {'page': self.page, 'user': self.author.user.username}
+        return _('%(comment_id)s by %(user)s') % {'comment_id': self.page, 'user': self.author.user.username}
 
         # Only use this when queried with
         # .prefetch_related(Prefetch('votes', queryset=CommentVote.objects.filter(voter_id=profile_id)))

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -5,7 +5,7 @@ from django.db.models import CASCADE, Q
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import gettext, gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jsonfield import JSONField
 from lupa import LuaRuntime
 from moss import MOSS_LANG_C, MOSS_LANG_CC, MOSS_LANG_JAVA, MOSS_LANG_PYTHON
@@ -565,10 +565,12 @@ class ContestParticipation(models.Model):
 
     def __str__(self):
         if self.spectate:
-            return gettext('%s spectating in %s') % (self.user.username, self.contest.name)
+            return _('%(user)s spectating in %(contest)s') % {'user': self.user.username, 'contest': self.contest.name}
         if self.virtual:
-            return gettext('%s in %s, v%d') % (self.user.username, self.contest.name, self.virtual)
-        return gettext('%s in %s') % (self.user.username, self.contest.name)
+            return _('%(user)s in %(contest)s, v%(id)d') % {
+                'user': self.user.username, 'contest': self.contest.name, 'id': self.virtual,
+            }
+        return _('%(user)s in %(contest)s') % {'user': self.user.username, 'contest': self.contest.name}
 
     class Meta:
         verbose_name = _('contest participation')

--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -125,7 +125,7 @@ class Class(models.Model):
         return cls.objects.filter(contest__organizations__admins=user.profile) | cls.objects.filter(admins=user.profile)
 
     def __str__(self):
-        return f'{self.name} in {self.organization.name}'
+        return _('%(class)s in %(organization)s') % {'class': self.name, 'organization': self.organization.name}
 
     def get_absolute_url(self):
         return reverse('class_home', args=self._url_args)
@@ -345,7 +345,7 @@ class WebAuthnCredential(models.Model):
         )
 
     def __str__(self):
-        return f'WebAuthn credential: {self.name}'
+        return _('WebAuthn credential: %(name)s') % {'name': self.name}
 
     class Meta:
         verbose_name = _('WebAuthn credential')

--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -197,7 +197,9 @@ class Submission(models.Model):
             return self.contest_object.key
 
     def __str__(self):
-        return 'Submission %d of %s by %s' % (self.id, self.problem, self.user.user.username)
+        return _('Submission %(id)d of %(problem)s by %(user)s') % {
+            'id': self.id, 'problem': self.problem, 'user': self.user.user.username,
+        }
 
     def get_absolute_url(self):
         return reverse('submission_status', args=(self.id,))
@@ -238,7 +240,7 @@ class SubmissionSource(models.Model):
     source = models.TextField(verbose_name=_('source code'), max_length=65536)
 
     def __str__(self):
-        return 'Source of %s' % self.submission
+        return _('Source of %(submission)s') % {'submission': self.submission}
 
     class Meta:
         verbose_name = _('submission source')


### PR DESCRIPTION
This affects the following admin pages:
```
Home › Online Judge › Classes › Foo Class in DMOJ: Modern Online Judge
Home › Online Judge › Comments › b:1 by admin
Home › Online Judge › Contest participations › d in Fake Contest 111
Home › Online Judge › Submissions › Submission 12 of testpdf2 by admin
```

`SubmissionSource.__str__` was tested by visiting a submission.

`WebAuthnCredential.__str__` was tested by visiting a user profile.