### PR TITLE
Add file submission to problem page

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -146,10 +146,9 @@ class ProblemSubmitForm(ModelForm):
         if file is not None:
             with file.open(mode='rb') as source_file:
                 source = ''.join(map(lambda b: b.decode('utf-8'), source_file.readlines()))
-                if len(source) > 65536: raise ValidationError(_('Source file is too long'))
+                if len(source) >= 65536: raise ValidationError(_('Source file is too long.'))
                 cleaned_data['source'] = source
-
-
+        elif cleaned_data['source'] is None: raise ValidationError(_('Source and file are both empty.'))
         return cleaned_data
 
     class Meta:

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -144,6 +144,10 @@ class ProblemDetail(ProblemMixin, SolvedProblemMixin, CommentedDetailView):
     def get_comment_page(self):
         return 'p:%s' % self.object.code
 
+    @cached_property
+    def default_language(self):
+        return self.request.profile.language
+
     def get_context_data(self, **kwargs):
         context = super(ProblemDetail, self).get_context_data(**kwargs)
         user = self.request.user
@@ -168,6 +172,8 @@ class ProblemDetail(ProblemMixin, SolvedProblemMixin, CommentedDetailView):
         context['has_pdf_render'] = HAS_PDF
         context['completed_problem_ids'] = self.get_completed_problems()
         context['attempted_problems'] = self.get_attempted_problems()
+        context['form'] = ProblemSubmitForm()
+        context['default_lang'] = self.default_language
 
         can_edit = self.object.is_editable_by(user)
         context['can_edit_problem'] = can_edit

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -173,12 +173,12 @@ class ProblemDetail(ProblemMixin, SolvedProblemMixin, CommentedDetailView):
         context['completed_problem_ids'] = self.get_completed_problems()
         context['attempted_problems'] = self.get_attempted_problems()
         context['form'] = ProblemSubmitForm()
-        context['default_lang'] = self.default_language
 
         can_edit = self.object.is_editable_by(user)
         context['can_edit_problem'] = can_edit
         if user.is_authenticated:
             tickets = self.object.tickets
+            context['default_lang'] = self.default_language
             if not can_edit:
                 tickets = tickets.filter(own_ticket_filter(user.profile.id))
             context['has_tickets'] = tickets.exists()

--- a/templates/problem/problem.html
+++ b/templates/problem/problem.html
@@ -1,6 +1,10 @@
 {% extends "common-content.html" %}
+{% block js_media %}
+	{{ form.media.js }}
+{% endblock %}
 {% block content_media %}
     {% include "comments/media-css.html" %}
+	{{ form.media.css }}
     <style>
         .title-state {
             font-size: 2em;
@@ -34,13 +38,17 @@
             min-width: 12.5em;
         }
 
-        #problem-types, #allowed-langs, #available-judges {
+        #problem-types, #allowed-langs, #available-judges, #file-upload {
             padding-top: 1em;
         }
 
         .problem-info-entry {
             padding-top: 0.5em;
         }
+
+		#file-upload-form > div {
+			margin-top: 5px;
+		}
     </style>
 {% endblock %}
 
@@ -98,7 +106,7 @@
     {% if request.user.is_authenticated and request.in_contest and submission_limit %}
         {% if submissions_left > 0 %}
             <a href="{{ url('problem_submit', problem.code) }}" class="unselectable button full">
-                {{ _('Submit solution') }}
+                {{ _('Go to editor') }}
             </a>
             <div class="submissions-left">
                 {% trans trimmed counter=submissions_left %}
@@ -108,13 +116,37 @@
                 {% endtrans %}
             </div>
         {% else %}
-            <a class="unselectable button full disabled">{{ _('Submit solution') }}</a>
+            <a class="unselectable button full disabled">{{ _('Go to editor') }}</a>
             <div class="no-submissions-left submissions-left">{{ _('0 submissions left') }}</div>
         {% endif %}
     {% else %}
         <a href="{{ url('problem_submit', problem.code) }}" class="unselectable button full">
-            {{ _('Submit solution') }}
+            {{ _('Go to editor') }}
         </a>
+		<form id="file-upload" method="post" action="{{ url('problem_submit', problem.code) }}" enctype="multipart/form-data">
+			{% csrf_token %}
+			{{ form.non_field_errors() }}
+
+			<div class="toggle closed unselectable">
+				<i class="fa fa-chevron-right fa-fw"></i>Upload a file
+			</div>
+			<div style="display:none" class="toggled" id="file-upload-form">
+				<div>
+					{{ form.file }}
+				</div>
+				<div id="language-select">
+					<select id="id_language" name="language" class="full">
+						{% for lang in form.fields.language.queryset %}
+							<option value="{{ lang.id }}" {% if lang.id == default_lang.id %}selected{% endif %}>{{ lang.name }}</option>
+						{% endfor %}
+					</select>
+				</div>
+				<div>
+					<input value="{{ _('Submit!') }}" type="submit" id="submit-file-button" class="unselectable button full" 
+						{% if request.in_contest and submission_limit and not submissions_left %}disabled{% endif %} />
+				</div>
+			</div>
+		</form>
     {% endif %}
 
     <hr style="padding-bottom: 0.3em">

--- a/templates/problem/problem.html
+++ b/templates/problem/problem.html
@@ -123,6 +123,8 @@
         <a href="{{ url('problem_submit', problem.code) }}" class="unselectable button full">
             {{ _('Go to editor') }}
         </a>
+    {% endif %}
+	{% if request.user.is_authenticated and (not request.in_contest or submission_limit) %}
 		<form id="file-upload" method="post" action="{{ url('problem_submit', problem.code) }}" enctype="multipart/form-data">
 			{% csrf_token %}
 			{{ form.non_field_errors() }}
@@ -137,7 +139,7 @@
 				<div id="language-select">
 					<select id="id_language" name="language" class="full">
 						{% for lang in form.fields.language.queryset %}
-							<option value="{{ lang.id }}" {% if lang.id == default_lang.id %}selected{% endif %}>{{ lang.name }}</option>
+							<option value="{{ lang.id }}" {% if request.user.is_authenticated and lang.id == default_lang.id %}selected{% endif %}>{{ lang.name }}</option>
 						{% endfor %}
 					</select>
 				</div>
@@ -147,7 +149,7 @@
 				</div>
 			</div>
 		</form>
-    {% endif %}
+	{% endif %}
 
     <hr style="padding-bottom: 0.3em">
 


### PR DESCRIPTION
- Changed the button labelled "Submit!" on the problem page to say "Go to editor"
- Added a small form beneath the "Go to editor" button, initially hidden behind a chevron, that allows users to submit a file. I tried to make the changes as unobtrusive as possible.

Notes:
- The file submission form goes to `/problem/<problem-code>/submit`, which means that error messages, for example when submitting a file with length greater than 65535, show up in the editor. This isn't amazing UX but it might be acceptable. 
- It might be worth adding a button to submit files from the editor page
- If a user selects a file and then clicks "Go to editor", should it load that file into their editor?