### PR TITLE
Fix i18n issues with relative_time

### DIFF
--- a/judge/jinja2/datetime.py
+++ b/judge/jinja2/datetime.py
@@ -23,5 +23,10 @@ registry.filter(localtime_wrapper(time))
 
 @registry.function
 @registry.render_with('widgets/relative-time.html')
-def relative_time(time, format=_('N j, Y, g:i a'), rel=_('{time}'), abs=_('on {time}')):
-    return {'time': time, 'format': format, 'rel_format': rel, 'abs_format': abs}
+def relative_time(time, **kwargs):
+    return {
+        'time': time,
+        'format': kwargs.get('format', _('N j, Y, g:i a')),
+        'rel_format': kwargs.get('rel', _('{time}')),
+        'abs_format': kwargs.get('abs', _('on {time}')),
+    }

--- a/templates/blog/content.html
+++ b/templates/blog/content.html
@@ -24,7 +24,7 @@
                 {% endif %}
             {% endwith %}
             <span class="post-time">
-                {% trans time=post.publish_on|date(_("N j, Y, g:i a")) %}
+                {% trans trimmed time=post.publish_on|date(_("N j, Y, g:i a")) %}
                     posted on {{ time }}
                 {% endtrans %}
             </span>

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -103,7 +103,9 @@
                                     <span class="post-authors">{{ link_users(authors) }}</span>
                                 {%- endif -%}
                             {% endwith %}
-                            {{ relative_time(post.publish_on, abs=_('posted on {time}'), rel=_('posted {time}')) -}}
+                            {% with abs=_('posted on {time}'), rel=_('posted {time}') %}
+                                {{ relative_time(post.publish_on, abs=abs, rel=rel) }}
+                            {% endwith %}
                         </span><span class="comment-data">
                             <a href="{{ url('blog_post', post.id, post.slug) }}#comments" class="comment-count-link">
                                 <i class="fa fa-comments comment-icon"></i><span class="comment-count">

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -44,7 +44,9 @@
                                     {% endwith %}
                                     {{ link_user(node.author) }}&nbsp;
                                 </span>
-                                {{ relative_time(node.time, abs=_('commented on {time}'), rel=_('commented {time}')) }}
+                                {% with abs=_('commented on {time}'), rel=_('commented {time}') %}
+                                    {{ relative_time(node.time, abs=abs, rel=rel) }}
+                                {% endwith %}
                                 <span class="comment-spacer"></span>
                                 <span class="comment-operation">
                                 {% if node.revisions > 1 %}

--- a/templates/contest/ranking-table.html
+++ b/templates/contest/ranking-table.html
@@ -24,7 +24,9 @@
     {% if not contest.ended %}
         {% if not user.participation.ended %}
             <div class="start-time active">
-                {{ relative_time(user.participation.start, abs=_('Started on {time}'), rel=_('Started {time}')) }}
+                {% with abs=_('Started on {time}'), rel=_('Started {time}') %}
+                    {{ relative_time(user.participation.start, abs=abs, rel=rel) }}
+                {% endwith %}
             </div>
         {% else %}
             <div class="start-time">{{ _('Participation ended.') }}</div>

--- a/templates/ticket/message.html
+++ b/templates/ticket/message.html
@@ -7,7 +7,11 @@
     </div>
     <div class="detail">
         <div class="header">
-            <span class="time">{{ relative_time(message.time, abs=_('messaged on {time}'), rel=_('messaged {time}')) }}</span>
+            <span class="time">
+                {% with abs=_('messaged on {time}'), rel=_('messaged {time}') %}
+                    {{ relative_time(message.time, abs=abs, rel=rel) }}
+                {% endwith %}
+            </span>
             <span class="operation">
                 {% if perms.judge.change_ticket and perms.judge.change_ticketmessage %}
                     <a href="{{ url('admin:judge_ticket_change', ticket.id) }}"


### PR DESCRIPTION
- Prevent `relative_time` from caching its default arguments.
- Use `{% with %}` so that `makemessages` picks up on `abs` and `rel`.

How I tested it:
- Run `python manage.py makemessages -l en -e py,html,txt` and check that the `en` locale contains both `commented on {time}` and `commented {time}`
- Default arguments: visit `/submissions/`
- `posted on`: visit `/`
- `commented on`: visit `/post/1-first-post`
- `Started on`: idk
- `messaged on`: visit `/ticket/1`