### PR TITLE
Remove dead functions

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -37,10 +37,6 @@ two_factor_validators_by_length = {
 }
 
 
-def fix_unicode(string, unsafe=tuple('\u202a\u202b\u202d\u202e')):
-    return string + (sum(k in unsafe for k in string) - string.count('\u202c')) * '\u202c'
-
-
 class ProfileForm(ModelForm):
     if newsletter_id is not None:
         newsletter = forms.BooleanField(label=_('Subscribe to contest updates'), initial=False, required=False)

--- a/judge/template_context.py
+++ b/judge/template_context.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.utils.functional import SimpleLazyObject, new_method_proxy
 
 from judge.utils.caniuse import CanIUse, SUPPORT
-from .models import MiscConfig, NavigationBar, Profile
+from .models import MiscConfig, NavigationBar
 
 
 class FixedSimpleLazyObject(SimpleLazyObject):
@@ -32,12 +32,6 @@ def get_resource(request):
         'DMOJ_SCHEME': scheme,
         'DMOJ_CANONICAL': settings.DMOJ_CANONICAL,
     }
-
-
-def get_profile(request):
-    if request.user.is_authenticated:
-        return Profile.objects.get_or_create(user=request.user)[0]
-    return None
 
 
 def comet_location(request):

--- a/judge/utils/views.py
+++ b/judge/utils/views.py
@@ -1,24 +1,8 @@
 from django.shortcuts import render
-from django.utils.decorators import method_decorator
 from django.views.generic import FormView
 from django.views.generic.detail import SingleObjectMixin
 
 from judge.utils.diggpaginator import DiggPaginator
-
-
-def class_view_decorator(function_decorator):
-    """Convert a function based decorator into a class based decorator usable
-    on class based Views.
-
-    Can't subclass the `View` as it breaks inheritance (super in particular),
-    so we monkey-patch instead.
-    """
-
-    def simple_decorator(View):
-        View.dispatch = method_decorator(function_decorator)(View.dispatch)
-        return View
-
-    return simple_decorator
 
 
 def generic_message(request, title, message, status=None):

--- a/judge/views/stats.py
+++ b/judge/views/stats.py
@@ -1,4 +1,3 @@
-from itertools import chain, repeat
 from operator import itemgetter
 
 from django.conf import settings
@@ -13,10 +12,6 @@ from judge.utils.stats import chart_colors, get_bar_chart, get_pie_chart, highli
 
 
 ac_count = Count(Case(When(submission__result='AC', then=Value(1)), output_field=IntegerField()))
-
-
-def repeat_chain(iterable):
-    return chain.from_iterable(repeat(iterable))
 
 
 def language_data(request, language_count=Language.objects.annotate(count=Count('submission'))):


### PR DESCRIPTION
Bash script that found these functions:
```bash
for i in `grep -hr --include=*.py -oE "^def (\w*)" .` ; do
  if [ "$i" = "def" ] || `git grep -q "[^\w ]$i\W"` || `git grep -q "[^f] $i\W"` ; then
    :
  else
    echo $i
  fi
done
```

For these 4 functions, `git grep <name>` and `git log -G <name>` returned uninteresting results. These 4 functions are likely dead.