### PR TITLE
Fix filters that break i18n

### DIFF
--- a/judge/jinja2/timedelta.py
+++ b/judge/jinja2/timedelta.py
@@ -22,7 +22,7 @@ def seconds(timedelta):
     return timedelta.total_seconds()
 
 
-@registry.filter
+@registry.function
 @registry.render_with('time-remaining-fragment.html')
 def as_countdown(timedelta):
     return {'countdown': timedelta}

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -160,7 +160,7 @@
                                     <a href="{{ url('contest_view', contest.key) }}">{{ contest.name }}</a>
                                 </div>
                                 <div class="time">
-                                    {{ _('Ends in %(countdown)s.', countdown=contest.time_before_end|as_countdown) }}
+                                    {{ _('Ends in %(countdown)s.', countdown=as_countdown(contest.time_before_end)) }}
                                 </div>
                             </div>
                         {% endfor %}
@@ -178,7 +178,7 @@
                                     <a href="{{ url('contest_view', contest.key) }}">{{ contest.name }}</a>
                                 </div>
                                 <div class="time">
-                                    {{ _('Starting in %(countdown)s.', countdown=contest.time_before_start|as_countdown) }}
+                                    {{ _('Starting in %(countdown)s.', countdown=as_countdown(contest.time_before_start)) }}
                                 </div>
                             </div>
                         {% endfor %}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -30,26 +30,26 @@
                 {{- contest.start_time|utc|date('Y-m-d\TH:i:s') }}" class="date">
             {%- if contest.is_in_contest(request.user) and not request.participation.live -%}
                 {% if request.participation.spectate %}
-                    {{- _('Spectating, contest ends in %(countdown)s.', countdown=contest.time_before_end|as_countdown) -}}
+                    {{- _('Spectating, contest ends in %(countdown)s.', countdown=as_countdown(contest.time_before_end)) -}}
                 {% elif request.participation.end_time %}
-                    {{- _('Participating virtually, %(countdown)s remaining.', countdown=request.participation.time_remaining|as_countdown) -}}
+                    {{- _('Participating virtually, %(countdown)s remaining.', countdown=as_countdown(request.participation.time_remaining)) -}}
                 {% else %}
                     {{- _('Participating virtually.') -}}
                 {% endif %}
             {%- else -%}
                 {% if contest.start_time > now %}
-                    {{- _('Starting in %(countdown)s', countdown=contest.time_before_start|as_countdown) -}}
+                    {{- _('Starting in %(countdown)s', countdown=as_countdown(contest.time_before_start)) -}}
                 {% elif contest.end_time < now %}
                     {{- _('Contest is over.') -}}
                 {% else %}
                     {%- if has_joined -%}
                         {% if live_participation.ended %}
-                            {{- _('Your time is up! Contest ends in %(countdown)s.', countdown=contest.time_before_end|as_countdown) -}}
+                            {{- _('Your time is up! Contest ends in %(countdown)s.', countdown=as_countdown(contest.time_before_end)) -}}
                         {% else %}
-                            {{- _('You have %(countdown)s remaining.', countdown=live_participation.time_remaining|as_countdown) -}}
+                            {{- _('You have %(countdown)s remaining.', countdown=as_countdown(live_participation.time_remaining)) -}}
                         {% endif %}
                     {%- else -%}
-                        {{ _('Contest ends in %(countdown)s.', countdown=contest.time_before_end|as_countdown) }}
+                        {{ _('Contest ends in %(countdown)s.', countdown=as_countdown(contest.time_before_end)) }}
                     {%- endif -%}
                 {% endif %}
             {%- endif -%}

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -112,9 +112,11 @@
         {% endif %}
         <br>
         {% if contest.time_limit %}
-            {{ _('%(time_limit)s window', time_limit=contest.time_limit|timedelta('localized-no-seconds')) }}
+            {% set time_limit=contest.time_limit|timedelta('localized-no-seconds') %}
+            {{ _('%(time_limit)s window', time_limit=time_limit) }}
         {% else %}
-            {{ _('%(duration)s long', duration=contest.contest_window_length|timedelta('localized-no-seconds')) }}
+            {% set duration=contest.contest_window_length|timedelta('localized-no-seconds') %}
+            {{ _('%(duration)s long', duration=duration) }}
         {% endif %}
     </div>
 {% endmacro %}
@@ -177,9 +179,9 @@
                                     {% if contest.start_time %}
                                         <br>
                                         {% if contest.time_limit %}
-                                            <span class="time">{{ _('Window ends in %(countdown)s', countdown=participation.time_remaining|as_countdown) }}</span>
+                                            <span class="time">{{ _('Window ends in %(countdown)s', countdown=as_countdown(participation.time_remaining)) }}</span>
                                         {% elif contest.time_before_end %}
-                                            <span class="time">{{ _('Ends in %(countdown)s', countdown=contest.time_before_end|as_countdown) }}</span>
+                                            <span class="time">{{ _('Ends in %(countdown)s', countdown=as_countdown(contest.time_before_end)) }}</span>
                                         {% endif %}
                                         {{ time_left(contest) }}
                                     {% endif %}
@@ -218,7 +220,7 @@
                                 {% if contest.start_time %}
                                     <br>
                                     {% if contest.time_before_end %}
-                                        <span class="time">{{ _('Ends in %(countdown)s', countdown=contest.time_before_end|as_countdown) }}</span>
+                                        <span class="time">{{ _('Ends in %(countdown)s', countdown=as_countdown(contest.time_before_end)) }}</span>
                                     {% endif %}
                                     {{ time_left(contest) }}
                                 {% endif %}
@@ -252,7 +254,7 @@
                                 {% if contest.start_time %}
                                     <br>
                                     {% if contest.time_before_start %}
-                                        <span class="time">{{ _('Starting in %(countdown)s.', countdown=contest.time_before_start|as_countdown) }}</span>
+                                        <span class="time">{{ _('Starting in %(countdown)s.', countdown=as_countdown(contest.time_before_start)) }}</span>
                                     {% endif %}
                                     {{ time_left(contest) }}
                                 {% endif %}

--- a/templates/user/pp-row.html
+++ b/templates/user/pp-row.html
@@ -21,11 +21,12 @@
         <a href="{{ url('submission_status', breakdown.sub_id) }}">{{ breakdown.points|floatformat(0) }}pp</a>
     </div>
     <div class="pp-weighted">
-        {{ _('weighted %(percent)s', percent='<b>%s%%</b>'|safe|format(breakdown.weight|floatformat(0))) }}
-        {% if breakdown.scaled_points < 10 %}
-            ({{ _('%(pp).1fpp', pp=breakdown.scaled_points) }})
-        {% else %}
-            ({{ _('%(pp).0fpp', pp=breakdown.scaled_points) }})
-        {% endif %}
+        {% with percent='<b>%s%%</b>'|safe|format(breakdown.weight|floatformat(0)), pp=breakdown.scaled_points %}
+            {% if pp < 10 %}
+                {{ _('weighted %(percent)s (%(pp).1fpp)', percent=percent, pp=pp) }}
+            {% else %}
+                {{ _('weighted %(percent)s (%(pp).0fpp)', percent=percent, pp=pp) }}
+            {% endif %}
+        {% endwith %}
     </div>
 </div>

--- a/templates/user/pp-row.html
+++ b/templates/user/pp-row.html
@@ -21,12 +21,9 @@
         <a href="{{ url('submission_status', breakdown.sub_id) }}">{{ breakdown.points|floatformat(0) }}pp</a>
     </div>
     <div class="pp-weighted">
-        {% with percent='<b>%s%%</b>'|safe|format(breakdown.weight|floatformat(0)), pp=breakdown.scaled_points %}
-            {% if pp < 10 %}
-                {{ _('weighted %(percent)s (%(pp).1fpp)', percent=percent, pp=pp) }}
-            {% else %}
-                {{ _('weighted %(percent)s (%(pp).0fpp)', percent=percent, pp=pp) }}
-            {% endif %}
+        {% with percent='<b>%s%%</b>'|safe|format(breakdown.weight|floatformat(0)),
+                pp=breakdown.scaled_points|floatformat(1 if breakdown.scaled_points < 10 else 0) %}
+            {{ _('weighted %(percent)s (%(pp)spp)', percent=percent, pp=pp) }}
         {% endwith %}
     </div>
 </div>

--- a/templates/user/prepare-data.html
+++ b/templates/user/prepare-data.html
@@ -81,7 +81,8 @@
             <a class="button aux-download-action" href="{{ in_progress_url }}">{{ _('Track progress') }}</a>
         {% elif can_prepare_data %}
             <div class="alert alert-warning">
-                {{ _('You may only prepare a new data download once every %(ratelimit)s.', ratelimit=ratelimit|timedelta) }}
+                {% set duration=ratelimit|timedelta %}
+                {{ _('You may only prepare a new data download once every %(duration)s.', duration=duration) }}
                 <br>
                 {{ _('Once your data is ready, you will find a download link on this page.') }}
             </div>
@@ -131,7 +132,7 @@
             <div class="alert alert-warning">
                 {{ _('Your data is ready!') }}
                 <br>
-                {{ _('You will need to wait %(countdown)s to prepare a new data download.', countdown=time_until_can_prepare|as_countdown) }}
+                {{ _('You will need to wait %(countdown)s to prepare a new data download.', countdown=as_countdown(time_until_can_prepare)) }}
             </div>
             <a class="button aux-download-action" href="{{ url('user_download_data') }}">{{ _('Download data') }}</a>
         {% endif %}


### PR DESCRIPTION
These issues were found with `git grep "_(.*=.*|"`

- Change `as_countdown` to a `registry.function`. Fix issues with `|timedelta`. Fix pp messages.
- Test that all affected pages still work properly.
- Test that makemessages can find the i18n strings:
```
python manage.py makemessages -l en -e py,html,txt
git diff upstream/update-i18n -- locale/en/LC_MESSAGES/django.po
```