### PR TITLE
Translate the problem types in a dropdown

### DIFF
--- a/templates/problem/search-form.html
+++ b/templates/problem/search-form.html
@@ -52,7 +52,7 @@
                     <select id="types" name="type" multiple>
                         {% for type in problem_types %}
                             <option value="{{ type.id }}"{% if type.id in selected_types %} selected{% endif %}>
-                                {{ type.full_name }}
+                                {{ user_trans(type.full_name) }}
                             </option>
                         {% endfor %}
                     </select>


### PR DESCRIPTION
Go to `/problems/`. `ru` contains [a translation for `String Algorithms`](https://github.com/DMOJ/online-judge/blob/966b37d52fe88ec28fbd845cf31164a56d900c17/locale/ru/LC_MESSAGES/dmoj-user.po#L88-L89), so the dropdown looks like:

![Capture](https://user-images.githubusercontent.com/14223529/170855525-325df671-2e09-4051-986e-119c3d5ea46b.PNG)