### PR TITLE
Updated the memory limit help text shown in the problem editor from 64mb to 256mb

### DIFF
--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -145,7 +145,7 @@ class Problem(models.Model):
                                                MaxValueValidator(settings.DMOJ_PROBLEM_MAX_TIME_LIMIT)])
     memory_limit = models.PositiveIntegerField(verbose_name=_('memory limit'),
                                                help_text=_('The memory limit for this problem, in kilobytes '
-                                                           '(e.g. 64mb = 65536 kilobytes).'),
+                                                           '(e.g. 512mb = 524288 kilobytes).'),
                                                validators=[MinValueValidator(settings.DMOJ_PROBLEM_MIN_MEMORY_LIMIT),
                                                            MaxValueValidator(settings.DMOJ_PROBLEM_MAX_MEMORY_LIMIT)])
     short_circuit = models.BooleanField(verbose_name=_('short circuit'), default=False)

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -145,7 +145,7 @@ class Problem(models.Model):
                                                MaxValueValidator(settings.DMOJ_PROBLEM_MAX_TIME_LIMIT)])
     memory_limit = models.PositiveIntegerField(verbose_name=_('memory limit'),
                                                help_text=_('The memory limit for this problem, in kilobytes '
-                                                           '(e.g. 512mb = 524288 kilobytes).'),
+                                                           '(e.g. 256mb = 262144 kilobytes).'),
                                                validators=[MinValueValidator(settings.DMOJ_PROBLEM_MIN_MEMORY_LIMIT),
                                                            MaxValueValidator(settings.DMOJ_PROBLEM_MAX_MEMORY_LIMIT)])
     short_circuit = models.BooleanField(verbose_name=_('short circuit'), default=False)


### PR DESCRIPTION
At the moment, the help text for the memory limit in the problem editor shows 64mb. As this is a very low limit to use in 2022 (PyPy already takes more than 64mb), changing the text to a higher limit may encourage new problem setters to use a more appropriate memory limit.

![image](https://user-images.githubusercontent.com/9375453/171096024-f347f916-90a4-4c8d-b0a7-bcab1ccfc439.png)