### PR TITLE
i1160

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,10 @@ import sys
 try:
     import MySQLdb  # noqa: F401, imported for side effect
 except ImportError:
-    import dmoj_install_pymysql  # noqa: F401, imported for side effect
+    try:
+        import dmoj_install_pymysql  # noqa: F401, imported for side effect
+    except ImportError:
+         raise EnvironmentError('at least one of mysqlclient or pymysql must be installed')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dmoj.settings")

--- a/manage.py
+++ b/manage.py
@@ -8,7 +8,7 @@ except ImportError:
     try:
         import dmoj_install_pymysql  # noqa: F401, imported for side effect
     except ImportError:
-         raise EnvironmentError('at least one of mysqlclient or pymysql must be installed')
+        raise EnvironmentError('at least one of mysqlclient or pymysql must be installed')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dmoj.settings")


### PR DESCRIPTION
Looks like @Xyene forgot to merge this branch. The new stacktrace looks like:
```
(dmojsite) d@d:~/site$ python3 manage.py check
Traceback (most recent call last):
  File "/home/d/site/manage.py", line 6, in <module>
    import MySQLdb  # noqa: F401, imported for side effect
ModuleNotFoundError: No module named 'MySQLdb'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/d/site/manage.py", line 9, in <module>
    import dmoj_install_pymysql  # noqa: F401, imported for side effect
  File "/home/d/site/dmoj_install_pymysql.py", line 1, in <module>
    import pymysql
ModuleNotFoundError: No module named 'pymysql'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/d/site/manage.py", line 11, in <module>
    raise EnvironmentError('at least one of mysqlclient or pymysql must be installed')
OSError: at least one of mysqlclient or pymysql must be installed
(dmojsite) d@d:~/site$ 
```