### PR TITLE
i18n plurals in error messages

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -11,7 +11,8 @@ from django.core.validators import RegexValidator
 from django.db.models import Q
 from django.forms import BooleanField, CharField, ChoiceField, Form, ModelForm, MultipleChoiceField
 from django.urls import reverse_lazy
-from django.utils.translation import gettext_lazy as _
+from django.utils.text import format_lazy
+from django.utils.translation import gettext_lazy as _, ngettext_lazy
 
 from django_ace import AceWidget
 from judge.models import Contest, Language, Organization, Problem, Profile, Submission, WebAuthnCredential
@@ -24,7 +25,9 @@ two_factor_validators_by_length = {
     TOTP_CODE_LENGTH: {
         'regex_validator': RegexValidator(
             f'^[0-9]{{{TOTP_CODE_LENGTH}}}$',
-            _(f'Two-factor authentication tokens must be {TOTP_CODE_LENGTH} decimal digits.'),
+            format_lazy(ngettext_lazy('Two-factor authentication tokens must be {count} decimal digit.',
+                                      'Two-factor authentication tokens must be {count} decimal digits.',
+                                      TOTP_CODE_LENGTH), count=TOTP_CODE_LENGTH),
         ),
         'verify': lambda code, profile: not profile.check_totp_code(code),
         'err': _('Invalid two-factor authentication token.'),
@@ -73,8 +76,9 @@ class ProfileForm(ModelForm):
         max_orgs = settings.DMOJ_USER_MAX_ORGANIZATION_COUNT
 
         if sum(org.is_open for org in organizations) > max_orgs:
-            raise ValidationError(
-                _('You may not be part of more than {count} public organizations.').format(count=max_orgs))
+            raise ValidationError(ngettext_lazy('You may not be part of more than {count} public organization.',
+                                                'You may not be part of more than {count} public organizations.',
+                                                max_orgs).format(count=max_orgs))
 
         return self.cleaned_data
 

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -288,8 +288,11 @@ class OrganizationRequestView(OrganizationRequestBaseView):
                 to_approve = sum(form.cleaned_data['state'] == 'A' for form in formset.forms if form not in deleted_set)
                 can_add = organization.slots - organization.members.count()
                 if to_approve > can_add:
-                    messages.error(request, _('Your organization can only receive %d more members. '
-                                              'You cannot approve %d users.') % (can_add, to_approve))
+                    msg1 = ngettext('Your organization can only receive %d more member.',
+                                    'Your organization can only receive %d more members.', can_add) % can_add
+                    msg2 = ngettext('You cannot approve %d user.',
+                                    'You cannot approve %d users.', to_approve) % to_approve
+                    messages.error(request, msg1 + '\n' + msg2)
                     return self.render_to_response(self.get_context_data(object=organization))
 
             approved, rejected = 0, 0

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -144,7 +144,9 @@ class JoinOrganization(OrganizationMembershipChange):
         if profile.organizations.filter(is_open=True).count() >= max_orgs:
             return generic_message(
                 request, _('Joining organization'),
-                _('You may not be part of more than {count} public organizations.').format(count=max_orgs),
+                ngettext('You may not be part of more than {count} public organization.',
+                         'You may not be part of more than {count} public organizations.',
+                         max_orgs).format(count=max_orgs),
             )
 
         profile.organizations.add(org)


### PR DESCRIPTION
- Fix i18n issues with `TOTP_CODE_LENGTH`. Note: `TOTP_CODE_LENGTH` was introduced in #1708. I don't see why this variable is needed (mostly because 6 is still hardcoded in tons of other places). Feel free to suggest its removal.
- Support plurals in the max org error message.
- Fix plurals in this error modal:

![Capture](https://user-images.githubusercontent.com/14223529/187101120-fbaa4861-c985-4eec-93cb-e96d29ea9a41.PNG)

## Testing

`makemessages` can detect all i18n strings properly.

Go to `~/site/locale/ru/LC_MESSAGES/django.po`. Keep the header and delete everything else. Insert:
```po
#: judge/forms.py:28
#, python-brace-format
msgid "Two-factor authentication tokens must be {count} decimal digit."
msgid_plural "Two-factor authentication tokens must be {count} decimal digits."
msgstr[0] "p0 {count}"
msgstr[1] "p1 {count}"
msgstr[2] "p2 {count}"
msgstr[3] "p3 {count}"

#: judge/forms.py:83 judge/views/organization.py:147
#, python-brace-format
msgid "You may not be part of more than {count} public organization."
msgid_plural "You may not be part of more than {count} public organizations."
msgstr[0] "A {count}"
msgstr[1] "B {count}"
msgstr[2] "C {count}"
msgstr[3] "D {count}"
```

Run `python manage.py compilemessages`.

- Go to `/accounts/2fa/enable/`. Test `_lazy` by switching between `en` and `ru`. Play around with `TOTP_CODE_LENGTH = 6` to see the different plural forms.
- Go to `/edit/profile/`. Join organizations until you reach the max limit.
- Go to `/organization/<num>-<slug>`. Join until you reach the max limit.