### PR TITLE
Fix 500 error on /contest/<code>/leave

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -24,7 +24,7 @@ from django.utils.safestring import mark_safe
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _, gettext_lazy
 from django.views.generic import ListView, TemplateView
-from django.views.generic.detail import BaseDetailView, DetailView, SingleObjectMixin, View
+from django.views.generic.detail import DetailView, SingleObjectMixin, View
 from django.views.generic.list import BaseListView
 from icalendar import Calendar as ICalendar, Event
 from reversion import revisions
@@ -331,7 +331,7 @@ class ContestAccessCodeForm(forms.Form):
         self.fields['access_code'].widget.attrs.update({'autocomplete': 'off'})
 
 
-class ContestJoin(LoginRequiredMixin, ContestMixin, BaseDetailView):
+class ContestJoin(LoginRequiredMixin, ContestMixin, SingleObjectMixin, View):
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
         return self.ask_for_access_code()

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -430,7 +430,7 @@ class ContestJoin(LoginRequiredMixin, ContestMixin, BaseDetailView):
         })
 
 
-class ContestLeave(LoginRequiredMixin, ContestMixin, BaseDetailView):
+class ContestLeave(LoginRequiredMixin, ContestMixin, SingleObjectMixin, View):
     def post(self, request, *args, **kwargs):
         contest = self.get_object()
 


### PR DESCRIPTION
The 500 error: visit https://dmoj.ca/contest/cheerio1j/leave while logged in.

The issue is that a GET request goes to `BaseDetailView.get` then crashes at `self.render_to_response`. https://github.com/django/django/blob/5c3300027b30c1b498d99010f7d618316f685045/django/views/generic/detail.py#L103-L108

In the new version, GET requests receive error 405.

Also, `ContestJoin` doesn't need `BaseDetailView` because `ContestJoin` implements its own `get` method.