### PR TITLE
Fix regression caused by 42ee283; fixes #1970

### DIFF
--- a/resources/content-description.scss
+++ b/resources/content-description.scss
@@ -19,6 +19,7 @@
 
     #content-left {
         flex: 5;
+        width: 100%;
 
         &.split-common-content {
             width: 70%;


### PR DESCRIPTION
Turns out `width: 100%;` is in fact necessary to prevent the contest ranking page from overflowing.

This patch is currently applied in prod.