### PR TITLE
Allow sorting of organization's user list

### DIFF
--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -21,7 +21,7 @@ from reversion import revisions
 from judge.forms import EditOrganizationForm
 from judge.models import Class, Organization, OrganizationRequest, Profile
 from judge.utils.ranker import ranker
-from judge.utils.views import TitleMixin, generic_message
+from judge.utils.views import QueryStringSortMixin, TitleMixin, generic_message
 
 __all__ = ['OrganizationList', 'OrganizationHome', 'OrganizationUsers', 'OrganizationMembershipChange',
            'JoinOrganization', 'LeaveOrganization', 'EditOrganization', 'RequestJoinOrganization',
@@ -29,8 +29,8 @@ __all__ = ['OrganizationList', 'OrganizationHome', 'OrganizationUsers', 'Organiz
            'KickUserWidgetView', 'ClassHome', 'RequestJoinClass']
 
 
-def users_for_template(users):
-    return ranker(users.filter(is_unlisted=False).order_by('-performance_points', '-problem_count')
+def users_for_template(users, order):
+    return ranker(users.filter(is_unlisted=False).order_by(order)
                   .select_related('user').defer('about', 'user_script', 'notes'))
 
 
@@ -107,16 +107,20 @@ class OrganizationHome(OrganizationDetailView):
         return context
 
 
-class OrganizationUsers(OrganizationDetailView):
+class OrganizationUsers(QueryStringSortMixin, OrganizationDetailView):
     template_name = 'organization/users.html'
+    all_sorts = frozenset(('problem_count', 'rating', 'performance_points'))
+    default_desc = all_sorts
+    default_sort = '-performance_points'
 
     def get_context_data(self, **kwargs):
         context = super(OrganizationUsers, self).get_context_data(**kwargs)
         context['title'] = _('%s Members') % self.object.name
-        context['users'] = users_for_template(self.object.members)
+        context['users'] = users_for_template(self.object.members, self.order)
         context['partial'] = True
         context['is_admin'] = self.can_edit_organization()
         context['kick_url'] = reverse('organization_user_kick', args=[self.object.id, self.object.slug])
+        context.update(self.get_sort_context())
         return context
 
 
@@ -395,14 +399,18 @@ class ClassMixin(TitleMixin, SingleObjectTemplateResponseMixin, SingleObjectMixi
         return self.render_to_response(context)
 
 
-class ClassHome(ClassMixin, DetailView):
+class ClassHome(QueryStringSortMixin, ClassMixin, DetailView):
     template_name = 'organization/class.html'
+    all_sorts = frozenset(('problem_count', 'rating', 'performance_points'))
+    default_desc = all_sorts
+    default_sort = '-performance_points'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['logo_override_image'] = self.object.organization.logo_override_image
-        context['users'] = users_for_template(self.object.members)
+        context['users'] = users_for_template(self.object.members, self.order)
         context['is_admin'] = False  # Don't allow kicking here
+        context.update(self.get_sort_context())
         return context
 
     def get_content_title(self):

--- a/resources/users.scss
+++ b/resources/users.scss
@@ -54,6 +54,18 @@ th.header.rank {
             background: #fff897;
         }
     }
+
+    th a {
+        color: white;
+
+        &:link, &:visited {
+            color: white;
+        }
+
+        &:hover {
+            color: #0F0;
+        }
+    }
 }
 
 #search-form {

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -29,14 +29,6 @@
             display: inline !important;
         }
 
-        #users-table th a, #users-table th a:link, #users-table th a:visited {
-            color: white;
-        }
-
-        #users-table th a:hover {
-            color: #0F0;
-        }
-
         #users-table td a:hover {
             text-decoration: underline;
         }

--- a/templates/user/list.html
+++ b/templates/user/list.html
@@ -6,10 +6,6 @@
             border-right: none;
             text-align: left;
         }
-
-        #users-table th a {
-            color: white;
-        }
     </style>
 {% endblock %}
 


### PR DESCRIPTION
Closes #1483. Makes #1533 redundant.

Allows sorting for the organization user list, and the class user list.

Also, clean up the css so that the headers are displayed as white.