### PR TITLE
Add i18n to server-side messages

### DIFF
--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -73,8 +73,8 @@ class ContestProblemInline(SortableInlineAdminMixin, admin.TabularInline):
     def rejudge_column(self, obj):
         if obj.id is None:
             return ''
-        return format_html('<a class="button rejudge-link" href="{}">Rejudge</a>',
-                           reverse('admin:judge_contest_rejudge', args=(obj.contest.id, obj.id)))
+        return format_html('<a class="button rejudge-link" href="{0}">{1}</a>',
+                           reverse('admin:judge_contest_rejudge', args=(obj.contest.id, obj.id)), _('Rejudge'))
     rejudge_column.short_description = ''
 
 

--- a/judge/admin/runtime.py
+++ b/judge/admin/runtime.py
@@ -50,7 +50,7 @@ class GenerateKeyTextInput(TextInput):
         text = super(TextInput, self).render(name, value, attrs)
         return mark_safe(text + format_html(
             """\
-<a href="#" onclick="return false;" class="button" id="id_{0}_regen">Regenerate</a>
+<a href="#" onclick="return false;" class="button" id="id_{0}_regen">{1}</a>
 <script type="text/javascript">
 django.jQuery(document).ready(function ($) {{
     $('#id_{0}_regen').click(function () {{
@@ -61,7 +61,7 @@ django.jQuery(document).ready(function ($) {{
     }});
 }});
 </script>
-""", name))
+""", name, _('Regenerate')))
 
 
 class JudgeAdminForm(ModelForm):

--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -9,6 +9,7 @@ from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext, gettext_lazy as _, ngettext, pgettext
 from reversion.admin import VersionAdmin
@@ -244,9 +245,10 @@ class SubmissionAdmin(VersionAdmin):
 
     def judge_column(self, obj):
         if obj.is_locked:
-            return format_html('<input type="button" disabled value="Locked"/>')
+            return format_html('<input type="button" disabled value="{0}"/>', _('Locked'))
         else:
-            return format_html('<input type="button" value="Rejudge" onclick="location.href=\'{}/judge/\'" />', obj.id)
+            return format_html('<input type="button" value="{0}" onclick="location.href=\'{1}\'"/>', _('Rejudge'),
+                               reverse('admin:judge_submission_rejudge', args=(obj.id,)))
     judge_column.short_description = ''
 
     def get_urls(self):

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -752,8 +752,10 @@ class ContestParticipationList(LoginRequiredMixin, ContestRankingBase):
 
     def get_title(self):
         if self.profile == self.request.profile:
-            return _('Your participation in %s') % self.object.name
-        return _("%s's participation in %s") % (self.profile.username, self.object.name)
+            return _('Your participation in %(contest)s') % {'contest': self.object.name}
+        return _("%(user)s's participation in %(contest)s") % {
+            'user': self.profile.username, 'contest': self.object.name,
+        }
 
     def get_ranking_list(self):
         if not self.object.can_see_full_scoreboard(self.request.user) and self.profile != self.request.profile:

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -618,13 +618,13 @@ class ProblemSubmit(LoginRequiredMixin, ProblemMixin, TitleMixin, SingleObjectFo
             Submission.objects.filter(user=self.request.profile, rejudged_date__isnull=True)
                               .exclude(status__in=['D', 'IE', 'CE', 'AB']).count() >= settings.DMOJ_SUBMISSION_LIMIT
         ):
-            return HttpResponse('<h1>You submitted too many submissions.</h1>', status=429)
+            return HttpResponse(format_html('<h1>{0}</h1>', _('You submitted too many submissions.')), status=429)
         if not self.object.allowed_languages.filter(id=form.cleaned_data['language'].id).exists():
             raise PermissionDenied()
         if not self.request.user.is_superuser and self.object.banned_users.filter(id=self.request.profile.id).exists():
             return generic_message(self.request, _('Banned from submitting'),
                                    _('You have been declared persona non grata for this problem. '
-                                     'You are permanently barred from submitting this problem.'))
+                                     'You are permanently barred from submitting to this problem.'))
         # Must check for zero and not None. None means infinite submissions remaining.
         if self.remaining_submission_count == 0:
             return generic_message(self.request, _('Too many submissions'),
@@ -678,7 +678,7 @@ class ProblemSubmit(LoginRequiredMixin, ProblemMixin, TitleMixin, SingleObjectFo
                 request.user.username,
                 kwargs.get(self.slug_url_kwarg),
             )
-            return HttpResponseForbidden('<h1>Do you want me to ban you?</h1>')
+            return HttpResponseForbidden(format_html('<h1>{0}</h1>', _('Do you want me to ban you?')))
 
     def dispatch(self, request, *args, **kwargs):
         submission_id = kwargs.get('submission')


### PR DESCRIPTION
Affected pages:

- `/admin/judge/contest/1/change/` > Problems > Rejudge column
- `/admin/judge/judge/add/` > Regenerate button
- `/admin/judge/submission/` > Rejudge button (and Locked button, if sub is locked)
- `/contest/c1/participations/<user>` page's title
- Too many running submissions
- Submit to an unviewable problem