### PR TITLE
Add i18n to js messages

### DIFF
--- a/templates/comments/media-js.html
+++ b/templates/comments/media-js.html
@@ -90,7 +90,7 @@
                             on_success();
                     },
                     error: function (data, textStatus, jqXHR) {
-                        alert('Could not vote: ' + data.responseText);
+                        alert('{{ _('Could not vote: {error}') }}'.replace('{error}', data.responseText));
                     }
                 });
             }
@@ -126,7 +126,7 @@
             var $comments = $('.comments');
             $comments.find('a.hide-comment').click(function (e) {
                 e.preventDefault();
-                if (!(e.ctrlKey || e.metaKey || confirm('Are you sure you want to hide this comment?')))
+                if (!(e.ctrlKey || e.metaKey || confirm('{{ _('Are you sure you want to hide this comment?') }}')))
                     return;
 
                 var id = $(this).attr('data-id');
@@ -134,7 +134,7 @@
                     $('#comment-' + id).remove();
                     $('#comment-' + id + '-children').remove();
                 }).catch(function () {
-                    alert('Failed.');
+                    alert('{{ _('Could not hide comment.') }}');
                 });
             });
 
@@ -169,10 +169,12 @@
                                 if (window.add_code_copy_buttons)
                                     window.add_code_copy_buttons($area);
                                 var $edits = $comment.find('.comment-edits').first();
-                                $edits.text('updated');
+                                $edits.text('{{ _('updated') }}');
                             }).fail(function () {
-                                console.log('Failed to update comment:' + id);
+                                alert('{{ _('Failed to update comment body.') }}');
                             });
+                        }).fail(function (data) {
+                            alert('{{ _('Could not edit comment: {error}') }}'.replace('{error}', data.responseText));
                         });
                     });
                 },

--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -1,15 +1,10 @@
 {% extends "base.html" %}
 
 {% block js_media %}
-    <script type="text/javascript">
-        window.valid_files = {{valid_files_json}};
-
-        $(function () {
-        });
-    </script>
     <script type="text/javascript" src="{{ static('libs/jquery-sortable.js') }}"></script>
     <script type="text/javascript" src="{{ static('libs/featherlight/featherlight.min.js') }}"></script>
     <script type="text/javascript">
+        window.valid_files = {{ valid_files_json }};
         $(function () {
             function autofill_if_exists($select, file) {
                 if (!$select.val() && ~window.valid_files.indexOf(file))
@@ -72,7 +67,7 @@
                 var $precision = $('<input>', {
                     type: 'number',
                     value: try_parse_json($args.val()).precision || 6,
-                    title: 'precision (decimal digits)',
+                    title: '{{ _('precision (decimal digits)') }}',
                     style: 'width: 4em'
                 }).change(function () {
                     if ($checker.val().startsWith('floats'))

--- a/templates/submission/list.html
+++ b/templates/submission/list.html
@@ -32,7 +32,7 @@
             <script type="text/javascript">
                 window.rejudge_submission = function (id, e) {
                     if ((typeof e !== 'undefined' && e.ctrlKey) ||
-                        confirm('Are you sure you want to rejudge?')) {
+                        confirm('{{ _('Are you sure you want to rejudge?') }}')) {
                         $.ajax({
                             url: '{{ url('submission_rejudge') }}',
                             type: "POST",
@@ -248,7 +248,7 @@
     {% if dynamic_update and last_msg %}
         <script type="text/javascript">
             $(function () {
-                load_dynamic_update({{last_msg}});
+                load_dynamic_update({{ last_msg }});
             });
         </script>
     {% endif %}

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -314,7 +314,7 @@
     {% if last_msg %}
         <script type="text/javascript">
             $(function () {
-                load_dynamic_update({{last_msg}});
+                load_dynamic_update({{ last_msg }});
             });
         </script>
     {% endif %}

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -202,7 +202,7 @@
                         update_ticket_state(open);
                     },
                     error: function (data) {
-                        alert('Could not change ticket: ' + data.responseText);
+                        alert('{{ _('Could not change ticket: {error}') }}'.replace('{error}', data.responseText));
                     }
                 });
             });


### PR DESCRIPTION
Translate these messages:

- error when voting, e.g. attempt to self-vote
- warning popup when hiding comment
- error when hiding comment
- "updated" message after editing a comment
- `/problem/aplusb/test_data` > Checker > select Floats > hover over input box
- error when closing/opening ticket