### PR TITLE
Increase precision on relative time offsets

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -79,12 +79,11 @@
         <script src="{{ static('libs/jquery-cookie.js') }}"></script>
         <script src="{{ static('libs/jquery-taphold.js') }}"></script>
         <script src="{{ static('libs/jquery.unveil.js') }}"></script>
-        <script src="{{ static('libs/moment.js') }}"></script>
         <script src="{{ static('libs/select2/select2.js') }}"></script>
         {% include "extra_js.html" %}
         <script src="{{ static('common.js') }}"></script>
         <script>
-            moment.locale('{{ LANGUAGE_CODE }}');
+            set_date_locale('{{ LANGUAGE_CODE }}');
             $(function () {
                 $('img.unveil').unveil(200);
             });


### PR DESCRIPTION
Fixes #1846. Makes moment.js redundant. The new relative time messages will be:

- `1 second` to `119 seconds`
- `2 minutes` to `179 minutes`
- `3 hours` to `47 hours`
- `2 days` to `99 days`

This diff is friendly towards i18n. German example:

![Capture](https://user-images.githubusercontent.com/14223529/185314893-ea0b291e-0669-4e67-8b01-3d239e0fdc13.PNG)

As a failsafe, always use absolute time if the browser doesn't support `Math.trunc` and `Intl.RelativeTimeFormat`. For example, IE11.