### PR TITLE
Improve styling of password reset email

### DIFF
--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,16 +1,14 @@
-<span style="display:block;margin: 0 2px;padding: 1em;border: 3px solid #FFDE05;background-color: #000;border-radius: 6px;font-size: .95em;color: #444;margin-bottom:0.75em">
-<div style="display:table;margin-left:2em"><img src="https://avatars1.githubusercontent.com/u/6934864?v=3&s=101" style="display:inline;vertical-align: middle">
-<h1 style="font-size:4em;display:inline;vertical-align: middle"><a href="{{ protocol }}://{{ domain }}" style="text-decoration:none;color:gray"><span style="color: #FFDE05">DM::</span>OJ</a>
-      </h1>
-</div>
-</span>
-<div style="display:block;margin: 0 2px;padding: 1em;border: 3px solid #2980B9;background-color: #f8f8f8;border-radius: 6px;font-size: .95em;color: #444;">
+<div style="border:2px solid #fd0;margin:4px 0;"><div style="background:#000;border:6px solid #000;">
+<a href="{{ protocol }}://{{ domain }}"><img src="{{ protocol }}://{{ domain }}/static/icons/logo.svg" alt="{{ site_name }}" width="160" height="44"></a>
+</div></div>
 
-<b>{{ _("Forgot your password on the %(site_name)s? Don't worry!", site_name=site_name) }}</b><br><br>
-{{ _('To reset the password for your account "%(username)s", click the button below.', username=user.get_username()) }}
-<p align="center">
-<a href="{{ protocol }}://{{ domain }}{{ url('password_reset_confirm', uidb64=uid, token=token) }}" style="cursor: pointer;display:block;text-align: center;padding: 4px 2px 5px;color: white;border: 1px solid #666;border-radius: 1px;background: #2980b9;background: linear-gradient(180deg, #00aee0, #2980b9);text-decoration: none;line-height:2em;font-size:1em;width:12em;">{{ _('Reset Password') }}</a>
-</p>
+<div style="border:2px solid #337ab7;margin:4px 0;"><div style="background:#fafafa;border:12px solid #fafafa;font-family:segoe ui,lucida grande,Arial,sans-serif;font-size:14px;">
+<strong>{{ _("Forgot your password on the %(site_name)s? Don't worry!", site_name=site_name) }}</strong>
+<br><br>
+{{ _('To reset the password for your account "%(username)s", click the link below.', username=user.get_username()) }}
+<br><br>
+<a href="{{ protocol }}://{{ domain }}{{ url('password_reset_confirm', uidb64=uid, token=token) }}">{{ protocol }}://{{ domain }}{{ url('password_reset_confirm', uidb64=uid, token=token) }}</a>
+<br><br>
 {% if site_admin_email %}
 {% with link='<a href="mailto:%(email)s">%(email)s</a>'|safe|format(email=site_admin_email) %}
 {{ _('See you soon! If you have problems resetting your password, feel free to shoot us an email at %(email)s.', email=link) }}
@@ -18,4 +16,4 @@
 {% else %}
 {{ _('See you soon!') }}
 {% endif %}
-</div>
+</div></div>


### PR DESCRIPTION
Make the email fit DMOJ's theme. Before and after:

![Capture](https://user-images.githubusercontent.com/14223529/198930856-bfcab30b-ad70-4e72-ba8d-51e520e69932.PNG)

This email displays correctly on Outlook, too.
Note: Buttons are impossible to style correctly on Outlook, so I used a link instead.