### PR TITLE
Delete & Prevent zombie editorials (Closes #1958)

### DIFF
--- a/judge/migrations/0136_remove_zombie_editorials.py
+++ b/judge/migrations/0136_remove_zombie_editorials.py
@@ -1,0 +1,23 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def delete_null_solutions(apps, scheme_editor):
+    model = apps.get_model('judge', 'Solution')
+    model.objects.filter(problem=None).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0135_disable_judge'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_null_solutions),
+        migrations.AlterField(
+            model_name='solution',
+            name='problem',
+            field=models.OneToOneField(blank=True, on_delete=django.db.models.deletion.CASCADE, related_name='solution', to='judge.Problem', verbose_name='associated problem'),
+        ),
+    ]

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -529,8 +529,8 @@ class LanguageLimit(models.Model):
 
 
 class Solution(models.Model):
-    problem = models.OneToOneField(Problem, on_delete=SET_NULL, verbose_name=_('associated problem'),
-                                   null=True, blank=True, related_name='solution')
+    problem = models.OneToOneField(Problem, on_delete=CASCADE, verbose_name=_('associated problem'),
+                                   blank=True, related_name='solution')
     is_public = models.BooleanField(verbose_name=_('public visibility'), default=False)
     publish_on = models.DateTimeField(verbose_name=_('publish date'))
     authors = models.ManyToManyField(Profile, verbose_name=_('authors'), blank=True)


### PR DESCRIPTION
This PR deletes editorials with problem=None (deleted problems), and auto-deletes editorials when problems are deleted in the future.

Tested by adding an editorial to the Hello World problem in the demo, deleting the Hello World problem, verifying in the shell that the editorial still exists in the current DMOJ:master@head commit. Then applied the patch, ran `python3 manage.py migrate`, verified that the editorial no longer exists in the shell. Then recreated the instance but with the patch from the beginning this time, and verified that the editorial was deleted when the problem was deleted.

Closes #1958 