### PR TITLE
Change how username is displayed in tickets

### DIFF
--- a/templates/ticket/message.html
+++ b/templates/ticket/message.html
@@ -2,11 +2,11 @@
     <div class="info">
         <a href="{{ url('user_page', message.user.user.username) }}" class="user">
             <img src="{{ gravatar(message.user, 135) }}" class="gravatar">
-            <div class="username {{ message.user.css_class }}">{{ message.user.display_name }}</div>
         </a>
     </div>
     <div class="detail">
         <div class="header">
+            {{ link_user(message.user) }}&nbsp;
             <span class="time">
                 {% with abs=_('messaged on {time}'), rel=_('messaged {time}') %}
                     {{ relative_time(message.time, abs=abs, rel=rel) }}

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -340,7 +340,6 @@
                 <div class="info">
                     <a href="{{ url('user_page', request.user.username) }}" class="user">
                         <img src="{{ gravatar(request.user, 135) }}" class="gravatar">
-                        <div class="username {{ request.profile.css_class }}">{{ request.profile.display_name }}</div>
                     </a>
                 </div>
                 <div class="detail">


### PR DESCRIPTION
Partially do #1881.

* In existing message, move username from gravatar image to info header. This looks similar to comments.
* In new message tool, remove username from gravatar.

![Capture](https://user-images.githubusercontent.com/14223529/195031989-6c490313-f38b-408c-9304-dbff79c4cec2.PNG)