### PR TITLE
Fixup active tab having a pixel border drawn

### DIFF
--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -202,6 +202,7 @@ input {
 
     > ul {
         margin: 0;
+        margin-bottom: -1px;
         padding: 0;
         list-style: outside none none;
         display: flex;
@@ -209,7 +210,6 @@ input {
         overflow-y: hidden;
 
         > li {
-            margin-bottom: -1px;
             position: relative;
             display: block;
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1403503/198799395-35ef6d60-31c7-4064-ae3a-d939acbe9f5a.png)

After:
![image](https://user-images.githubusercontent.com/1403503/198799320-3a26eb5d-7ab5-4f4c-96a5-3da68561f16d.png)
