### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.7'
     - name: Install flake8
       run: pip install flake8 flake8-import-order flake8-future-import flake8-commas flake8-logging-format flake8-quotes
     - name: Lint with flake8
@@ -20,9 +20,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.7'
     - name: Cache pip
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
@@ -18,7 +18,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
@@ -44,7 +44,7 @@ jobs:
   styles:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Node 14
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/caniuse.yml
+++ b/.github/workflows/caniuse.yml
@@ -12,7 +12,7 @@ jobs:
       run: |
         curl -s https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json | python3 -m json.tool > resources/caniuse.json
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.REPO_SCOPED_TOKEN }}
         author: dmoj-build <build@dmoj.ca>

--- a/.github/workflows/caniuse.yml
+++ b/.github/workflows/caniuse.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.repository == 'DMOJ/online-judge'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download Can I use... data
       run: |
         curl -s https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json | python3 -m json.tool > resources/caniuse.json

--- a/.github/workflows/compilemessages.yml
+++ b/.github/workflows/compilemessages.yml
@@ -10,7 +10,7 @@ jobs:
   compilemessages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/compilemessages.yml
+++ b/.github/workflows/compilemessages.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.7'
     - name: Checkout submodules
       run: |
         git submodule init

--- a/.github/workflows/makemessages.yml
+++ b/.github/workflows/makemessages.yml
@@ -7,7 +7,7 @@ jobs:
   makemessages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/makemessages.yml
+++ b/.github/workflows/makemessages.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.7'
     - name: Checkout submodules
       run: |
         git submodule init

--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.repository == 'DMOJ/online-judge'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Python 3.7

--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -87,7 +87,7 @@ jobs:
           git reset --hard "$i18n_head"
         fi
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.REPO_SCOPED_TOKEN }}
         author: dmoj-build <build@dmoj.ca>

--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -11,9 +11,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.7'
     - name: Checkout submodules
       run: |
         git submodule init


### PR DESCRIPTION
Resolving:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/checkout