### PR TITLE
Fix submission table for 0 submissions

### DIFF
--- a/resources/user_profile.js
+++ b/resources/user_profile.js
@@ -82,7 +82,7 @@ function init_submission_table($, submission_activity, metadata, language_code) 
                 .append($('<td>').addClass('activity-blank').append('<div>'));
         }
 
-        var max_activity = Math.max.apply(null, days.map(function (obj) { return obj.activity; }));
+        var max_activity = Math.max(1, Math.max.apply(null, days.map(function (obj) { return obj.activity; })));
         days.forEach(function (obj) {
             var level = Math.ceil((obj.activity / max_activity) * (activity_levels - 1));
             var text = ngettext('%(cnt)d submission on %(date)s', '%(cnt)d submissions on %(date)s', obj.activity)


### PR DESCRIPTION
In the old code, `obj.activity / max_activity` can divide by 0, and break the ui.

New screenshot:

![Capture](https://user-images.githubusercontent.com/14223529/199132774-b6954337-5129-4431-ad15-7b2d64783fc2.PNG)