### PR TITLE
Clean up ContestCalendar css

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -443,12 +443,11 @@ class ContestLeave(LoginRequiredMixin, ContestMixin, SingleObjectMixin, View):
         return HttpResponseRedirect(reverse('contest_view', args=(contest.key,)))
 
 
-ContestDay = namedtuple('ContestDay', 'date weekday is_pad is_today starts ends oneday')
+ContestDay = namedtuple('ContestDay', 'date is_pad is_today starts ends oneday')
 
 
 class ContestCalendar(TitleMixin, ContestListMixin, TemplateView):
     firstweekday = SUNDAY
-    weekday_classes = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
     template_name = 'contest/calendar.html'
 
     def get(self, request, *args, **kwargs):
@@ -484,9 +483,9 @@ class ContestCalendar(TitleMixin, ContestListMixin, TemplateView):
         starts, ends, oneday = self.get_contest_data(make_aware(datetime.combine(calendar[0][0], time.min)),
                                                      make_aware(datetime.combine(calendar[-1][-1], time.min)))
         return [[ContestDay(
-            date=date, weekday=self.weekday_classes[weekday], is_pad=date.month != self.month,
+            date=date, is_pad=date.month != self.month,
             is_today=date == self.today, starts=starts[date], ends=ends[date], oneday=oneday[date],
-        ) for weekday, date in enumerate(week)] for week in calendar]
+        ) for date in week] for week in calendar]
 
     def get_context_data(self, **kwargs):
         context = super(ContestCalendar, self).get_context_data(**kwargs)

--- a/resources/contest.scss
+++ b/resources/contest.scss
@@ -5,17 +5,8 @@
     width: 100%;
 
     th {
-        border-bottom: 1px solid $border_gray;
-
-        &.sun {
-            border-left: 1px solid $border_gray;
-        }
-
-        &.sun, &.mon, &.tue, &.wed, &.thu, &.fri, &.sat {
-            font-size: 0.95em;
-            border-right: 1px solid $border_gray;
-            background: $background_light_gray;
-        }
+        border: 1px solid $border_gray;
+        background: $background_light_gray;
     }
 
     td {
@@ -25,8 +16,7 @@
         vertical-align: top;
         text-align: right;
         font-size: 0.75em;
-        border-right: 1px solid $border_gray;
-        border-bottom: 1px solid $border_gray;
+        border: 1px solid $border_gray;
         transition-duration: 0.2s;
 
         .num {
@@ -65,28 +55,23 @@
 
         &:hover {
             background: rgba(0, 0, 255, 0.3);
-            color: white;
 
             .num {
-                font-weight: bold;
+                color: white;
             }
 
             ul li a {
-                font-weight: normal;
+                color: white;
             }
         }
     }
 
     .noday {
-        background: #f1f1f1;
+        background: $background_gray;
     }
 
     .today {
         background: rgba(255, 255, 100, 0.5);
-    }
-
-    tr td:first-child {
-        border-left: 1px solid #aaa;
     }
 }
 

--- a/templates/contest/calendar.html
+++ b/templates/contest/calendar.html
@@ -19,7 +19,7 @@
         </tr>
         {% for week in calendar %}
             <tr>{% for day in week %}
-                <td class="{{ day.weekday }}{% if day.is_today %} today{% endif %}{% if day.is_pad %} noday{% endif %}">
+                <td class="{% if day.is_today %}today{% endif %}{% if day.is_pad %} noday{% endif %}">
                     <span class="num">{{ day.date.day }}</span>
                     <ul class="fa-ul">
                         {% for contest in day.starts %}


### PR DESCRIPTION
* `weekday_classes` is useless. It only affects `<th>`, but no `<th>` uses it.
* No need for `border-right/left/bottom`. `border` is enough because of `border-collapse: collapse;`.

New version of ContestCalendar:

![Capture](https://user-images.githubusercontent.com/14223529/201552098-fbd5cc0d-6fa0-4d6d-85f4-d70bf25f6abf.PNG)