### PR TITLE
Clean up table css

### DIFF
--- a/resources/table.scss
+++ b/resources/table.scss
@@ -16,38 +16,12 @@
         background: #f7f7f7;
     }
 
-    td:first-child {
-        border-color: $border_gray;
-        border-width: 1px 1px 0 1px;
-    }
-
-    tr:last-child td {
-        &:first-child {
-            border: 1px solid $border_gray;
-        }
-
-        border-color: $border_gray;
-        border-width: 1px 1px 1px 0;
-    }
-
-    thead th {
-        vertical-align: middle;
-
-        &:first-child {
-            border-top-left-radius: $table_header_rounding;
-        }
-
-        &:last-child {
-            border-top-right-radius: $table_header_rounding;
-        }
-    }
-
     th {
         height: 2em;
         color: #FFF;
         background-color: $widget_black;
         border-color: #555;
-        border-width: 1px 1px 0 0;
+        border-width: 0 1px 1px 0;
         border-style: solid;
         padding: 4px 10px;
         vertical-align: middle;
@@ -55,35 +29,36 @@
         white-space: nowrap;
         font-weight: 600;
         font-size: 1.1em;
-
-        &:first-child {
-            border-top-left-radius: $table_header_rounding;
-        }
-
-        &:last-child {
-            border-top-right-radius: $table_header_rounding;
-        }
     }
 
     td {
         border-color: $border_gray;
-        border-width: 1px 1px 0 0;
+        border-width: 0 1px 1px 0;
         border-style: solid;
         padding: 7px 5px;
         vertical-align: middle;
         text-align: center;
     }
 
-    // Monkey-patches for awkward table rounding
-    tr:not(:first-child) th {
-        border-radius: 0;
+    // Border fixes
+    th:first-child, td:first-child {
+        border-left-width: 1px;
     }
 
-    tr:last-child th {
+    tr:first-child th, tr:first-child td {
+        border-top-width: 1px;
+    }
+
+    // Rounded corners for <th>
+    tr:first-child th:first-child {
+        border-top-left-radius: $table_header_rounding;
+    }
+
+    tr:first-child th:last-child {
+        border-top-right-radius: $table_header_rounding;
+    }
+
+    tbody tr:last-child th:first-child {
         border-bottom-left-radius: $table_header_rounding;
-    }
-
-    thead tr th {
-        border-bottom-left-radius: 0 !important;
     }
 }


### PR DESCRIPTION
* Table in `/problems/` still looks ok. (There's a 2px border between `thead` and `tbody`, but I don't care enough to fix it.)
* Table in `/runtimes/matrix/` still looks ok. There are still 3 rounded corners.
* Problem statements that use `td rowspan` should look a little better. This affects most NOI problem statements. Before and after: ![Capture](https://user-images.githubusercontent.com/14223529/201576406-8ffc2565-f3b8-4194-86ce-9f9dcfb1c8e6.PNG)
