### PR TITLE
Clean up page tab's css

### DIFF
--- a/resources/base.scss
+++ b/resources/base.scss
@@ -498,11 +498,6 @@ noscript #noscript {
     display: inline-block;
 }
 
-.spacer {
-    display: inline-block;
-    flex: 1 1 1px;
-}
-
 #user-links {
     height: 100%;
 

--- a/resources/common.js
+++ b/resources/common.js
@@ -360,17 +360,3 @@ $.fn.textWidth = function () {
     $(this).html(html_org);
     return width;
 };
-
-$(function () {
-    $('.tabs').each(function () {
-        var $this = $(this), $h2 = $(this).find('h2'), $ul = $(this).find('ul');
-        var cutoff = ($h2.textWidth() || 400) + 20, handler;
-        $ul.children().each(function () {
-            cutoff += $(this).width();
-        });
-        $(window).resize(handler = function () {
-            $this.toggleClass('tabs-no-flex', $this.width() < cutoff);
-        });
-        handler();
-    });
-});

--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -170,10 +170,8 @@ input {
     margin: 0 0 8px;
     width: 100%;
     display: flex;
-
-    &.tabs-no-flex {
-        display: block;
-    }
+    justify-content: space-between;
+    flex-wrap: wrap;
 
     .tab {
         .tab-icon {

--- a/templates/contest/contest-list-tabs.html
+++ b/templates/contest/contest-list-tabs.html
@@ -15,7 +15,6 @@
             {% if prev_month or next_month %}|{% endif %}
             <a href="{{ url('contest_ical') }}">{{ _("Export") }}</a>
         </div>
-        <span class="spacer"></span>
     {% endif %}
 {% endblock %}
 

--- a/templates/tabs-base.html
+++ b/templates/tabs-base.html
@@ -6,13 +6,10 @@
     </li>
 {% endmacro %}
 
-<div class="page-title">
-    <div class="tabs">
-        <h2>{{ content_title or title }}</h2>
-        <span class="spacer"></span>
-        {% block post_tab_spacer %}{% endblock %}
-        <ul>
-            {% block tabs %}{% endblock %}
-        </ul>
-    </div>
+<div class="tabs">
+    <h2>{{ content_title or title }}</h2>
+    {% block post_tab_spacer %}{% endblock %}
+    <ul>
+        {% block tabs %}{% endblock %}
+    </ul>
 </div>

--- a/templates/user/user-base.html
+++ b/templates/user/user-base.html
@@ -16,13 +16,6 @@
             display: block;
             border-radius: 6px;
         }
-
-        .page-title {
-            display: -webkit-box;
-            display: -webkit-flex;
-            display: -ms-flexbox;
-            display: flex;
-        }
     </style>
 {% endblock %}
 


### PR DESCRIPTION
* `class="page-title"` is dead (and I have no idea why its css was in `templates/user/user-base.html`)
* `<span class="spacer"></span>` became redundant due to `justify-content: space-between;`
* Replace `tabs-no-flex` nonsense with `flex-wrap: wrap;`

The page tabs in `/contests/2022/11/` should behave a little more nicely now.

Example of `flex-wrap` doing something: ![Capture](https://user-images.githubusercontent.com/14223529/201601160-22a5662c-2d62-424d-b2a8-1ab20fd802f1.PNG)
