### PR TITLE
Introduce primary color in scss

### DIFF
--- a/resources/base-description.scss
+++ b/resources/base-description.scss
@@ -70,7 +70,7 @@
         height: 0;
         border: 0;
         font-style: italic;
-        border-bottom: 1px solid $border_gray;
+        border-bottom: 1px solid $color_primary25;
         margin: 25px 0 20px 0;
         padding: 0;
     }
@@ -86,7 +86,7 @@
         font-family: $monospace-fonts !important;
         margin: 0 2px;
         padding: 0 5px;
-        border: 1px solid $border_gray;
+        border: 1px solid $color_primary25;
         background-color: #f8f8f8;
         border-radius: $widget_border_radius;
         font-size: 0.95em;
@@ -108,7 +108,7 @@
         word-wrap: break-word;
         margin: 1.5em 0 1.5em 0;
         padding: 1em;
-        border: 1px solid $border_gray;
+        border: 1px solid $color_primary25;
         background-color: #f8f8f8;
         color: black;
         border-radius: $widget_border_radius;

--- a/resources/base.scss
+++ b/resources/base.scss
@@ -40,7 +40,7 @@ img {
 }
 
 table.sortable thead {
-    background-color: $background_gray;
+    background-color: $color_primary10;
     color: #666;
     font-weight: bold;
     cursor: default;
@@ -71,12 +71,12 @@ hr {
     height: 0;
     border: 0;
     font-style: italic;
-    border-bottom: 1px solid $border_gray;
+    border-bottom: 1px solid $color_primary25;
     padding: 0;
 }
 
 .dashed {
-    border-bottom: 1px dashed $border_gray;
+    border-bottom: 1px dashed $color_primary25;
 }
 
 th {
@@ -85,10 +85,10 @@ th {
 
 .form-area {
     display: inline-block;
-    background: $background_light_gray;
+    background: $color_primary5;
     padding: 5px 10px 10px 15px;
     border-radius: $widget_border_radius;
-    border: 1px solid $border_gray;
+    border: 1px solid $color_primary25;
 }
 
 div.info-float {
@@ -111,7 +111,7 @@ body {
     max-width: 107em;
     font-size: $base_font_size;
     line-height: 1.231;
-    background: $background_light_gray;
+    background: $color_primary5;
     font-family: "Segoe UI", "Lucida Grande", Arial, sans-serif;
     color: #000;
     height: 100%;
@@ -223,7 +223,7 @@ header {
 }
 
 #nav-container {
-    background: $widget_black;
+    background: $color_primary75;
 
     // opacity: 0.77
     // filter: alpha(opacity=77)
@@ -306,14 +306,14 @@ nav {
                 left: 5px;
                 display: none;
                 color: #fff;
-                background: $widget_black;
+                background: $color_primary75;
                 margin: 0 !important;
                 box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.4);
 
                 li {
                     &:first-child {
                         a.active {
-                            border-top: 1px solid $widget_black;
+                            border-top: 1px solid $color_primary75;
                         }
                     }
                 }
@@ -386,7 +386,7 @@ hr {
 footer {
     text-align: center;
     height: 40px;
-    border-top: 1px solid $border_gray;
+    border-top: 1px solid $color_primary25;
     background: #ededed;
 }
 
@@ -466,8 +466,8 @@ noscript #noscript {
     height: 47px;
     max-width: 107em;
     background: white;
-    border-right: 1px solid $border_gray;
-    border-left: 1px solid $border_gray;
+    border-right: 1px solid $color_primary25;
+    border-left: 1px solid $color_primary25;
 }
 
 #contest-info {
@@ -521,8 +521,8 @@ noscript #noscript {
     min-height: 100%;
     position: relative;
     margin: 0 auto;
-    border-right: 1px solid $border_gray;
-    border-left: 1px solid $border_gray;
+    border-right: 1px solid $color_primary25;
+    border-left: 1px solid $color_primary25;
     background: white;
 }
 
@@ -590,7 +590,7 @@ math {
         border-left: 4px solid $highlight_blue;
         position: fixed;
         top: 36px;
-        background: $widget_black;
+        background: $color_primary75;
         bottom: 0;
         width: 8em;
         left: 0;

--- a/resources/blog.scss
+++ b/resources/blog.scss
@@ -7,7 +7,7 @@
     margin-right: 0;
 
     .post {
-        border-bottom: 2px solid $border_gray;
+        border-bottom: 2px solid $color_primary25;
         padding-top: 0.5em;
 
         .title {
@@ -52,7 +52,7 @@
     .contest {
         padding: 1.25em 0 1.5em 0;
         text-align: center;
-        border-bottom: 1px solid $border_gray;
+        border-bottom: 1px solid $color_primary25;
 
         &:last-child {
             border-bottom: none;

--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -38,7 +38,7 @@ a {
     background: rgba(0, 0, 0, 0.1);
     padding: 5px 10px 5px 5px;
     margin-left: 30px;
-    border: 1px solid $border_gray;
+    border: 1px solid $color_primary25;
     border-radius: $widget_border_radius;
     display: flex;
 }
@@ -93,7 +93,7 @@ a {
 .comment-box {
     border-radius: $widget_border_radius;
     padding: 5px 10px 10px 15px;
-    border: 1px solid $border_gray;
+    border: 1px solid $color_primary25;
     background: rgba(0, 0, 0, 0.01);
 }
 

--- a/resources/contest.scss
+++ b/resources/contest.scss
@@ -5,8 +5,8 @@
     width: 100%;
 
     th {
-        border: 1px solid $border_gray;
-        background: $background_light_gray;
+        border: 1px solid $color_primary25;
+        background: $color_primary5;
     }
 
     td {
@@ -16,14 +16,14 @@
         vertical-align: top;
         text-align: right;
         font-size: 0.75em;
-        border: 1px solid $border_gray;
+        border: 1px solid $color_primary25;
         transition-duration: 0.2s;
 
         .num {
             font-size: 1.1em;
             font-weight: bold;
             display: block;
-            border-bottom: 1px dashed $border_gray;
+            border-bottom: 1px dashed $color_primary25;
             padding-right: 0.2em;
             margin-bottom: 0.4em;
         }
@@ -67,7 +67,7 @@
     }
 
     .noday {
-        background: $background_gray;
+        background: $color_primary10;
     }
 
     .today {

--- a/resources/table.scss
+++ b/resources/table.scss
@@ -19,7 +19,7 @@
     th {
         height: 2em;
         color: #FFF;
-        background-color: $widget_black;
+        background-color: $color_primary75;
         border-color: #555;
         border-width: 0 1px 1px 0;
         border-style: solid;
@@ -32,7 +32,7 @@
     }
 
     td {
-        border-color: $border_gray;
+        border-color: $color_primary25;
         border-width: 0 1px 1px 0;
         border-style: solid;
         padding: 7px 5px;

--- a/resources/users.scss
+++ b/resources/users.scss
@@ -281,7 +281,7 @@ a.edit-profile {
     }
 
     #submission-activity-display {
-        border: 1px solid $border_gray;
+        border: 1px solid $color_primary25;
         border-radius: $table_header_rounding;
 
         .info-bar {

--- a/resources/vars.scss
+++ b/resources/vars.scss
@@ -1,8 +1,13 @@
+$color_primary0: #fff;
+$color_primary5: #f8f8f8;   // light background
+$color_primary10: #eee;     // background
+$color_primary25: #ccc;     // border
+$color_primary50: #808080;
+$color_primary75: #3b3b3b;  // widget
+$color_primary90: #111;
+$color_primary100: #000;
+
 $highlight_blue: #2980B9;
-$widget_black: #3b3b3b;
-$border_gray: #ccc;
-$background_gray: #ededed;
-$background_light_gray: #fafafa;
 $announcement_red: #ae0000;
 
 $base_font_size: 14px;

--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -78,7 +78,7 @@ input {
         padding: 4px 8px;
         color: #555;
         background: #FFF none;
-        border: 1px solid $border_gray;
+        border: 1px solid $color_primary25;
         border-radius: $widget_border_radius;
         box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075) inset;
         transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
@@ -102,7 +102,7 @@ textarea {
     padding: 4px 8px;
     color: #555;
     background: #FFF none;
-    border: 1px solid $border_gray;
+    border: 1px solid $color_primary25;
     border-radius: $widget_border_radius;
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075) inset;
     transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
@@ -160,13 +160,13 @@ input {
     color: black;
     cursor: default;
     background-color: #fff;
-    border: 1px solid $border_gray;
+    border: 1px solid $color_primary25;
     border-bottom-color: transparent;
     border-image: none;
 }
 
 .tabs {
-    border-bottom: 1px solid $border_gray;
+    border-bottom: 1px solid $color_primary25;
     margin: 0 0 8px;
     width: 100%;
     display: flex;
@@ -279,7 +279,7 @@ ul.pagination {
                     line-height: 1.42857;
                     text-decoration: none;
                     color: #FFF;
-                    background-color: $widget_black;
+                    background-color: $color_primary75;
                     border: 1px solid #505050;
                     margin-left: -1px;
                 }
@@ -289,13 +289,13 @@ ul.pagination {
         .disabled-page > {
             a {
                 color: #888;
-                background-color: $widget_black;
+                background-color: $color_primary75;
                 border-color: #282828;
             }
 
             span {
                 color: #888;
-                background-color: $widget_black;
+                background-color: $color_primary75;
                 border-color: #505050;
             }
         }
@@ -425,7 +425,7 @@ ul.select2-selection__rendered {
 
 .sidebox h3 {
     margin: 0 -5px;
-    background: $widget_black;
+    background: $color_primary75;
     border-radius: $widget_border_radius $widget_border_radius 0 0;
     color: white;
     padding-top: 5px;
@@ -441,7 +441,7 @@ ul.select2-selection__rendered {
 }
 
 .sidebox-content {
-    border: 1px solid $border_gray;
+    border: 1px solid $color_primary25;
     border-top: none;
     margin: 0 -5px;
     padding: 1px 0.5em 3px;
@@ -526,8 +526,8 @@ ul.select2-selection__rendered {
 }
 
 details {
-    border: 1px solid $border_gray;
-    background: $background_light_gray;
+    border: 1px solid $color_primary25;
+    background: $color_primary5;
     padding: 5px 10px;
     border-radius: 4px;
 }


### PR DESCRIPTION
Part of #2035. Replace color names in `vars.scss` with names convenient for dark mode. The convention I'm using is `$color_<base name><percentage>`.

In a future pr, migrate hardcoded grays to `$color_primaryXX`.