### PR TITLE
Standardize SCSS gray colors

### DIFF
--- a/resources/base-description.scss
+++ b/resources/base-description.scss
@@ -17,7 +17,7 @@
 
     h1, h2, h3, h4, h5, h6 {
         font-weight: normal;
-        color: #111;
+        color: $color_primary90;
         margin-bottom: 0.75em;
         padding: 0;
         background: 0;
@@ -43,7 +43,7 @@
 
     h4 {
         font-size: 1.4em;
-        border-bottom: 1px solid #EEE;
+        border-bottom: 1px solid rgba($color_primary100, 0.1);
         line-height: 1.225;
         padding-bottom: 0.3em;
         padding-top: 0.5em;
@@ -59,10 +59,10 @@
     }
 
     blockquote {
-        color: #666;
+        color: $color_primary50;
         margin: 0;
         padding-left: 1.5em;
-        border-left: 0.5em #EEE solid;
+        border-left: 0.5em $color_primary10 solid;
     }
 
     hr {
@@ -76,7 +76,7 @@
     }
 
     pre, code, kbd, samp, span.code {
-        color: #000;
+        color: $color_primary100;
         page-break-inside: avoid;
         font-family: $monospace-fonts;
         font-size: 0.98em;
@@ -87,10 +87,10 @@
         margin: 0 2px;
         padding: 0 5px;
         border: 1px solid $color_primary25;
-        background-color: #f8f8f8;
+        background-color: $color_primary5;
         border-radius: $widget_border_radius;
         font-size: 0.95em;
-        color: #444;
+        color: $color_primary75;
     }
 
     pre {
@@ -101,7 +101,7 @@
             padding: 0;
             background: transparent;
             font-size: 1em;
-            color: black;
+            color: $color_primary100;
         }
 
         white-space: pre-wrap;
@@ -109,8 +109,8 @@
         margin: 1.5em 0 1.5em 0;
         padding: 1em;
         border: 1px solid $color_primary25;
-        background-color: #f8f8f8;
-        color: black;
+        background-color: $color_primary5;
+        color: $color_primary100;
         border-radius: $widget_border_radius;
     }
 

--- a/resources/base.scss
+++ b/resources/base.scss
@@ -97,7 +97,7 @@ div.info-float {
 }
 
 footer {
-    color: gray;
+    color: $color_primary50;
     display: block;
     width: 100%;
     position: absolute;
@@ -113,7 +113,7 @@ body {
     line-height: 1.231;
     background: $color_primary5;
     font-family: "Segoe UI", "Lucida Grande", Arial, sans-serif;
-    color: #000;
+    color: $color_primary100;
     height: 100%;
 }
 
@@ -223,7 +223,7 @@ header {
 }
 
 #nav-container {
-    background: $color_primary75;
+    background: #3b3b3b;
 
     // opacity: 0.77
     // filter: alpha(opacity=77)
@@ -306,14 +306,14 @@ nav {
                 left: 5px;
                 display: none;
                 color: #fff;
-                background: $color_primary75;
+                background: #3b3b3b;
                 margin: 0 !important;
                 box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.4);
 
                 li {
                     &:first-child {
                         a.active {
-                            border-top: 1px solid $color_primary75;
+                            border-top: 1px solid #3b3b3b;
                         }
                     }
                 }
@@ -379,7 +379,7 @@ hr {
     display: block;
 
     .title {
-        color: #393630;
+        color: $color_primary75;
     }
 }
 
@@ -387,7 +387,7 @@ footer {
     text-align: center;
     height: 40px;
     border-top: 1px solid $color_primary25;
-    background: #ededed;
+    background: $color_primary10;
 }
 
 html {
@@ -435,7 +435,7 @@ noscript #noscript {
 }
 
 .time {
-    color: #555;
+    color: $color_primary75;
 }
 
 .toggle {
@@ -523,7 +523,7 @@ noscript #noscript {
     margin: 0 auto;
     border-right: 1px solid $color_primary25;
     border-left: 1px solid $color_primary25;
-    background: white;
+    background: $color_pageBg;
 }
 
 // border-bottom: 1px solid rgb(204, 204, 204)
@@ -590,7 +590,7 @@ math {
         border-left: 4px solid $highlight_blue;
         position: fixed;
         top: 36px;
-        background: $color_primary75;
+        background: #3b3b3b;
         bottom: 0;
         width: 8em;
         left: 0;

--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -7,11 +7,11 @@
 
 a {
     &.upvote-link, &.downvote-link {
-        color: black;
+        color: $color_primary100;
     }
 
     &.voted {
-        text-shadow: 0 0 4px black, 0 0 9px blue;
+        text-shadow: 0 0 4px $color_primary100, 0 0 9px blue;
     }
 }
 
@@ -54,14 +54,14 @@ a {
 
 .comment-edits:not(:empty) {
     padding-right: 2px;
-    color: #444;
+    color: $color_primary75;
 }
 
 .comment-operation {
     flex: auto;
 
     .fa {
-        color: #444;
+        color: $color_primary75;
     }
 
     a + a {

--- a/resources/content-description.scss
+++ b/resources/content-description.scss
@@ -73,7 +73,7 @@ a.view-pdf {
 }
 
 .info-float .fa {
-    color: #000;
+    color: $color_primary100;
     padding-right: 0.2em;
 }
 

--- a/resources/contest.scss
+++ b/resources/contest.scss
@@ -12,7 +12,7 @@
     td {
         height: 110px;
         width: 170px;
-        color: #000;
+        color: $color_primary100;
         vertical-align: top;
         text-align: right;
         font-size: 0.75em;
@@ -44,7 +44,7 @@
 
                 a {
                     text-decoration: none;
-                    color: #222;
+                    color: $color_primary75;
 
                     &:hover {
                         text-decoration: underline;
@@ -76,9 +76,9 @@
 }
 
 #banner {
-    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+    border-bottom: 1px solid $color_primary25;
     padding-bottom: 1em;
-    color: rgb(85, 85, 85);
+    color: $color_primary75;
     font-size: $base_font_size;
 
     a.date {
@@ -162,7 +162,7 @@
     }
 
     a.contest-sort-link {
-        color: white;
+        color: $color_primary0;
     }
 }
 
@@ -201,7 +201,7 @@ form.contest-join-pseudotab {
     float: right;
 
     .fa {
-        color: #444;
+        color: $color_primary75;
     }
 
     a + a {

--- a/resources/misc.scss
+++ b/resources/misc.scss
@@ -8,11 +8,12 @@
     }
 
     .version-blank {
-        background: #eee;
+        background: $color_primary10;
     }
 
     .version-latest {
         background: #b3ff3fe6;
+        color: black;
     }
 
     .version-outdated {

--- a/resources/problem.scss
+++ b/resources/problem.scss
@@ -1,3 +1,5 @@
+@import "vars";
+
 #problem-table {
     td {
         &.category {
@@ -41,7 +43,7 @@
         transition: background-color linear 0.2s;
 
         &:hover {
-            background: #eaeaea;
+            background: rgba($color_primary100, 0.05);
         }
     }
 }
@@ -159,7 +161,7 @@ ul.problem-list {
 }
 
 .submissions-left {
-    color: black;
+    color: $color_primary100;
     font-weight: 600;
     text-align: center;
     margin-top: 0.5em;
@@ -175,19 +177,19 @@ ul.problem-list {
 }
 
 .organization-tag {
-    box-shadow: inset 0 -0.1em 0 rgba(0, 0, 0, 0.12);
+    box-shadow: inset 0 -0.1em 0 rgba($color_primary100, 0.12);
     padding: 0.15em 0.3em;
     border-radius: 0.15em;
     font-weight: 600;
     margin-right: 0.45em;
     position: relative;
-    background-color: #ccc;
+    background-color: $color_primary25;
     transform: translateY(+35%);
     display: inline-block;
 }
 
 .organization-tag a {
-    color: #000;
+    color: $color_primary100;
 }
 
 .pdf-icon {
@@ -215,7 +217,7 @@ ul.problem-list {
     font-size: 0.85em;
 
     a {
-        color: gray;
+        color: $color_primary50;
         text-decoration: none;
     }
 }

--- a/resources/ranks.scss
+++ b/resources/ranks.scss
@@ -1,5 +1,7 @@
+@import "vars";
+
 .admin a, .admin {
-    color: black !important;
+    color: $color_primary100 !important;
     font-weight: bold !important;
 }
 

--- a/resources/submission.scss
+++ b/resources/submission.scss
@@ -1,3 +1,5 @@
+@import "vars";
+
 .info-float {
     position: sticky;
     top: 60px;
@@ -5,7 +7,7 @@
 }
 
 #submissions-table {
-    background: rgba(0, 0, 0, .01);
+    background: rgba($color_primary100, .01);
 }
 
 .submissions-status-table {
@@ -14,13 +16,13 @@
 
 .submission-row {
     display: flex;
-    border-top: #ccc 1px solid;
-    border-left: #ccc 1px solid;
-    border-right: #ccc 1px solid;
+    border-top: $color_primary25 1px solid;
+    border-left: $color_primary25 1px solid;
+    border-right: $color_primary25 1px solid;
     transition: background-color linear 0.2s;
 
     &:hover {
-        background: #F2F2F2;
+        background: $color_primary10;
     }
 
     &:not(:empty) ~ & {
@@ -30,7 +32,7 @@
     > div {
         padding: 7px 5px;
         vertical-align: middle;
-        border-bottom: #ccc 1px solid;
+        border-bottom: $color_primary25 1px solid;
         display: flex;
         flex-direction: column;
         justify-content: center;
@@ -40,8 +42,8 @@
         min-width: 80px;
         width: 80px;
         text-align: center;
-        border-bottom-color: white;
-        border-right: #ccc 1px solid;
+        border-bottom-color: $color_primary0;
+        border-right: $color_primary25 1px solid;
 
         .state {
             font-size: 0.7em;
@@ -74,7 +76,7 @@
         }
 
         .sub-testcase {
-            color: #555;
+            color: $color_primary50;
             white-space: nowrap;
             padding-right: 5px;
         }
@@ -91,7 +93,7 @@
         width: 70px;
         white-space: nowrap;
         text-align: center;
-        border-left: #ccc 1px solid;
+        border-left: $color_primary25 1px solid;
 
         .time {
             font-weight: bold;
@@ -104,12 +106,12 @@
 }
 
 .sub-prop .grey-label {
-    color: grey;
+    color: $color_primary50;
     font-style: italic;
 }
 
 .sub-prop .grey-icon {
-    color: grey;
+    color: $color_primary50;
 }
 
 label[for="language"], label[for="status"] {
@@ -162,17 +164,17 @@ label[for="language"], label[for="status"] {
 }
 
 .submission-contest {
-    color: #555;
+    color: $color_primary75;
 }
 
 .source-ln {
-    color: gray;
-    border-right: 1px solid gray;
+    color: $color_primary50;
+    border-right: 1px solid $color_primary50;
     padding-right: 5px;
     text-align: right;
 
     a {
-        color: gray;
+        color: $color_primary50;
         display: block;
 
         &:hover {
@@ -252,7 +254,7 @@ label[for="language"], label[for="status"] {
         border: 1px solid #2980b9;
         border-left-width: .5em;
         border-radius: 4px;
-        color: #222;
+        color: $color_primary75;
     }
 
     .case-output {
@@ -340,6 +342,6 @@ label[for="language"], label[for="status"] {
     float: right;
 
     .submission-date {
-        color: gray;
+        color: $color_primary50;
     }
 }

--- a/resources/table.scss
+++ b/resources/table.scss
@@ -10,17 +10,17 @@
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 0.5em;
-    background: rgba(0, 0, 0, 0.01);
+    background: rgba($color_primary100, 0.01);
 
     &.striped tr:nth-child(even) {
-        background: #f7f7f7;
+        background: rgba($color_primary100, 0.03);
     }
 
     th {
         height: 2em;
-        color: #FFF;
+        color: $color_primary0;
         background-color: $color_primary75;
-        border-color: #555;
+        border-color: $color_primary50;
         border-width: 0 1px 1px 0;
         border-style: solid;
         padding: 4px 10px;

--- a/resources/users.scss
+++ b/resources/users.scss
@@ -47,7 +47,7 @@ th.header.rank {
         transition: background-color linear .2s;
 
         &:hover {
-            background: #EAEAEA;
+            background: $color_primary10;
         }
 
         &.highlight {
@@ -56,10 +56,10 @@ th.header.rank {
     }
 
     th a {
-        color: white;
+        color: $color_primary0;
 
         &:link, &:visited {
-            color: white;
+            color: $color_primary0;
         }
     }
 }
@@ -159,7 +159,7 @@ a.edit-profile {
     top: 50%;
     width: 100000px;
     height: 1px;
-    background: rgba(0, 0, 0, 0.2);
+    background: $color_primary25;
     right: 100%;
     margin-right: 5px;
 }
@@ -207,7 +207,7 @@ a.edit-profile {
     }
 
     .pp-weighted {
-        color: #777;
+        color: $color_primary50;
     }
 
     div.sub-pp {
@@ -233,7 +233,7 @@ a.edit-profile {
 
 #pp-load-link-wrapper {
     text-align: center;
-    border: 1px solid #ccc;
+    border: 1px solid $color_primary25;
 }
 
 #pp-load-more-link {
@@ -276,7 +276,7 @@ a.edit-profile {
         }
         #year {
             font-size: 1.25em;
-            color: #444;
+            color: $color_primary75;
         }
     }
 
@@ -302,7 +302,7 @@ a.edit-profile {
             font-size: 0.75em;
             line-height: 1;
             font-weight: 100;
-            color: #444;
+            color: $color_primary75;
         }
 
         #submission-total-count {

--- a/resources/vars.scss
+++ b/resources/vars.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $color_primary0: #fff;
 $color_primary5: #f8f8f8;   // light background
 $color_primary10: #eee;     // background
@@ -6,6 +8,8 @@ $color_primary50: #808080;
 $color_primary75: #3b3b3b;  // widget
 $color_primary90: #111;
 $color_primary100: #000;
+
+$color_pageBg: color.adjust($color_primary5, $lightness: 10%);
 
 $highlight_blue: #2980B9;
 $announcement_red: #ae0000;

--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -76,11 +76,11 @@ button:hover, button:hover, input[type=submit]:hover {
 input {
     &[type=text], &[type=password], &[type=email], &[type=number] {
         padding: 4px 8px;
-        color: #555;
-        background: #FFF none;
+        color: $color_primary75;
+        background: $color_primary0 none;
         border: 1px solid $color_primary25;
         border-radius: $widget_border_radius;
-        box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075) inset;
+        box-shadow: 0 1px 1px rgba($color_primary100, 0.075) inset;
         transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
         box-sizing: border-box;
 
@@ -100,37 +100,37 @@ input {
 
 textarea {
     padding: 4px 8px;
-    color: #555;
-    background: #FFF none;
+    color: $color_primary75;
+    background: $color_primary0 none;
     border: 1px solid $color_primary25;
     border-radius: $widget_border_radius;
-    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075) inset;
+    box-shadow: 0 1px 1px rgba($color_primary100, 0.075) inset;
     transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
     box-sizing: border-box;
 }
 
 textarea:hover {
     border-color: rgba(82, 168, 236, 0.8);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 4px rgba(82, 168, 236, 0.6);
+    box-shadow: inset 0 1px 1px rgba($color_primary100, 0.075), 0 0 4px rgba(82, 168, 236, 0.6);
 }
 
 input {
     &[type="text"]:hover, &[type="password"]:hover {
         border-color: rgba(82, 168, 236, 0.8);
-        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 4px rgba(82, 168, 236, 0.6);
+        box-shadow: inset 0 1px 1px rgba($color_primary100, 0.075), 0 0 4px rgba(82, 168, 236, 0.6);
     }
 }
 
 textarea:focus {
     border-color: rgba(82, 168, 236, 0.8);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+    box-shadow: inset 0 1px 1px rgba($color_primary100, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
     outline: 0;
 }
 
 input {
     &[type="text"]:focus, &[type="password"]:focus {
         border-color: rgba(82, 168, 236, 0.8);
-        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+        box-shadow: inset 0 1px 1px rgba($color_primary100, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
         outline: 0;
     }
 }
@@ -141,10 +141,10 @@ input {
     right: 0;
     display: block;
     font-size: 12px;
-    color: #767676;
+    color: $color_primary50;
     cursor: pointer;
-    background-color: #FFF;
-    border: 1px solid #E1E1E8;
+    background-color: $color_pageBg;
+    border: 1px solid $color_primary25;
     border-radius: 0 $widget_border_radius;
     position: absolute;
     padding: 5px 8px;
@@ -157,11 +157,10 @@ input {
 
 // Bootstrap-y tabs
 .ul_tab_a_active {
-    color: black;
+    color: $color_primary100;
     cursor: default;
-    background-color: #fff;
     border: 1px solid $color_primary25;
-    border-bottom-color: transparent;
+    border-bottom-color: $color_pageBg;
     border-image: none;
 }
 
@@ -176,7 +175,7 @@ input {
     .tab {
         .tab-icon {
             padding-right: 0.3em;
-            color: gray;
+            color: $color_primary50;
         }
 
         a, span {
@@ -189,13 +188,13 @@ input {
             }
 
             .tab-icon {
-                color: black;
+                color: $color_primary100;
             }
         }
     }
 
     h2 {
-        color: #393630;
+        color: $color_primary75;
     }
 
     > ul {
@@ -231,7 +230,7 @@ input {
                 position: relative;
                 display: block;
                 padding: 10px 15px;
-                color: #555;
+                color: $color_primary50;
                 text-decoration: none;
                 white-space: nowrap;
             }
@@ -241,8 +240,8 @@ input {
 
 // Bootstrap-y pagination
 ul.pagination a:hover {
-    color: #FFF;
-    background: rgba(0, 0, 0, 0.55);
+    color: $color_primary0;
+    background: rgba($color_primary100, 0.55);
 }
 
 ul.pagination {
@@ -278,38 +277,24 @@ ul.pagination {
                     padding: 4px 12px;
                     line-height: 1.42857;
                     text-decoration: none;
-                    color: #FFF;
+                    color: $color_primary0;
                     background-color: $color_primary75;
-                    border: 1px solid #505050;
+                    border: 1px solid $color_primary50;
                     margin-left: -1px;
                 }
             }
         }
 
         .disabled-page > {
-            a {
-                color: #888;
+            a, span {
+                color: $color_primary50;
                 background-color: $color_primary75;
-                border-color: #282828;
-            }
-
-            span {
-                color: #888;
-                background-color: $color_primary75;
-                border-color: #505050;
+                border-color: $color_primary50;
             }
         }
 
         .active-page > {
-            a {
-                z-index: 2;
-                color: #FFF;
-                background-color: $highlight_blue;
-                border-color: transparent;
-                cursor: default;
-            }
-
-            span {
+            a, span {
                 z-index: 2;
                 color: #FFF;
                 background-color: $highlight_blue;
@@ -413,7 +398,7 @@ a.close {
 }
 
 .form-submit-group {
-    border-top: 1px solid #EEE;
+    border-top: 1px solid rgba($color_primary100, 0.1);
     margin-top: 0.8em;
     padding-top: 0.5em;
     text-align: right;
@@ -427,7 +412,7 @@ ul.select2-selection__rendered {
     margin: 0 -5px;
     background: $color_primary75;
     border-radius: $widget_border_radius $widget_border_radius 0 0;
-    color: white;
+    color: $color_primary0;
     padding-top: 5px;
     padding-bottom: 5px;
     padding-left: 7px;
@@ -435,7 +420,7 @@ ul.select2-selection__rendered {
 }
 
 .sidebox h3 .fa {
-    color: white;
+    color: $color_primary0;
     float: right;
     margin: 0.2em 0.4em 0 0;
 }


### PR DESCRIPTION
Part of #2035.

* Update scss files with the proper grays. Lots of grays were rounded to the nearest `$color_primaryXX`.
* Don't invert colors in `nav`. (navbar's colors are already ok for dark mode)
* This pr shouldn't break anything. The original theme should continue to work.

Inverting the `$color_primaryXX` results in:
![Capture](https://user-images.githubusercontent.com/14223529/204124642-6947c70c-b80c-4b01-a416-c70587807139.PNG)

There are a few styling errors. Probably good enough for now.