### PR TITLE
Migrate text editor css to scss

### DIFF
--- a/judge/widgets/pagedown.py
+++ b/judge/widgets/pagedown.py
@@ -22,7 +22,7 @@ else:
         compress_js = True
 
         def __init__(self, *args, **kwargs):
-            kwargs.setdefault('css', ('pagedown_widget.css',))
+            kwargs.setdefault('css', ())
             super(PagedownWidget, self).__init__(*args, **kwargs)
 
 
@@ -64,5 +64,4 @@ else:
             }
 
         class Media:
-            css = {'all': ['dmmd-preview.css']}
             js = ['dmmd-preview.js']

--- a/resources/dmmd-preview.scss
+++ b/resources/dmmd-preview.scss
@@ -1,10 +1,12 @@
+@import "vars";
+
 div.dmmd-preview {
     padding: 0;
 }
 
 div.dmmd-preview-update {
-    background: #ccc;
-    color: #333;
+    background: $color_primary25;
+    color: $color_primary75;
     text-align: center;
     cursor: pointer;
     border-radius: 4px;
@@ -37,5 +39,5 @@ div.dmmd-no-button:not(.dmmd-preview-has-content) {
 }
 
 div.dmmd-preview-stale {
-	background: repeating-linear-gradient(-45deg, #fff, #fff 10px, #f8f8f8 10px, #f8f8f8 20px);
+	background: repeating-linear-gradient(-45deg, $color_primary0, $color_primary0 10px, $color_primary5 10px, $color_primary5 20px);
 }

--- a/resources/pagedown-widget.scss
+++ b/resources/pagedown-widget.scss
@@ -1,3 +1,5 @@
+@import "vars";
+
 .wmd-panel {
     margin: 0;
     width: 100%;
@@ -13,8 +15,8 @@
     height: 300px;
     width: 100%;
     max-width: 100%;
-    background: #fff;
-    border: 1px solid DarkGray;
+    background: $color_primary0;
+    border: 1px solid $color_primary50;
     font-family: Consolas, "Liberation Mono", Monaco, "Courier New", monospace !important;
 }
 
@@ -58,8 +60,8 @@
 }
 
 .wmd-prompt-dialog {
-    border: 1px solid #999999;
-    background-color: #F5F5F5;
+    border: 1px solid $color_primary25;
+    background-color: $color_primary5;
 }
 
 .wmd-prompt-dialog > div {
@@ -68,12 +70,12 @@
 }
 
 .wmd-prompt-dialog > form > input[type="text"] {
-    border: 1px solid #999999;
-    color: black;
+    border: 1px solid $color_primary25;
+    color: $color_primary100;
 }
 
 .wmd-prompt-dialog > form > input[type="button"] {
-    border: 1px solid #888888;
+    border: 1px solid $color_primary50;
     font-family: trebuchet MS, helvetica, sans-serif;
     font-size: 0.8em;
     font-weight: bold;
@@ -86,10 +88,10 @@
 .wmd-preview {
     margin-top: 15px;
     padding: 7px;
-    background: white;
+    background: $color_primary0;
     line-height: 1.5em;
     font-size: 1em;
-    border: 1px solid #a9a9a9;
+    border: 1px solid $color_primary50;
     border-radius: 5px;
     box-sizing: border-box;
 }

--- a/resources/style.scss
+++ b/resources/style.scss
@@ -9,6 +9,8 @@
 @import "content-description";
 @import "widgets";
 @import "comments";
+@import "pagedown-widget";
+@import "dmmd-preview";
 @import "submission";
 @import "contest";
 @import "misc";


### PR DESCRIPTION
Part of #2035. When `$color_primaryXX` is inverted, text editors will look like this:

![Capture](https://user-images.githubusercontent.com/14223529/205816344-0d302403-79b2-4533-a5e2-559a9d851dd8.PNG)

(the new scss files are super untidy, but that's a problem for another time)