### PR TITLE
Add scss variables for link colors

### DIFF
--- a/resources/base.scss
+++ b/resources/base.scss
@@ -18,14 +18,14 @@
 }
 
 a {
-    color: #1958c1;
+    color: $color_link75;
 
     &:hover {
-        color: #0645ad;
+        color: $color_link100;
     }
 
     &:active {
-        color: #faa700;
+        color: $color_link200;
     }
 }
 

--- a/resources/blog.scss
+++ b/resources/blog.scss
@@ -15,10 +15,14 @@
             font-size: 1.7em;
 
             a {
-                color: #5b80b9 !important;
+                color: $color_link50;
 
                 &:hover {
-                    color: #0645ad !important;
+                    color: $color_link100;
+                }
+
+                &:active {
+                    color: $color_link200;
                 }
             }
         }
@@ -56,19 +60,6 @@
 
         &:last-child {
             border-bottom: none;
-        }
-
-        .name {
-            font-size: 1.25em;
-            font-weight: 500;
-
-            a {
-                color: #5b80b9 !important;
-
-                &:hover {
-                    color: #0645ad !important;
-                }
-            }
         }
     }
 

--- a/resources/contest.scss
+++ b/resources/contest.scss
@@ -54,7 +54,7 @@
         }
 
         &:hover {
-            background: rgba(0, 0, 255, 0.3);
+            background: rgba($color_link100, 0.2);
 
             .num {
                 color: white;
@@ -71,7 +71,7 @@
     }
 
     .today {
-        background: rgba(255, 255, 100, 0.5);
+        background: rgba($color_link200, 0.2);
     }
 }
 
@@ -88,13 +88,14 @@
         line-height: 1.3;
         font-size: 2.3em;
         padding-bottom: 0.15em;
-
-        &:link, &:visited {
-            color: #5B80B9;
-        }
+        color: $color_link50;
 
         &:hover {
-            color: #0645AD;
+            color: $color_link100;
+        }
+
+        &:active {
+            color: $color_link200;
         }
     }
 

--- a/resources/users.scss
+++ b/resources/users.scss
@@ -9,7 +9,7 @@ tr {
     padding-bottom: 96px;
 
     &:target {
-        background: #fff897;
+        background: rgba($color_link200, 0.2);
     }
 }
 
@@ -47,11 +47,11 @@ th.header.rank {
         transition: background-color linear .2s;
 
         &:hover {
-            background: $color_primary10;
+            background: rgba($color_primary100, 0.05);
         }
 
         &.highlight {
-            background: #fff897;
+            background: rgba($color_link200, 0.2);
         }
     }
 
@@ -75,31 +75,6 @@ th.header.rank {
 
     .select2-selection__rendered {
         cursor: text;
-    }
-
-    .select2-results__option {
-        position: relative;
-    }
-
-    .select2-results__option--highlighted {
-        background-color: #DEDEDE !important;
-    }
-
-    li.select2-results__option--highlighted a.user-redirect {
-        display: inline-block;
-    }
-}
-
-a.user-redirect {
-    color: #2980b9;
-    vertical-align: middle;
-    font-size: 1.2em;
-    position: absolute;
-    right: 0.8em;
-    display: none;
-
-    &:hover {
-        text-shadow: 0 0 2px blue;
     }
 }
 

--- a/resources/vars.scss
+++ b/resources/vars.scss
@@ -9,6 +9,11 @@ $color_primary75: #3b3b3b;  // widget
 $color_primary90: #111;
 $color_primary100: #000;
 
+$color_link50: #5b80b9;     // default (title)
+$color_link75: #1958c1;     // default
+$color_link100: #0645ad;    // hover
+$color_link200: #faa700;    // active
+
 $color_pageBg: color.adjust($color_primary5, $lightness: 10%);
 
 $highlight_blue: #2980B9;

--- a/templates/ticket/list.html
+++ b/templates/ticket/list.html
@@ -30,39 +30,6 @@
                 top: 60px;
             }
         }
-
-        .select2-selection__arrow {
-            display: none;
-        }
-
-        .select2-selection__rendered {
-            cursor: text;
-        }
-
-        .select2-results__option {
-            position: relative;
-        }
-
-        .select2-results__option--highlighted {
-            background-color: #DEDEDE !important;
-        }
-
-        li.select2-results__option--highlighted a.user-redirect {
-            display: inline-block;
-        }
-
-        a.user-redirect {
-            color: #2980b9;
-            vertical-align: middle;
-            font-size: 1.2em;
-            position: absolute;
-            right: 0.8em;
-            display: none;
-        }
-
-        a.user-redirect:hover {
-            text-shadow: 0 0 2px blue;
-        }
     </style>
 {% endblock %}
 

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -22,14 +22,7 @@
                             'class': 'user-search-image', src: data.gravatar_url,
                             width: 24, height: 24
                         }))
-                        .append($('<span>', {'class': data.display_rank + ' user-search-name'}).text(data.text))
-                        .append($('<a>', {href: '/user/' + data.text, 'class': 'user-redirect'})
-                            .append($('<i>', {'class': 'fa fa-mail-forward'}))
-                            .mouseover(function () {
-                                in_user_redirect = true;
-                            }).mouseout(function () {
-                                in_user_redirect = false;
-                            }));
+                        .append($('<span>', {'class': data.display_rank + ' user-search-name'}).text(data.text));
                 }
             }).on('select2:selecting', function () {
                 return !in_user_redirect;


### PR DESCRIPTION
Part of #2035. Introduce `$color_linkXX` for link colors.

* `.blog-sidebox .contest .name` is dead, so delete css (it should have been `.blog-sidebox .contest .contest-list-title` but it looks fine as-is)
* Add `:active` to `/blog/1` blog post title link, `/contest/<name>` countdown link
* `#search-form .select2-results__option` is dead, so delete css
* Delete code for `a.user-redirect`. It looks like the arrow in this screenshot. However, it's been dead for years, and might make admins nostalgic.

![Capture](https://user-images.githubusercontent.com/14223529/206409995-cabfda0b-aa67-41fe-a3b4-f7784fe31131.PNG)