### PR TITLE
Make problem search more sane

### DIFF
--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -443,8 +443,9 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         if not points:
             return 0, 0, {}
         if len(points) == 1:
-            return points[0], points[0], {
+            return points[0] - 1, points[0] + 1, {
                 'min': points[0] - 1,
+                '50%': points[0],
                 'max': points[0] + 1,
             }
 
@@ -496,7 +497,7 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
             return generic_message(request, 'FTS syntax error', e.args[1], status=400)
 
     def post(self, request, *args, **kwargs):
-        to_update = ('hide_solved', 'show_types', 'full_text')
+        to_update = ('hide_solved', 'show_types', 'has_public_editorial', 'full_text')
         for key in to_update:
             if key in request.GET:
                 val = request.GET.get(key) == '1'


### PR DESCRIPTION
fixes these 2 issues:

1. go to `/problems/`. search for `a20`. get 1 result. clear `a20` and search again. see `point_start=5.0&point_end=5.0` in querystring.
2. go to `/problems/`. select all 4 checkboxes. click "PROBLEMS" in site header. see "Has editorial" get unselected.