### PR TITLE
fix page titles on dark mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -266,7 +266,7 @@
     <br>
     <main id="content">
         {% block title_row %}
-            <h2 style="color:#393630; display:inline">
+            <h2 style="display:inline">
                 {% block content_title %}
                     {% if content_title %}{{ content_title }}{% else %}{{ title }}{% endif %}
                 {% endblock %}

--- a/templates/problem/problem.html
+++ b/templates/problem/problem.html
@@ -69,7 +69,7 @@
                 </a>
             {% endif %}
         {% endif %}
-        <h2 style="color:#393630; display: inline-block">{{ title }}</h2>
+        <h2 style="display: inline-block">{{ title }}</h2>
         {% if problem.is_organization_private %}
             <span class="organization-tags">
                 {% for org in problem.organizations.all() %}

--- a/templates/problem/raw.html
+++ b/templates/problem/raw.html
@@ -55,7 +55,7 @@
 </head>
 
 <body>
-<h2 style="color:#393630; display: inline-block;">{{ problem_name }}</h2>
+<h2 style="display: inline-block;">{{ problem_name }}</h2>
 <hr>
 <div align="center" style="position: relative;">
     <div class="problem-info-entry">


### PR DESCRIPTION
By deleting the specified hex colour for page titles (that doesn't change in dark or light mode), this forces page titles to revert to `$color_primary90` which is defined [here]( https://github.com/DMOJ/online-judge/blob/master/resources/base-description.scss#L20) and variable based on either dark or light mode.

Before change:
![image](https://user-images.githubusercontent.com/31290848/208209956-af17cd43-2c37-48e7-83fd-52437ae2a383.png)
![image](https://user-images.githubusercontent.com/31290848/208210021-dc2e05f8-41a4-4fd7-adc2-4b50775b4404.png)

After change:
![image](https://user-images.githubusercontent.com/31290848/208210163-30d9d2dc-2883-42fe-be1c-f85a41d1ff97.png)
![image](https://user-images.githubusercontent.com/31290848/208210244-2723bf79-3416-430d-a88e-535e94f7f1e4.png)
