### PR TITLE
Use striped tables

### DIFF
--- a/templates/comments/votes.html
+++ b/templates/comments/votes.html
@@ -1,5 +1,5 @@
 <h2 style="text-align: center">{{ _('Votes') }}</h2>
-<table class="table" style="display: table">
+<table class="table striped">
     <thead>
     <tr>
         <th>{{ _('Voter') }}</th>

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -189,7 +189,7 @@
         <hr>
         <div class="contest-problems">
             <h2 style="margin-bottom: 0.2em"><i class="fa fa-fw fa-question-circle"></i>{{ _('Problems') }} </h2>
-            <table id="contest-problems" class="table">
+            <table class="table striped">
                 <thead>
                 <tr>
                     <th>{{ _('Problem') }}</th>

--- a/templates/contest/moss.html
+++ b/templates/contest/moss.html
@@ -35,7 +35,7 @@
 {% endblock %}
 {% block body %}
     {% if has_results %}
-        <table class="table">
+        <table class="table striped">
             <thead>
             <tr>
                 <th class="header">{{ _('Problem') }}</th>

--- a/templates/organization/home.html
+++ b/templates/organization/home.html
@@ -84,7 +84,7 @@
 
     {% if classes %}
         <hr>
-        <table class="table class-list">
+        <table class="table striped class-list">
             <thead><tr><th>{{ _('Class') }}</th><th></th></tr></thead>
             <tbody>
                 {% for class in classes %}

--- a/templates/organization/list.html
+++ b/templates/organization/list.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block body %}
-    <table id="organization-table" class="table">
+    <table id="organization-table" class="table striped">
         <thead>
         <tr>
             <th style="width:85%">{{ _('Name') }}</th>

--- a/templates/status/judge-status.html
+++ b/templates/status/judge-status.html
@@ -18,7 +18,7 @@
 
 {% block body %}
     <div class="h-scrollable-table">
-        <table id="judge-status" class="table">
+        <table id="judge-status" class="table striped">
             {% include "status/judge-status-table.html" %}
         </table>
     </div>

--- a/templates/status/language-list.html
+++ b/templates/status/language-list.html
@@ -28,7 +28,7 @@
 
 {% block body %}
     <div class="h-scrollable-table">
-        <table class="table">
+        <table class="table striped">
             <thead>
             <tr>
                 <th>{{ _('ID') }}</th>

--- a/templates/ticket/list.html
+++ b/templates/ticket/list.html
@@ -224,7 +224,7 @@
 
         <main>
             <div class="h-scrollable-table">
-                <table id="ticket-list" class="table">
+                <table id="ticket-list" class="table striped">
                     <thead>
                     <tr>
                         <th></th>

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -71,7 +71,7 @@
             {% block before_users_table %}{% endblock %}
 
             <div class="h-scrollable-table">
-                <table id="users-table" class="table">
+                <table id="users-table" class="table striped">
                     {% block users_table %}{% endblock %}
                 </table>
             </div>

--- a/templates/user/user-problems.html
+++ b/templates/user/user-problems.html
@@ -52,7 +52,7 @@
             <h3 class="unselectable toggle closed">
                 <span class="fa fa-chevron-right fa-fw"></span>{{ _('Authored problems') }} ({{ authored|length }})
             </h3>
-            <table style="display: none" class="table toggled">
+            <table style="display: none" class="table striped toggled">
                 <thead>
                 <tr>
                     <th>{{ _('Problem') }}</th>
@@ -96,7 +96,7 @@
                     {{ _('%(group)s (%(val)s points)', group=group.name, val=points_str) }}
                 {%- endwith -%}
             </h3>
-            <table style="display: none" class="table toggled">
+            <table style="display: none" class="table striped toggled">
                 <thead>
                 <tr>
                     <th>{{ _('Problem') }}</th>


### PR DESCRIPTION
Increase the number of striped tables from 5 to 16. List of affected tables:

1. `/problem/aplusb` > comment > view votes (needs comment moderation perms)
2. `/contest/<key>` > Problems (also, I deleted `#contest-problems` because there's no css for it)
3. `/contest/<key>/moss` (requires moss results)
4. `/organization/<slug>` > class table (requires at least 1 class)
5. `/organizations/`
6. `/status/`
7. `/runtimes/`
8. `/tickets/`
9. `/users/`
10. `/user/<username>/solved` author table
11. `/user/<username>/solved` problem group table