### PR TITLE
Fix small error in pp calculation

### DIFF
--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -235,14 +235,15 @@ class Profile(models.Model):
                            .annotate(max_points=Max('submission__points')).order_by('-max_points')
                            .values_list('max_points', flat=True).filter(max_points__gt=0)
         )
-        extradata = (
-            public_problems.filter(submission__user=self, submission__result='AC').values('id').distinct().count()
-        )
         bonus_function = settings.DMOJ_PP_BONUS_FUNCTION
         points = sum(data)
-        problems = len(data)
         entries = min(len(data), len(table))
-        pp = sum(map(mul, table[:entries], data[:entries])) + bonus_function(extradata)
+        problems = (
+            public_problems.filter(submission__user=self, submission__result='AC',
+                                   submission__case_points__gte=F('submission__case_total'))
+            .values('id').distinct().count()
+        )
+        pp = sum(map(mul, table[:entries], data[:entries])) + bonus_function(problems)
         if self.points != points or problems != self.problem_count or self.performance_points != pp:
             self.points = points
             self.problem_count = problems


### PR DESCRIPTION
According to the [blog post](https://dmoj.ca/post/103-point-system-rework), the bonus should only consider full ACs.

List of changes:

* Previously, `Profile.problem_count` was the number of problems with a positive score. Now, it's the number of problems with a full AC.
* Previously, the pp bonus includes partial ACs. Now, it excludes partial ACs.

Also, everything looked ok when I ran `for x in Profile.objects.all(): x.calculate_points()` in the shell.