### PR TITLE
Fix CSS for rating circles

### DIFF
--- a/resources/ranks.scss
+++ b/resources/ranks.scss
@@ -26,6 +26,10 @@ svg.rate-box {
         visibility: hidden;
     }
 
+    &.rate-primary0 {
+        @include rate-svg-color($color_primary0);
+    }
+
     &.rate-newbie {
         @include rate-svg-color(#999);
     }
@@ -106,10 +110,11 @@ svg.rate-box {
 
     .rating {
         display: inline-block;
+        vertical-align: middle;
     }
 
     .rate-box {
         margin-right: 0.2em;
-        vertical-align: bottom;
+        vertical-align: middle;
     }
 }

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -113,26 +113,7 @@
             color: gray !important;
             font-weight: 600;
         }
-    </style>
 
-    {% if has_rating %}
-        <style>#users-table .rate-box {
-            font-size: 0.85em;
-            float: left;
-        }
-
-        #users-table td:nth-child(1) .rating {
-            margin-left: 1.25em;
-            display: block;
-        }
-
-        #users-table td:nth-child(2) a {
-            display: block;
-        }
-        </style>
-    {% endif %}
-
-    <style>
         .select2-selection__arrow {
             display: none;
         }

--- a/templates/user/users-table.html
+++ b/templates/user/users-table.html
@@ -4,9 +4,9 @@
     <th class="header rank">
         {% if sort_links %}<a href="{{ sort_links.rating }}">{% endif %}
         <span class="rate-group">
-            <svg class="rate-box" viewBox="0 0 16 16">
-                <circle cx="8" cy="8" r="7" stroke="white"></circle>
-                <path clip-path="url(#rating-clip)" d="M0 16v-4.8h16 0v16z" fill="white"></path>
+            <svg class="rate-box rate-primary0" viewBox="0 0 16 16">
+                <circle cx="8" cy="8" r="7"></circle>
+                <path clip-path="url(#rating-clip)" d="M0 16v-4.8h16 0v16z"></path>
             </svg>
         </span>
         {%- if sort_links %}{{ sort_order.rating }}</a>{% endif %}


### PR DESCRIPTION
* `/users/?dark` Support dark mode for the rating circle in the table header.
* `/contest/<key>/ranking/` Vertically align the rating circle.