### PR TITLE
Dark mode images

### DIFF
--- a/judge/jinja2/markdown/__init__.py
+++ b/judge/jinja2/markdown/__init__.py
@@ -88,7 +88,7 @@ class AwesomeRenderer(MathRenderer, mistune.Renderer):
                 return '<pre>%s</pre>' % mistune.escape(latex, smart_amp=False)
             elif 'error' not in result:
                 img = ('''<img src="%(svg)s" onerror="this.src='%(png)s';this.onerror=null"'''
-                       'width="%(width)s" height="%(height)s"%(tail)s>') % {
+                       'class="tex-full" width="%(width)s" height="%(height)s"%(tail)s>') % {
                     'svg': result['svg'], 'png': result['png'],
                     'width': result['meta']['width'], 'height': result['meta']['height'],
                     'tail': ' /' if self.options.get('use_xhtml') else '',
@@ -96,7 +96,7 @@ class AwesomeRenderer(MathRenderer, mistune.Renderer):
                 style = ['max-width: 100%',
                          'height: %s' % result['meta']['height'],
                          'max-height: %s' % result['meta']['height'],
-                         'width: %s' % result['meta']['height']]
+                         'width: %s' % result['meta']['width']]
                 if 'inline' in attr:
                     tag = 'span'
                 else:

--- a/resources/base-description.scss
+++ b/resources/base-description.scss
@@ -15,6 +15,10 @@
         height: auto;
     }
 
+    img.tex-full {
+        @include vars-img;
+    }
+
     h1, h2, h3, h4, h5, h6 {
         font-weight: normal;
         color: $color_primary90;

--- a/resources/pagedown-widget.scss
+++ b/resources/pagedown-widget.scss
@@ -49,6 +49,7 @@
 }
 
 .wmd-button > span {
+    @include vars-img;
     background: url($path_to_root + '/pagedown/wmd-buttons.png') no-repeat 0 0;
     width: 20px;
     height: 20px;

--- a/resources/vars-dark.scss
+++ b/resources/vars-dark.scss
@@ -17,3 +17,7 @@ $color_link200: #960;   // active
 $color_pageBg: #222;    // #222 because some elements should be darker than pageBg
 
 $path_to_root: '..';    // relative path from style.css to STATIC_ROOT
+
+@mixin vars-img {
+    filter: invert(1) hue-rotate(180deg);
+}

--- a/resources/vars-default.scss
+++ b/resources/vars-default.scss
@@ -17,3 +17,5 @@ $color_link200: #faa700;    // active
 $color_pageBg: #fff;
 
 $path_to_root: '.';     // relative path from style.css to STATIC_ROOT
+
+@mixin vars-img {}


### PR DESCRIPTION
Part of #2035. Use inverted brightness for:

* LaTeX images
* Comment editor buttons

![Capture1](https://user-images.githubusercontent.com/14223529/209743504-ddd23788-e7c3-46bb-bf02-c632f2ae09c3.PNG)