### PR TITLE
Fix blank submission activity colour

### DIFF
--- a/resources/users.scss
+++ b/resources/users.scss
@@ -318,7 +318,7 @@ a.edit-profile {
                 }
 
                 &.activity-blank {
-                    background-color: white;
+                    background-color: $color_pageBg;
                 }
                 &.activity-0 {
                     background-color: #ddd;


### PR DESCRIPTION
Part of #2035. Non-existent days (used only for aligning with day of the week) should match the page background colour.

Before:
![image](https://user-images.githubusercontent.com/29607503/209883240-3b823eac-75d9-4730-a69b-4e98bbd00b0f.png)

After:
![image](https://user-images.githubusercontent.com/29607503/209883232-10d1e7de-e2be-415b-b23a-550eae0697de.png)
