### PR TITLE
Fix the check for has_any_solves

### DIFF
--- a/judge/comments.py
+++ b/judge/comments.py
@@ -46,8 +46,7 @@ class CommentForm(ModelForm):
             if profile.mute:
                 raise ValidationError(_('Your part is silent, little toad.'))
             elif not self.request.user.is_staff and not profile.has_any_solves:
-                raise ValidationError(_('You need to have solved at least one problem '
-                                        'before your voice can be heard.'))
+                raise ValidationError(_('You must solve at least one problem before your voice can be heard.'))
         return super(CommentForm, self).clean()
 
 

--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -223,7 +223,7 @@ class Profile(models.Model):
 
     @cached_property
     def has_any_solves(self):
-        return self.submission_set.filter(points=F('problem__points')).exists()
+        return self.submission_set.filter(result='AC', case_points__gte=F('case_total')).exists()
 
     _pp_table = [pow(settings.DMOJ_PP_STEP, i) for i in range(settings.DMOJ_PP_ENTRIES)]
 

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -132,7 +132,7 @@
             {% endblock %}
             {% if is_new_user %}
                 <div style="margin-bottom: 0" class="alert alert-info">
-                    {{ _('You need to have solved at least one problem before your voice can be heard.') }}
+                    {{ _('You must solve at least one problem before your voice can be heard.') }}
                 </div>
             {% else %}
                 <form class="comment-submit-form" action="" method="post">


### PR DESCRIPTION
~~I have no idea if I should keep `@cached_property`. Or delete `@cached_property`. Or delete all of `has_any_solves()`, and replace every `profile.has_any_solves` with `profile.problem_count > 0`.~~

Change the check to result = AC, case_points >= case_total.

![Capture](https://user-images.githubusercontent.com/14223529/210050709-c96bfb49-e05a-40f6-8b7d-56784d7f1e3e.PNG)
![Capture](https://user-images.githubusercontent.com/14223529/210050667-111d4d3c-8a69-4ed5-ba78-428461b0108b.PNG)