### PR TITLE
Fix SVG/PNG math in dark mode

### DIFF
--- a/resources/base-description.scss
+++ b/resources/base-description.scss
@@ -15,7 +15,7 @@
         height: auto;
     }
 
-    img.tex-full {
+    img.tex-full, img.tex-image, img.inline-math, img.display-math {
         @include vars-img;
     }
 


### PR DESCRIPTION
Part of #2035. This fixes `<img>` math that use black text.

I got the relevant `<img>` classes from [mathoid.py](https://github.com/DMOJ/online-judge/blob/6c5dd7bc217295870a60d2f6cc3b44b18de4e626/judge/utils/mathoid.py). (I ignored `output_msp` because I think this function is dead)