### PR TITLE
Fix ticket form's width

### DIFF
--- a/resources/ticket.scss
+++ b/resources/ticket.scss
@@ -3,7 +3,6 @@
 form#ticket-form {
     display: block;
     margin: 0 auto;
-    width: 100%;
     max-width: 750px;
     padding-top: 1em;
 


### PR DESCRIPTION
`/problem/aplusb/tickets/new`
On narrow screens, `width: 100%;` causes overflow and looks bad.