### PR TITLE
Improve padding and margin of comment section

### DIFF
--- a/resources/base.scss
+++ b/resources/base.scss
@@ -86,7 +86,7 @@ th {
 .form-area {
     display: inline-block;
     background: $color_primary5;
-    padding: 5px 10px 10px 15px;
+    padding: 5px 10px 10px;
     border-radius: $widget_border_radius;
     border: 1px solid $color_primary25;
 }

--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -16,8 +16,6 @@ a {
 }
 
 .comment-area {
-    margin-right: 30px;
-
     h2 {
         margin-bottom: 20px;
     }
@@ -43,11 +41,6 @@ a {
     display: flex;
 }
 
-.comment-lock {
-    width: 100%;
-    padding-left: 14px;
-}
-
 .comment-spacer {
     flex: 1;
 }
@@ -69,17 +62,15 @@ a {
     }
 }
 
-.comments.top-level-comments {
-    margin-right: -26px;
-}
-
-.comment-submit {
+.form-area.comment-submit {
+    padding-left: 15px;
+    padding-right: 15px;
     width: 100%;
+    box-sizing: border-box;
 }
 
 .comment-post-wrapper {
-    padding-bottom: 2px;
-    padding-right: 10px;
+    padding-bottom: 5px;
 
     input, textarea {
         min-width: 100%;
@@ -100,7 +91,7 @@ a {
 .comment {
     list-style: none none;
     border-radius: $widget_border_radius;
-    margin: 0px -4px 10px -40px;
+    margin: 0 0 10px -40px;
 
     &:target > .comment-box {
         border-left: 10px solid $highlight_blue;
@@ -117,7 +108,7 @@ a {
 }
 
 .reply-comment {
-    margin: 0 23px 10px -40px;
+    margin: 0 0 10px -40px;
 }
 
 @media (max-width: 760px) {

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -156,7 +156,7 @@
     {% endif %}
 
     {% if comment_lock %}
-        <div class="alert alert-warning comment-lock">
+        <div class="alert alert-warning">
             {{ _('Comments are disabled on this page.') }}
         </div>
     {% endif %}


### PR DESCRIPTION
Follow-up from #2096. Biggest changes:
* For `.form-area`, left padding changed from 15px to 10px. This affects lots of forms.
* In comment UI, "Post!" button is aligned with textarea.

Before and after:
![0](https://user-images.githubusercontent.com/14223529/210300533-d801e3c3-0d05-4d59-985b-3aef69c140d2.PNG)
![1](https://user-images.githubusercontent.com/14223529/210300537-509bbe8e-a641-457e-8863-03c874b40599.PNG)