### PR TITLE
Remove negative margins in comments

### DIFF
--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -15,15 +15,21 @@ a {
     }
 }
 
-.comment-area {
-    h2 {
-        margin-bottom: 20px;
-    }
+.no-comments-message {
+    margin: 10px 0 15px 2.75em;
 }
 
-.no-comments-message {
-    margin-top: -15px;
-    margin-left: 2.75em;
+.comment-header-space {
+    height: 20px;
+}
+
+.comment-lock {
+    margin: 0 0 5px;
+}
+
+.comments.top-level-comments {
+    padding: 0;
+    margin: 0 0 5px;
 }
 
 .comment-author {
@@ -91,7 +97,7 @@ a {
 .comment {
     list-style: none none;
     border-radius: $widget_border_radius;
-    margin: 0 0 10px -40px;
+    margin: 0 0 5px;
 
     &:target > .comment-box {
         border-left: 10px solid $highlight_blue;
@@ -108,16 +114,7 @@ a {
 }
 
 .reply-comment {
-    margin: 0 0 10px -40px;
-}
-
-@media (max-width: 760px) {
-    .comments {
-        padding-inline-start: 5%;
-    }
-    .comment {
-        margin-left: -5%;
-    }
+    margin: 0 0 5px;
 }
 
 .comment-author {
@@ -152,7 +149,6 @@ a {
 .new-comments {
     .comment-display {
         display: flex;
-        margin-top: -0.25em !important;
         padding-left: 1em;
         padding-top: 0.5em !important;
         border: 1px solid $color_primary25;
@@ -234,10 +230,6 @@ a {
             margin-right: 0em;
         }
     }
-}
-
-.comments.top-level-comments {
-    margin-bottom: -3px;
 }
 
 .bad-comment {

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -1,5 +1,18 @@
 <div id="comments" class="comment-area">
     <h2><i style="padding-right: 0.3em" class="fa fa-comments"></i>{{ _('Comments') }}</h2>
+
+    {% if not comment_lock and not has_comments %}
+        <p class="no-comments-message">{{ _('There are no comments at the moment.') }}</p>
+    {% else %}
+        <div class="comment-header-space"></div>
+    {% endif %}
+
+    {% if comment_lock %}
+        <div class="alert alert-warning comment-lock">
+            {{ _('Comments are disabled on this page.') }}
+        </div>
+    {% endif %}
+
     {% if has_comments %}
         <ul class="comments top-level-comments new-comments">
             {% set logged_in = request.user.is_authenticated %}
@@ -120,8 +133,6 @@
                 {% endwith %}
             {% endfor %}
         </ul>
-    {% elif not comment_lock %}
-        <p class="no-comments-message">{{ _('There are no comments at the moment.') }}</p>
     {% endif %}
 
     {% if request.user.is_authenticated and comment_form and not comment_lock %}
@@ -152,12 +163,6 @@
                     <input style="float:right" type="submit" value="{{ _('Post!') }}" class="button">
                 </form>
             {% endif %}
-        </div>
-    {% endif %}
-
-    {% if comment_lock %}
-        <div class="alert alert-warning">
-            {{ _('Comments are disabled on this page.') }}
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
Biggest visual changes:

* Comment lock message was moved from the bottom to the top.
![Capture](https://user-images.githubusercontent.com/14223529/210434771-0b651374-b3de-4d4b-87a8-96e8ec079913.PNG)
* Spacing between title and no comment message has changed from 5px to 10px.