### PR TITLE
Clean up pagination css in user table

### DIFF
--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -293,9 +293,10 @@ ul.pagination {
 }
 
 .top-pagination-bar {
-    margin-top: 11px;
-    margin-bottom: 7px;
+    margin: 11px 0 7px;
     display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
 }
 
 .bottom-pagination-bar {

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -46,18 +46,11 @@
 
 {% block media %}
     {% block users_media %}{% endblock %}
-    <style>
-        .user-pagination {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: space-between;
-        }
-    </style>
 {% endblock %}
 
 {% block body %}
     {% if page_obj and page_obj.has_other_pages() %}
-        <div class="top-pagination-bar user-pagination">
+        <div class="top-pagination-bar">
             {% include "list-pages.html" %}
             <form id="search-form" name="form" action="{{ url('user_ranking_redirect') }}" method="get">
                 <input id="search-handle" type="text" name="search"


### PR DESCRIPTION
No visual changes expected.

Delete `.user-pagination` and another `<style>`. Other places use `div.top-pagination-bar`, but they have 1 child, and they should be unaffected.