### PR TITLE
Simplify CSS in judge version table

### DIFF
--- a/resources/misc.scss
+++ b/resources/misc.scss
@@ -1,8 +1,6 @@
 @import "vars";
 
 #judge-versions {
-    display: block;
-
     .version {
         font-family: $monospace-fonts;
     }
@@ -12,7 +10,7 @@
     }
 
     .version-latest {
-        background: #b3ff3fe6;
+        background: #af3c;
         color: black;
     }
 
@@ -21,28 +19,9 @@
         color: white;
     }
 
-    tbody {
-        display: block;
-    }
-
-    tr {
-        display: flex;
-        flex-direction: row;
-        padding: 0;
-
-        &:first-child {
-            position: sticky;
-            top: 42px;
-            line-height: 1.8em;
-        }
-    }
-
-    td, th {
-        display: block;
-        flex: 1 0 110px;
-        overflow-x: hidden;
-        height: auto;
-        padding: 7px 5px;
+    tr:first-child {
+        position: sticky;
+        top: 43px;
     }
 }
 


### PR DESCRIPTION
only the `tr:first-child` css did anything important

page is still mobile friendly
![Capture](https://user-images.githubusercontent.com/14223529/211220462-6a759577-6ff9-4572-a16e-7aea393d2101.PNG)