### PR TITLE
Simplify design of user table's rating column

### DIFF
--- a/resources/users.scss
+++ b/resources/users.scss
@@ -27,9 +27,14 @@ tr:target {
         white-space: nowrap;
     }
 
-    th.rank {
+    th.rank, th.rate {
         padding-left: 5px;
         padding-right: 5px;
+    }
+
+    th.rate, td.rate {
+        border-right: none;
+        text-align: left;
     }
 
     th.username {

--- a/templates/organization/class.html
+++ b/templates/organization/class.html
@@ -1,11 +1,3 @@
 {% extends "user/base-users.html" %}
-{% block users_media %}
-    <style>
-        #users-table td:nth-child(2), #users-table th:nth-child(2) {
-            border-right: none;
-            text-align: left;
-        }
-    </style>
-{% endblock %}
 
 {% block users_table %}{% include "organization/users-table.html" %}{% endblock %}

--- a/templates/organization/users.html
+++ b/templates/organization/users.html
@@ -1,11 +1,6 @@
 {% extends "user/base-users.html" %}
 {% block users_media %}
     <style>
-        #users-table td:nth-child(2), #users-table th:nth-child(2) {
-            border-right: none;
-            text-align: left;
-        }
-
         .kick-form .button {
             margin: -8px 0;
         }

--- a/templates/user/list.html
+++ b/templates/user/list.html
@@ -1,14 +1,5 @@
 {% extends "user/base-users.html" %}
 
-{% block users_media %}
-    <style>
-        #users-table td:nth-child(2), #users-table th:nth-child(2) {
-            border-right: none;
-            text-align: left;
-        }
-    </style>
-{% endblock %}
-
 {% block title_ruler %}{% endblock %}
 
 {% block title_row %}

--- a/templates/user/users-table.html
+++ b/templates/user/users-table.html
@@ -1,7 +1,7 @@
 {% extends "user/base-users-table.html" %}
 
 {% block after_rank_head %}
-    <th class="header rank">
+    <th class="header rate">
         {% if sort_links %}<a href="{{ sort_links.rating }}">{% endif %}
         <span class="rate-group">
             <svg class="rate-box rate-primary0" viewBox="0 0 16 16">
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block after_rank %}
-    <td>{% if user.rating %}{{ rating_number(user) }}{% endif %}</td>
+    <td class="rate">{% if user.rating %}{{ rating_number(user) }}{% endif %}</td>
 {% endblock %}
 
 {% block after_point_head %}


### PR DESCRIPTION
Simplify css by introducing `.rate`. (Note: `.rating` was taken)

There are no visual changes expected.

Pages that use this new css:
* `/users/`
* `/organization/2-org1/users`
* `/organization/1-dmoj/class/2-dmoj2`