### PR TITLE
Remove png support in mathoid

### DIFF
--- a/judge/models/choices.py
+++ b/judge/models/choices.py
@@ -57,9 +57,9 @@ ACE_THEMES = (
 
 MATH_ENGINES_CHOICES = (
     ('tex', _('Leave as LaTeX')),
-    ('svg', _('SVG with PNG fallback')),
+    ('svg', _('SVG only')),
     ('mml', _('MathML only')),
-    ('jax', _('MathJax with SVG/PNG fallback')),
+    ('jax', _('MathJax with SVG fallback')),
     ('auto', _('Detect best quality')),
 )
 


### PR DESCRIPTION
Part of #2129. I deleted `output_png` because there's no `png` math engine. (I think `raw` is dead too, but it's probably easier to keep it)

It works in shell.

```py
>>> from judge.utils.mathoid import *
>>> print( MathoidMathParser.output_jax(None, {'svg': 'meme.svg', 'css': 'display:none;', 'tex':'1 \\le 2', 'display': 0}) )
<span class="inline-math"><img class="tex-image" src="meme.svg" style="display:none;" alt="1 \le 2"><span class="tex-text" style="display:none">~1 \le 2~</span></span>
>>> print( MathoidMathParser.output_svg(None, {'svg': 'meme.svg', 'css': 'display:none;', 'tex':'1 \\le 2', 'display': 0}) )
<img class="inline-math" src="meme.svg" style="display:none;" alt="1 \le 2">
```

Todo:

* test in prod
* check if texoid is affected by the png removal
* check all math engines, check pdf math