### PR TITLE
Add OpenGraph to blog posts

### DIFF
--- a/judge/utils/opengraph.py
+++ b/judge/utils/opengraph.py
@@ -10,7 +10,7 @@ def generate_opengraph(cache_key, data, style):
     if metadata is None:
         description = None
         tree = reference(markdown(data, style)).tree
-        for p in tree.iterfind('.//p'):
+        for p in tree.iterfind('..//p'):
             text = p.text_content().strip()
             if text:
                 description = text

--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -11,6 +11,7 @@ from judge.models import BlogPost, Comment, Contest, Language, Problem, ProblemC
     Ticket
 from judge.utils.cachedict import CacheDict
 from judge.utils.diggpaginator import DiggPaginator
+from judge.utils.opengraph import generate_opengraph
 from judge.utils.tickets import filter_visible_tickets
 from judge.utils.views import TitleMixin
 
@@ -101,7 +102,12 @@ class PostView(TitleMixin, CommentedDetailView):
 
     def get_context_data(self, **kwargs):
         context = super(PostView, self).get_context_data(**kwargs)
-        context['og_image'] = self.object.og_image
+
+        metadata = generate_opengraph('generated-meta-blog:%d' % self.object.id,
+                                      self.object.summary or self.object.content, 'blog')
+        context['meta_description'] = metadata[0]
+        context['og_image'] = self.object.og_image or metadata[1]
+
         return context
 
     def get_object(self, queryset=None):


### PR DESCRIPTION
this should improve the discord preview of `https://dmoj.ca/post/<id>-<slug>`

* For `meta_description`, use `summary` and fall back to `content`.
* Fix a bug with `generate_opengraph`. If `data` is one line, `tree` would be a `<p>` and `.//p` can't find anything. Use `..//p`.