### PR TITLE
Introduce navbar arrow

### DIFF
--- a/resources/common.js
+++ b/resources/common.js
@@ -125,7 +125,6 @@ $(function () {
             $(this).blur().removeClass('hover');
         else {
             $(this).addClass('hover');
-            $nav_list.find('li ul').css('left', $('#nav-list').width()).hide();
         }
     }).hover(function () {
         $(this).addClass('hover');
@@ -135,7 +134,7 @@ $(function () {
 
     $nav_list.find('li a .nav-expand').click(function (event) {
         event.preventDefault();
-        $(this).parent().siblings('ul').css('display', 'block');
+        $(this).parent().siblings('ul').toggleClass('show-list');
     });
 
     $nav_list.find('li a').each(function () {

--- a/resources/navbar.scss
+++ b/resources/navbar.scss
@@ -254,9 +254,11 @@ nav {
 
             ul {
                 left: 8em;
-                top: auto;
-                bottom: auto;
-                margin-top: -36px;
+                top: 0px;
+
+                &.show-list {
+                    display: block;
+                }
             }
 
             &.home-nav-element {

--- a/templates/base.html
+++ b/templates/base.html
@@ -185,8 +185,8 @@
                 <li>
                     <a href="{{ node.path }}" class="nav-{{ node.key }}{% if node.key in nav_tab %} active{% endif %}">
                         {{ user_trans(node.label) }}
-                        {% if not node.is_leaf_node %}
-                            <div href="javascript:void(0)" class="nav-expand">></div>
+                        {% if not node.is_leaf_node() %}
+                            <div class="nav-expand">&gt;</div>
                         {% endif %}
                     </a>
                     {% with children=node.get_children() %}


### PR DESCRIPTION
These arrows never show up because the code did `node.is_leaf_node` instead of `node.is_leaf_node()`.

Let's re-introduce the navbar arrow (and clean some of its code). It works well enough locally.

![Capture](https://user-images.githubusercontent.com/14223529/212862502-4edb5e8f-e897-40fa-9b35-3725f5b8b03d.PNG)