### PR TITLE
Pin packaging to < 22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ pyotp
 qrcode[pil]
 jsonfield @ git+https://github.com/DMOJ/jsonfield.git
 pymoss
-packaging
+packaging<22
 celery
 ansi2html @ git+https://github.com/DMOJ/ansi2html.git
 sqlparse


### PR DESCRIPTION
Temporarily fixes #2116. We should look into migrating off of `LegacyVersion` in the future.