### PR TITLE
Rename sorted checker in site interface

### DIFF
--- a/judge/models/problem_data.py
+++ b/judge/models/problem_data.py
@@ -25,7 +25,7 @@ CHECKERS = (
     ('floatsabs', _('Floats (absolute)')),
     ('floatsrel', _('Floats (relative)')),
     ('rstripped', _('Non-trailing spaces')),
-    ('sorted', _('Unordered')),
+    ('sorted', _('Sorted')),
     ('identical', _('Byte identical')),
     ('linecount', _('Line-by-line')),
 )


### PR DESCRIPTION
The `sorted` checker in the site interface is currently called Unordered. This is confusing because a checker named `unordered` also exists on the judge-side, and is mentioned in the [docs](https://docs.dmoj.ca/#/problem_format/custom_checkers?id=unordered-checker-unordered).