### PR TITLE
Make dark mode links slightly lighter

### DIFF
--- a/resources/vars-dark.scss
+++ b/resources/vars-dark.scss
@@ -12,9 +12,9 @@ $color_primary90: #eee;
 $color_primary100: #fff;
 
 $color_link50: #06d;    // default (title)
-$color_link75: #38e;    // default
-$color_link100: #59f;   // hover
-$color_link200: #960;   // active
+$color_link75: #6bf;    // default
+$color_link100: #49e;   // hover
+$color_link200: #d83;   // active
 
 $color_pageBg: #222;    // #222 because some elements should be darker than pageBg
 


### PR DESCRIPTION
Part of #2035.

Active / Hover / Default

Before:
![image](https://user-images.githubusercontent.com/29607503/216785192-9ec92c5b-73fd-47e4-b75b-83af81dec2ac.png)


After:
![image](https://user-images.githubusercontent.com/29607503/216785144-9b4e2c30-29ae-48ed-b8dc-dc16c001f689.png)
