### PR TITLE
Add ability to specify table ids for user tables

### DIFF
--- a/resources/users.scss
+++ b/resources/users.scss
@@ -22,7 +22,7 @@ tr:target {
     padding-left: 0.5em;
 }
 
-#users-table {
+.users-table {
     th.rank, th.points, th.problems, th.username {
         white-space: nowrap;
     }

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -9,19 +9,19 @@
 
 {% block users_media %}
     <style>
-        #users-table .username {
+        #ranking-table .username {
             min-width: 20em;
         }
 
-        #users-table .rating-column {
+        #ranking-table .rating-column {
             min-width: 3em;
         }
 
-        #users-table td {
+        #ranking-table td {
             height: 2.5em;
         }
 
-        #users-table a {
+        #ranking-table a {
             display: block;
         }
 
@@ -30,11 +30,11 @@
         }
 
         /* Make problem table headers green on hover */
-        #users-table th a:hover {
+        #ranking-table th a:hover {
             color: #0F0;
         }
 
-        #users-table td a:hover {
+        #ranking-table td a:hover {
             text-decoration: underline;
         }
 
@@ -234,5 +234,6 @@
 {% endblock %}
 
 {% block users_table %}
+    {% set table_id='ranking-table' %}
     {% include "contest/ranking-table.html" %}
 {% endblock %}

--- a/templates/organization/users.html
+++ b/templates/organization/users.html
@@ -15,7 +15,7 @@
     </style>
 
     {% if is_admin %}
-        <style>#users-table td:nth-child(3), #users-table th:nth-child(3) {
+        <style>#organization-users-table td:nth-child(3), #organization-users th:nth-child(3) {
             border-right: none;
         }
         </style>
@@ -35,4 +35,7 @@
     </script>
 {% endblock %}
 
-{% block users_table %}{% include "organization/users-table.html" %}{% endblock %}
+{% block users_table %}
+    {% set table_id='organization-users-table' %}
+    {% include "organization/users-table.html" %}
+{% endblock %}

--- a/templates/user/base-users-table.html
+++ b/templates/user/base-users-table.html
@@ -1,32 +1,34 @@
-<thead>
-<tr>
-    <th class="header rank">{{ rank_header or _("Rank") }}</th>
-    {% block after_rank_head %}{% endblock %}
-    <th class="header username">{{ _('Username') }}</th>
-    {% block before_point_head %}{% endblock %}
+<table {% if table_id %}id="{{ table_id }}"{% endif %} class="users-table table striped">
+    <thead>
+    <tr>
+        <th class="header rank">{{ rank_header or _("Rank") }}</th>
+        {% block after_rank_head %}{% endblock %}
+        <th class="header username">{{ _('Username') }}</th>
+        {% block before_point_head %}{% endblock %}
 
-    <th class="header points">
-        {% if sort_links %}<a href="{{ sort_links.performance_points }}">{% endif %}
-        {{ _('Points') }}
-        {%- if sort_links %}{{ sort_order.performance_points }}</a>{% endif %}
-    </th>
-    {% block after_point_head %}{% endblock %}
-</tr>
-</thead>
-
-<tbody>
-{% for rank, user in users %}
-    <tr id="user-{{ user.user.username }}" {% block row_extra scoped %}{% endblock %}>
-        <td>{{ rank }}</td>
-        {% block after_rank scoped %}{% endblock %}
-        <td class="user-name">{{ link_user(user) }} {% block user_data scoped %}{% endblock %}</td>
-        {% block before_point scoped %}{% endblock %}
-        {% block point scoped %}
-            <td title="{{ user.performance_points|floatformat(2) }}" class="user-points">
-                {{ user.performance_points|floatformat(0) }}
-            </td>
-        {% endblock %}
-        {% block after_point scoped %}{% endblock %}
+        <th class="header points">
+            {% if sort_links %}<a href="{{ sort_links.performance_points }}">{% endif %}
+            {{ _('Points') }}
+            {%- if sort_links %}{{ sort_order.performance_points }}</a>{% endif %}
+        </th>
+        {% block after_point_head %}{% endblock %}
     </tr>
-{% endfor %}
-</tbody>
+    </thead>
+
+    <tbody>
+    {% for rank, user in users %}
+        <tr id="user-{{ user.user.username }}" {% block row_extra scoped %}{% endblock %}>
+            <td>{{ rank }}</td>
+            {% block after_rank scoped %}{% endblock %}
+            <td class="user-name">{{ link_user(user) }} {% block user_data scoped %}{% endblock %}</td>
+            {% block before_point scoped %}{% endblock %}
+            {% block point scoped %}
+                <td title="{{ user.performance_points|floatformat(2) }}" class="user-points">
+                    {{ user.performance_points|floatformat(0) }}
+                </td>
+            {% endblock %}
+            {% block after_point scoped %}{% endblock %}
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -64,9 +64,7 @@
             {% block before_users_table %}{% endblock %}
 
             <div class="h-scrollable-table">
-                <table id="users-table" class="table striped">
-                    {% block users_table %}{% endblock %}
-                </table>
+                {% block users_table %}{% endblock %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This is necessary to be able to move contest ranking CSS to SCSS files without affecting other user tables.

With this, we can add dark mode colours for the contest ranking table, which will be done in a future PR.