### PR TITLE
Add submission activity dark mode

### DIFF
--- a/resources/users.scss
+++ b/resources/users.scss
@@ -269,19 +269,19 @@ img.user-gravatar {
                     background-color: $color_pageBg;
                 }
                 &.activity-0 {
-                    background-color: #ddd;
+                    background-color: $color_user_submission_activity0;
                 }
                 &.activity-1 {
-                    background-color: #9be9a8;
+                    background-color: $color_user_submission_activity1;
                 }
                 &.activity-2 {
-                    background-color: #40c463;
+                    background-color: $color_user_submission_activity2;
                 }
                 &.activity-3 {
-                    background-color: #2f9c4c;
+                    background-color: $color_user_submission_activity3;
                 }
                 &.activity-4 {
-                    background-color: #216e39;
+                    background-color: $color_user_submission_activity4;
                 }
             }
         }

--- a/resources/vars-dark.scss
+++ b/resources/vars-dark.scss
@@ -18,6 +18,7 @@ $color_link200: #d83;   // active
 
 $color_pageBg: #222;    // #222 because some elements should be darker than pageBg
 
+// custom one-off colours
 $color_rating_none: #aaa;
 $color_rating_newbie: #aaa;
 $color_rating_amateur: #00a900;
@@ -26,6 +27,12 @@ $color_rating_candidate_master: mediumpurple;
 $color_rating_master: #ffb100;
 $color_rating_grandmaster: #e00;
 $color_rating_target: #f55;
+
+$color_user_submission_activity0: #3b3b3b;
+$color_user_submission_activity1: #0e4429;
+$color_user_submission_activity2: #006d32;
+$color_user_submission_activity3: #26a641;
+$color_user_submission_activity4: #39d353;
 
 $path_to_root: '..';    // relative path from style.css to STATIC_ROOT
 

--- a/resources/vars-default.scss
+++ b/resources/vars-default.scss
@@ -18,6 +18,7 @@ $color_link200: #faa700;    // active
 
 $color_pageBg: #fff;
 
+// custom one-off colours
 $color_rating_none: #999;
 $color_rating_newbie: #999;
 $color_rating_amateur: #00a900;
@@ -26,6 +27,12 @@ $color_rating_candidate_master: purple;
 $color_rating_master: #ffb100;
 $color_rating_grandmaster: #e00;
 $color_rating_target: #700;
+
+$color_user_submission_activity0: #ddd;
+$color_user_submission_activity1: #9be9a8;
+$color_user_submission_activity2: #40c463;
+$color_user_submission_activity3: #2f9c4c;
+$color_user_submission_activity4: #216e39;
 
 $path_to_root: '.';     // relative path from style.css to STATIC_ROOT
 


### PR DESCRIPTION
Part of #2035. Dark mode colours shamelessly taken from Github contribution activity.

After:
![image](https://user-images.githubusercontent.com/29607503/216839084-003099fc-ad24-46f1-8f1c-2838843c5236.png)
