### PR TITLE
Fix dark mode colour for alert close button

### DIFF
--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -344,8 +344,7 @@ ul.pagination {
     font-size: 21px;
     font-weight: 700;
     line-height: 1;
-    color: #000;
-    text-shadow: 0 1px 0 #fff;
+    color: $color_primary100;
     filter: alpha(opacity=20);
     opacity: 0.2;
 }
@@ -356,7 +355,7 @@ a.close {
     line-height: 1;
 
     &:hover {
-        color: black !important;
+        color: $color_primary100;
     }
 }
 


### PR DESCRIPTION
Part of #2035.

`text-shadow` does nothing on light mode, and messes up the rendering on dark mode, so just remove it.
