### PR TITLE
Standardize gravatar images

### DIFF
--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -144,11 +144,6 @@ a {
         display: flex;
     }
 
-    .gravatar {
-        width: 75px;
-        max-width: 75px;
-    }
-
     .gravatar-mobile {
         display: none;
     }
@@ -164,9 +159,9 @@ a {
     }
 
     @media (max-width: 760px) {
-        .gravatar {
-            width: 10px;
-            max-width: 10px;
+        img.user-gravatar {
+            display: inline-block;
+            border-radius: 2px;
         }
 
         .gravatar-mobile {

--- a/resources/ticket.scss
+++ b/resources/ticket.scss
@@ -162,9 +162,7 @@ div.ticket-title {
         width: 130px;
     }
 
-    .gravatar {
-        width: 80px;
-        display: block;
+    img.user-gravatar {
         margin: 0 auto;
     }
 

--- a/resources/users.scss
+++ b/resources/users.scss
@@ -117,6 +117,7 @@ tr:target {
 img.user-gravatar {
     display: block;
     border-radius: 6px;
+    background-color: white;
 }
 
 .user-content {

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -43,7 +43,7 @@
                             </div>
                             {% with author=node.author, user=node.author.user %}
                                 <a href="{{ url('user_page', user.username) }}" class="user gravatar-main">
-                                    <img src="{{ gravatar(author, 135) }}" class="gravatar">
+                                    <img src="{{ gravatar(author, 75) }}" class="user-gravatar">
                                 </a>
                             {% endwith %}
                         </div>
@@ -52,7 +52,7 @@
                                 <span>
                                     {% with author=node.author, user=node.author.user %}
                                         <a href="{{ url('user_page', user.username) }}" class="user gravatar-mobile">
-                                            <img src="{{ gravatar(author, 135) }}" class="gravatar">
+                                            <img src="{{ gravatar(author, 10) }}" class="user-gravatar">
                                         </a>
                                     {% endwith %}
                                     {{ link_user(node.author) }}&nbsp;

--- a/templates/ticket/message.html
+++ b/templates/ticket/message.html
@@ -1,7 +1,7 @@
 <section id="message-{{ message.id }}" class="ticket-message">
     <div class="info">
         <a href="{{ url('user_page', message.user.user.username) }}" class="user">
-            <img src="{{ gravatar(message.user, 135) }}" class="gravatar">
+            <img src="{{ gravatar(message.user, 80) }}" class="user-gravatar">
         </a>
     </div>
     <div class="detail">

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -165,7 +165,7 @@
             <section class="ticket-message new-message">
                 <div class="info">
                     <a href="{{ url('user_page', request.user.username) }}" class="user">
-                        <img src="{{ gravatar(request.user, 135) }}" class="gravatar">
+                        <img src="{{ gravatar(request.user, 80) }}" class="user-gravatar">
                     </a>
                 </div>
                 <div class="detail">

--- a/templates/user/user-base.html
+++ b/templates/user/user-base.html
@@ -11,7 +11,7 @@
 {% block body %}
     <div class="user-info-page">
         <div class="user-sidebar">
-            <img src="{{ gravatar(user, 135) }}" width="135px" height="135px" class="user-gravatar">
+            <img src="{{ gravatar(user, 135) }}" class="user-gravatar">
             <br>
 
             <div><b>


### PR DESCRIPTION
Consists of 4 changes:
 - Use gravatar size parameter in URL instead of always grabbing `size=135` and then resizing ourselves.
 - Always use `user-gravatar` class. Side effect is comment/ticket gravatars now have rounded borders.
      - Add overrides for comment gravatars on small-width devices so the gravatar is not a circle.
 - Add `background-color: white` to all gravatars (part of #2035).

Before:
![image](https://user-images.githubusercontent.com/29607503/216843189-55b74dd2-5416-43b2-a067-ca0568707ceb.png)
![image](https://user-images.githubusercontent.com/29607503/216843210-c8c65f6f-93b1-4ead-b162-8767e941814c.png)

After:
![image](https://user-images.githubusercontent.com/29607503/216843197-a8c9d37c-883c-4bd8-b27c-96798640eafb.png)
![image](https://user-images.githubusercontent.com/29607503/216843082-b6d0cd39-5c56-4f9d-8017-d4490eb9f9be.png)