### PR TITLE
Use a darker (light theme) / lighter (dark theme) color for tab text

### DIFF
--- a/resources/vars-dark.scss
+++ b/resources/vars-dark.scss
@@ -7,6 +7,7 @@ $color_primary5: #080808;   // light background
 $color_primary10: #111;     // background
 $color_primary25: #3b3b3b;  // border
 $color_primary50: #808080;
+$color_primary66: #aaa;     // tabs
 $color_primary75: #ccc;     // widget
 $color_primary90: #eee;
 $color_primary100: #fff;

--- a/resources/vars-default.scss
+++ b/resources/vars-default.scss
@@ -7,6 +7,7 @@ $color_primary5: #f8f8f8;   // light background
 $color_primary10: #eee;     // background
 $color_primary25: #ccc;     // border
 $color_primary50: #808080;
+$color_primary66: #555;     // tabs
 $color_primary75: #3b3b3b;  // widget
 $color_primary90: #111;
 $color_primary100: #000;

--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -222,7 +222,7 @@ textarea:focus {
                 position: relative;
                 display: block;
                 padding: 10px 15px;
-                color: $color_primary50;
+                color: $color_primary66;
                 text-decoration: none;
                 white-space: nowrap;
             }


### PR DESCRIPTION
This matches the tab text color before 1b68ed36b. Currently, the text looks off since it has the same colour as unclickable text.