### PR TITLE
Use custom dmoj select2 theme for dark mode support

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -106,6 +106,7 @@ DMOJ_THEME_CSS = {
     'light': 'style.css',
     'dark': 'dark/style.css',
 }
+DMOJ_SELECT2_THEME = 'dmoj'
 
 MARKDOWN_STYLES = {}
 MARKDOWN_DEFAULT_STYLE = {}

--- a/judge/template_context.py
+++ b/judge/template_context.py
@@ -30,6 +30,7 @@ def get_resource(request):
         'FONTAWESOME_CSS': settings.FONTAWESOME_CSS,
         'DMOJ_SCHEME': scheme,
         'DMOJ_CANONICAL': settings.DMOJ_CANONICAL,
+        'DMOJ_SELECT2_THEME': settings.DMOJ_SELECT2_THEME,
     }
 
 

--- a/judge/widgets/select2.py
+++ b/judge/widgets/select2.py
@@ -64,6 +64,7 @@ class Select2Mixin(object):
     def build_attrs(self, base_attrs, extra_attrs=None):
         """Add select2 data attributes."""
         attrs = super(Select2Mixin, self).build_attrs(base_attrs, extra_attrs)
+        attrs.setdefault('data-theme', settings.DMOJ_SELECT2_THEME)
         if self.is_required:
             attrs.setdefault('data-allow-clear', 'false')
         else:
@@ -102,7 +103,7 @@ class AdminSelect2Mixin(Select2Mixin):
     def media(self):
         return forms.Media(
             js=['admin/js/jquery.init.js', settings.SELECT2_JS_URL, 'django_select2.js'],
-            css={'screen': [settings.SELECT2_CSS_URL]},
+            css={'screen': [settings.SELECT2_CSS_URL, 'select2-dmoj.css']},
         )
 
 

--- a/make_style.sh
+++ b/make_style.sh
@@ -20,7 +20,7 @@ build_style() {
   echo "Creating $1 style..."
   cp resources/vars-$1.scss resources/vars.scss
   sass resources:sass_processed
-  postcss sass_processed/style.css sass_processed/martor-description.css --verbose --use autoprefixer -d $2
+  postcss sass_processed/style.css sass_processed/martor-description.css sass_processed/select2-dmoj.css --verbose --use autoprefixer -d $2
 }
 
 build_style 'default' 'resources'

--- a/resources/select2-dmoj.scss
+++ b/resources/select2-dmoj.scss
@@ -28,7 +28,7 @@
     .select2-search--dropdown {
         .select2-search__field {
             border: 1px solid $color_primary33;
-            background-color: $color_primary10;
+            background-color: $color_select2_search_dropdown;
             color: $color_primary100;
         }
     }

--- a/resources/select2-dmoj.scss
+++ b/resources/select2-dmoj.scss
@@ -1,6 +1,15 @@
-.select2-container--default {
-    @import "single";
-    @import "multiple";
+@import "vars";
+
+/* Hack to make dropdown background follow theming */
+.select2-dropdown {
+    background-color: $color_primary0 !important;
+    border: 1px solid $color_primary33 !important;
+    color: $color_primary100 !important;
+}
+
+.select2-container--dmoj {
+    @import "select2/single";
+    @import "select2/multiple";
 
     &.select2-container--open.select2-container--above {
         .select2-selection--single, .select2-selection--multiple {
@@ -18,7 +27,9 @@
 
     .select2-search--dropdown {
         .select2-search__field {
-            border: 1px solid #aaa;
+            border: 1px solid $color_primary33;
+            background-color: $color_primary10;
+            color: $color_primary100;
         }
     }
 
@@ -35,6 +46,7 @@
     .select2-results > .select2-results__options {
         max-height: 200px;
         overflow-y: auto;
+        color: $color_primary100;
     }
 
     .select2-results__option {
@@ -43,11 +55,11 @@
         }
 
         &[aria-disabled=true] {
-            color: #999;
+            color: $color_primary50;
         }
 
         &[aria-selected=true] {
-            background-color: #ddd;
+            background-color: $color_primary25;
         }
 
         .select2-results__option {
@@ -85,8 +97,8 @@
     }
 
     .select2-results__option--highlighted[aria-selected] {
-        background-color: #5897fb;
-        color: white;
+        background-color: $highlight_blue;
+        color: $color_primary0;
     }
 
     .select2-results__group {

--- a/resources/select2/_multiple.scss
+++ b/resources/select2/_multiple.scss
@@ -1,0 +1,98 @@
+.select2-selection--multiple {
+    background-color: white;
+    border: 1px solid #aaa;
+    border-radius: 4px;
+    cursor: text;
+
+    .select2-selection__rendered {
+        box-sizing: border-box;
+        list-style: none;
+        margin: 0;
+        padding: 0 5px;
+        width: 100%;
+
+        li {
+            list-style: none;
+        }
+    }
+
+    .select2-selection__placeholder {
+        color: #999;
+
+        margin-top: 5px;
+
+        float: left;
+    }
+
+    .select2-selection__clear {
+        cursor: pointer;
+        float: right;
+        font-weight: bold;
+        margin-top: 5px;
+        margin-right: 10px;
+    }
+
+    .select2-selection__choice {
+        background-color: #e4e4e4;
+
+        border: 1px solid #aaa;
+        border-radius: 4px;
+        cursor: default;
+
+        float: left;
+
+        margin-right: 5px;
+        margin-top: 5px;
+        padding: 0 5px;
+    }
+
+    .select2-selection__choice__remove {
+        color: #999;
+        cursor: pointer;
+
+        display: inline-block;
+        font-weight: bold;
+
+        margin-right: 2px;
+
+        &:hover {
+            color: #333;
+        }
+    }
+}
+
+&[dir="rtl"] {
+    .select2-selection--multiple {
+        .select2-selection__choice, .select2-selection__placeholder, .select2-search--inline {
+            float: right;
+        }
+
+        .select2-selection__choice {
+            margin-left: 5px;
+            margin-right: auto;
+        }
+
+        .select2-selection__choice__remove {
+            margin-left: 2px;
+            margin-right: auto;
+        }
+    }
+}
+
+&.select2-container--focus {
+    .select2-selection--multiple {
+        border: solid black 1px;
+        outline: 0;
+    }
+}
+
+&.select2-container--disabled {
+    .select2-selection--multiple {
+        background-color: #eee;
+        cursor: default;
+    }
+
+    .select2-selection__choice__remove {
+        display: none;
+    }
+}

--- a/resources/select2/_multiple.scss
+++ b/resources/select2/_multiple.scss
@@ -1,6 +1,6 @@
 .select2-selection--multiple {
-    background-color: white;
-    border: 1px solid #aaa;
+    background-color: $color_primary0;
+    border: 1px solid $color_primary33;
     border-radius: 4px;
     cursor: text;
 
@@ -17,7 +17,7 @@
     }
 
     .select2-selection__placeholder {
-        color: #999;
+        color: $color_primary50;
 
         margin-top: 5px;
 
@@ -33,9 +33,10 @@
     }
 
     .select2-selection__choice {
-        background-color: #e4e4e4;
+        background-color: $color_primary10;
+        color: $color_primary100;
 
-        border: 1px solid #aaa;
+        border: 1px solid $color_primary33;
         border-radius: 4px;
         cursor: default;
 
@@ -47,7 +48,7 @@
     }
 
     .select2-selection__choice__remove {
-        color: #999;
+        color: $color_primary50;
         cursor: pointer;
 
         display: inline-block;
@@ -56,7 +57,7 @@
         margin-right: 2px;
 
         &:hover {
-            color: #333;
+            color: $color_primary75;
         }
     }
 }
@@ -81,14 +82,14 @@
 
 &.select2-container--focus {
     .select2-selection--multiple {
-        border: solid black 1px;
+        border: solid $color_primary100 1px;
         outline: 0;
     }
 }
 
 &.select2-container--disabled {
     .select2-selection--multiple {
-        background-color: #eee;
+        background-color: $color_primary10;
         cursor: default;
     }
 

--- a/resources/select2/_single.scss
+++ b/resources/select2/_single.scss
@@ -1,0 +1,83 @@
+.select2-selection--single {
+    background-color: #fff;
+    border: 1px solid #aaa;
+    border-radius: 4px;
+
+    .select2-selection__rendered {
+        color: #444;
+        line-height: 28px;
+    }
+
+    .select2-selection__clear {
+        cursor: pointer;
+        float: right;
+        font-weight: bold;
+    }
+
+    .select2-selection__placeholder {
+        color: #999;
+    }
+
+    .select2-selection__arrow {
+        height: 26px;
+
+        position: absolute;
+
+        top: 1px;
+        right: 1px;
+
+        width: 20px;
+
+        b {
+            border-color: #888 transparent transparent transparent;
+            border-style: solid;
+            border-width: 5px 4px 0 4px;
+
+            height: 0;
+            left: 50%;
+
+            margin-left: -4px;
+            margin-top: -2px;
+
+            position: absolute;
+
+            top: 50%;
+            width: 0;
+        }
+    }
+}
+
+&[dir="rtl"] {
+    .select2-selection--single {
+        .select2-selection__clear {
+            float: left;
+        }
+
+        .select2-selection__arrow {
+            left: 1px;
+            right: auto;
+        }
+    }
+}
+
+&.select2-container--disabled {
+    .select2-selection--single {
+        background-color: #eee;
+        cursor: default;
+
+        .select2-selection__clear {
+            display: none;
+        }
+    }
+}
+
+&.select2-container--open {
+    .select2-selection--single {
+        .select2-selection__arrow {
+            b {
+                border-color: transparent transparent #888 transparent;
+                border-width: 0 4px 5px 4px;
+            }
+        }
+    }
+}

--- a/resources/select2/_single.scss
+++ b/resources/select2/_single.scss
@@ -1,10 +1,10 @@
 .select2-selection--single {
-    background-color: #fff;
-    border: 1px solid #aaa;
+    background-color: $color_primary0;
+    border: 1px solid $color_primary33;
     border-radius: 4px;
 
     .select2-selection__rendered {
-        color: #444;
+        color: $color_primary75;
         line-height: 28px;
     }
 
@@ -15,7 +15,7 @@
     }
 
     .select2-selection__placeholder {
-        color: #999;
+        color: $color_primary50;
     }
 
     .select2-selection__arrow {
@@ -29,7 +29,7 @@
         width: 20px;
 
         b {
-            border-color: #888 transparent transparent transparent;
+            border-color: $color_primary50 transparent transparent transparent;
             border-style: solid;
             border-width: 5px 4px 0 4px;
 
@@ -62,7 +62,7 @@
 
 &.select2-container--disabled {
     .select2-selection--single {
-        background-color: #eee;
+        background-color: $color_primary10;
         cursor: default;
 
         .select2-selection__clear {
@@ -75,7 +75,7 @@
     .select2-selection--single {
         .select2-selection__arrow {
             b {
-                border-color: transparent transparent #888 transparent;
+                border-color: transparent transparent $color_primary50 transparent;
                 border-width: 0 4px 5px 4px;
             }
         }

--- a/resources/select2/layout.scss
+++ b/resources/select2/layout.scss
@@ -1,0 +1,97 @@
+.select2-container--default {
+    @import "single";
+    @import "multiple";
+
+    &.select2-container--open.select2-container--above {
+        .select2-selection--single, .select2-selection--multiple {
+            border-top-left-radius: 0;
+            border-top-right-radius: 0;
+        }
+    }
+
+    &.select2-container--open.select2-container--below {
+        .select2-selection--single, .select2-selection--multiple {
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+    }
+
+    .select2-search--dropdown {
+        .select2-search__field {
+            border: 1px solid #aaa;
+        }
+    }
+
+    .select2-search--inline {
+        .select2-search__field {
+            background: transparent;
+            border: none;
+            outline: 0;
+            box-shadow: none;
+            -webkit-appearance: textfield;
+        }
+    }
+
+    .select2-results > .select2-results__options {
+        max-height: 200px;
+        overflow-y: auto;
+    }
+
+    .select2-results__option {
+        &[role=group] {
+            padding: 0;
+        }
+
+        &[aria-disabled=true] {
+            color: #999;
+        }
+
+        &[aria-selected=true] {
+            background-color: #ddd;
+        }
+
+        .select2-results__option {
+            padding-left: 1em;
+
+            .select2-results__group {
+                padding-left: 0;
+            }
+
+            .select2-results__option {
+                margin-left: -1em;
+                padding-left: 2em;
+
+                .select2-results__option {
+                    margin-left: -2em;
+                    padding-left: 3em;
+
+                    .select2-results__option {
+                        margin-left: -3em;
+                        padding-left: 4em;
+
+                        .select2-results__option {
+                            margin-left: -4em;
+                            padding-left: 5em;
+
+                            .select2-results__option {
+                                margin-left: -5em;
+                                padding-left: 6em;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    .select2-results__option--highlighted[aria-selected] {
+        background-color: #5897fb;
+        color: white;
+    }
+
+    .select2-results__group {
+        cursor: default;
+        display: block;
+        padding: 6px;
+    }
+}

--- a/resources/style.scss
+++ b/resources/style.scss
@@ -19,3 +19,4 @@
 @import "submission";
 @import "contest";
 @import "misc";
+@import "select2-dmoj";

--- a/resources/vars-dark.scss
+++ b/resources/vars-dark.scss
@@ -6,6 +6,7 @@ $color_primary0: #000;
 $color_primary5: #080808;   // light background
 $color_primary10: #111;     // background
 $color_primary25: #3b3b3b;  // border
+$color_primary33: #555;     // widget
 $color_primary50: #808080;
 $color_primary66: #aaa;     // tabs
 $color_primary75: #ccc;     // widget

--- a/resources/vars-dark.scss
+++ b/resources/vars-dark.scss
@@ -32,6 +32,8 @@ $color_rating_master: #ffb100;
 $color_rating_grandmaster: #e00;
 $color_rating_target: #f55;
 
+$color_select2_search_dropdown: $color_primary10;
+
 $color_user_submission_activity0: #3b3b3b;
 $color_user_submission_activity1: #0e4429;
 $color_user_submission_activity2: #006d32;

--- a/resources/vars-default.scss
+++ b/resources/vars-default.scss
@@ -6,6 +6,7 @@ $color_primary0: #fff;
 $color_primary5: #f8f8f8;   // light background
 $color_primary10: #eee;     // background
 $color_primary25: #ccc;     // border
+$color_primary33: #aaa;     // widget
 $color_primary50: #808080;
 $color_primary66: #555;     // tabs
 $color_primary75: #3b3b3b;  // widget

--- a/resources/vars-default.scss
+++ b/resources/vars-default.scss
@@ -32,6 +32,8 @@ $color_rating_master: #ffb100;
 $color_rating_grandmaster: #e00;
 $color_rating_target: #700;
 
+$color_select2_search_dropdown: $color_primary0;
+
 $color_user_submission_activity0: #ddd;
 $color_user_submission_activity1: #9be9a8;
 $color_user_submission_activity2: #40c463;

--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -391,15 +391,6 @@ a.close {
     text-align: right;
 }
 
-ul.select2-results__options {
-    color: black;
-}
-
-ul.select2-selection__rendered {
-    padding: 0 5px !important;
-    color: black;
-}
-
 .sidebox h3 {
     margin: 0 -5px;
     background: $color_primary75;

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -81,6 +81,7 @@
             })).attr('placeholder');
 
             $('#search-contest').select2({
+                theme: '{{ DMOJ_SELECT2_THEME }}',
                 placeholder: placeholder,
                 ajax: {
                     url: '{{ url('contest_user_search_select2_ajax', contest.key) }}'

--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -20,6 +20,7 @@
                         style: 'width: 100%'
                     })).val();
                     $select.select2({
+                        theme: '{{ DMOJ_SELECT2_THEME }}',
                         data: window.valid_files,
                         allowClear: true,
                         placeholder: ''

--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -54,9 +54,13 @@
                     $form.submit();
                 }
 
-                $category.select2().css({'visibility': 'visible'}).change(clean_submit);
-                $('#types').select2({multiple: 1, placeholder: '{{ _('Filter by type...') }}'})
-                    .css({'visibility': 'visible'});
+                $category.select2({
+                    theme: '{{ DMOJ_SELECT2_THEME }}'
+                }).css({'visibility': 'visible'}).change(clean_submit);
+                $('#types').select2({
+                    theme: '{{ DMOJ_SELECT2_THEME }}',
+                    multiple: 1, placeholder: '{{ _('Filter by type...') }}'
+                }).css({'visibility': 'visible'});
 
                 // This is incredibly nasty to do but it's needed because otherwise the select2 steals the focus
                 $search.keypress(function (e) {

--- a/templates/problem/manage_submission.html
+++ b/templates/problem/manage_submission.html
@@ -51,11 +51,13 @@
     <script>
         $(function () {
             $('#by-lang-filter').select2({
+                theme: '{{ DMOJ_SELECT2_THEME }}',
                 multiple: true,
                 placeholder: '{{ _('Leave empty to not filter by language') }}'
             });
 
             $('#by-result-filter').select2({
+                theme: '{{ DMOJ_SELECT2_THEME }}',
                 multiple: true,
                 placeholder: '{{ _('Leave empty to not filter by result') }}'
             });

--- a/templates/problem/submit.html
+++ b/templates/problem/submit.html
@@ -69,6 +69,7 @@
                 var customAdapter = $.fn.select2.amd.require('select2/data/customAdapter');
 
                 $("#id_language").select2({
+                    theme: '{{ DMOJ_SELECT2_THEME }}',
                     templateResult: format,
                     templateSelection: formatSelection,
                     resultsAdapter: customAdapter

--- a/templates/submission/list.html
+++ b/templates/submission/list.html
@@ -70,12 +70,14 @@
                 }
 
                 $('#status').select2({
+                    theme: '{{ DMOJ_SELECT2_THEME }}',
                     multiple: 1,
                     placeholder: '{{ _('Filter by status...') }}',
                     matcher: idAndTextMatcher,
                 }).css({'visibility': 'visible'});
 
                 $('#language').select2({
+                    theme: '{{ DMOJ_SELECT2_THEME }}',
                     multiple: 1,
                     placeholder: '{{ _('Filter by language...') }}',
                     matcher: idAndTextMatcher,

--- a/templates/ticket/list.html
+++ b/templates/ticket/list.html
@@ -102,6 +102,7 @@
             };
 
             var user_select2 = {
+                theme: '{{ DMOJ_SELECT2_THEME }}',
                 templateResult: function (data, container) {
                     return $('<span>')
                         .append($('<img>', {

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -11,6 +11,7 @@
             }));
             var in_user_redirect = false;
             $('#search-handle').select2({
+                theme: '{{ DMOJ_SELECT2_THEME }}',
                 placeholder: '{{ _('Search by handle...') }}',
                 ajax: {
                     url: '{{ url('user_search_select2_ajax') }}'


### PR DESCRIPTION
Part of #2035. This PR will make the problem submit language select2 look bad due to a lot of custom CSS, but it will be fixed in a followup PR as this one is getting too large.

After:
![image](https://user-images.githubusercontent.com/29607503/216863470-42145d4d-3b78-4854-badc-19fc8ac15d10.png)
![image](https://user-images.githubusercontent.com/29607503/216863393-4b5340d9-3964-4f5c-893d-f490cee822e1.png)

![image](https://user-images.githubusercontent.com/29607503/216863528-053c496c-039f-4373-b60b-47c452a49744.png)
![image](https://user-images.githubusercontent.com/29607503/216863592-87241f22-6ec4-4c7a-8317-4ce42cbf5f4c.png)


The admin site only uses the light mode version:
![image](https://user-images.githubusercontent.com/29607503/216863662-02d8ae53-666e-4ea0-a98d-f71299c159c9.png)
