### PR TITLE
Use custom styling of checkboxes for dark mode support

### DIFF
--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -101,7 +101,19 @@ input {
     }
 
     &[type=checkbox] {
+        appearance: none;
         vertical-align: middle;
+        border: 1px solid $color_primary50;
+        background: $color_primary0;
+        border-radius: 2px;
+        width: 0.95em;
+        height: 0.95em;
+        cursor: pointer;
+
+        &:checked {
+            appearance: auto;
+            accent-color: $highlight_blue;
+        }
     }
 }
 


### PR DESCRIPTION
Part of #2035.

Before:
![image](https://user-images.githubusercontent.com/29607503/217414089-6b44961a-e197-430c-afab-fe8db2add2f8.png)
![image](https://user-images.githubusercontent.com/29607503/217414163-26d99bd7-6c2c-43ba-9cb5-c8fcda4c2aa2.png)

After:
![image](https://user-images.githubusercontent.com/29607503/217414187-9a75b897-2de5-4f9d-b047-b9bc0e6fbc9d.png)
![image](https://user-images.githubusercontent.com/29607503/217414202-24d2f051-1baf-42a8-a6b3-1baea2a0c417.png)
