### PR TITLE
`UserList`: avoid a query per row for display name overrides

### DIFF
--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -435,8 +435,8 @@ class UserList(QueryStringSortMixin, DiggPaginatorMixin, TitleMixin, ListView):
 
     def get_queryset(self):
         return (Profile.objects.filter(is_unlisted=False).order_by(self.order).select_related('user')
-                .only('display_rank', 'user__username', 'points', 'rating', 'performance_points',
-                      'problem_count'))
+                .only('display_rank', 'user__username', 'username_display_override', 'points', 'rating',
+                      'performance_points', 'problem_count'))
 
     def get_context_data(self, **kwargs):
         context = super(UserList, self).get_context_data(**kwargs)


### PR DESCRIPTION
Should speed up `/users/` by ~150ms in prod.