### PR TITLE
Prevent data leak after login but before 2fa completed

### DIFF
--- a/judge/views/two_factor.py
+++ b/judge/views/two_factor.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from django.utils.http import is_safe_url
 from django.utils.translation import gettext as _, gettext_lazy
 from django.views.generic import FormView, View
+from django.views.generic.base import ContextMixin
 from django.views.generic.detail import SingleObjectMixin
 
 from judge.forms import TOTPEnableForm, TOTPForm, TwoFactorLoginForm
@@ -225,10 +226,11 @@ class WebAuthnDeleteView(SingleObjectMixin, WebAuthnView):
         return HttpResponse()
 
 
-class TwoFactorLoginView(SuccessURLAllowedHostsMixin, TOTPView):
+class TwoFactorLoginView(SuccessURLAllowedHostsMixin, TOTPView, ContextMixin):
     form_class = TwoFactorLoginForm
     title = gettext_lazy('Perform Two-factor Authentication')
     template_name = 'registration/two_factor_auth.html'
+    extra_context = {'tfa_in_progress': True}
 
     def get_form_kwargs(self):
         result = super().get_form_kwargs()

--- a/templates/base.html
+++ b/templates/base.html
@@ -145,7 +145,7 @@
         </script>
     {% endif %}
 
-    {% if request.user.is_authenticated %}
+    {% if request.user.is_authenticated and not tfa_in_progress %}
         <script>
             window.user = {
                 email: '{{ request.user.email|escapejs }}',
@@ -162,7 +162,7 @@
     {% endif %}
 
     {# Don't run userscript since it may be malicious #}
-    {% if request.user.is_authenticated and request.profile.user_script and not request.user.is_impersonate and not ignore_user_script %}
+    {% if request.user.is_authenticated and request.profile.user_script and not request.user.is_impersonate and not tfa_in_progress and not ignore_user_script %}
         <script type="text/javascript">{{ request.profile.user_script|safe }}</script>
     {% endif %}
 


### PR DESCRIPTION
When a user logs in, but before they complete 2fa, the `window.user` object is populated with the user's data (including email) and the user-script is injected.

This is not intended behavior because the user should not be considered logged in yet, so they should not get access to those resources.