### PR TITLE
Avoid expensive problem queries on submissions

### DIFF
--- a/judge/jinja2/submission.py
+++ b/judge/jinja2/submission.py
@@ -16,7 +16,10 @@ def submission_layout(submission, profile_id, user, completed_problem_ids, edita
     can_view = False
     can_edit = False
 
-    if user.has_perm('judge.edit_all_problem') or problem_id in editable_problem_ids:
+    if (user.has_perm('judge.edit_all_problem') or
+            (user.has_perm('judge.edit_public_problem') and submission.problem.is_public) or
+            # We try to avoid evaluating this as much as possible to keep it lazy.
+            problem_id in editable_problem_ids):
         can_view = True
         can_edit = True
     elif user.has_perm('judge.view_all_submission'):

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -12,7 +12,7 @@ from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpRespo
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, lazy
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _, gettext_lazy
@@ -330,9 +330,9 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
         context['dynamic_update'] = False
         context['dynamic_contest_id'] = self.in_contest and self.contest.id
         context['show_problem'] = self.show_problem
-        context['completed_problem_ids'] = user_completed_ids(self.request.profile) if authenticated else []
-        context['editable_problem_ids'] = user_editable_ids(self.request.profile) if authenticated else []
-        context['tester_problem_ids'] = user_tester_ids(self.request.profile) if authenticated else []
+        context['completed_problem_ids'] = lazy(user_completed_ids, set)(self.request.profile) if authenticated else []
+        context['editable_problem_ids'] = lazy(user_editable_ids, set)(self.request.profile) if authenticated else []
+        context['tester_problem_ids'] = lazy(user_tester_ids, set)(self.request.profile) if authenticated else []
 
         context['all_languages'] = Language.objects.all().values_list('key', 'name')
         context['selected_languages'] = self.selected_languages


### PR DESCRIPTION
This PR avoids querying for `completed_problem_ids`, `editable_problem_ids`, and `tester_problem_ids` on submission lists unless absolutely necessary. This eliminates the massively expensive query for `editable_problem_ids` for users who can edit almost all problems.