### PR TITLE
Drop submission indexes that are prefixes of other indexes

### DIFF
--- a/judge/migrations/0144_submission_index_cleanup.py
+++ b/judge/migrations/0144_submission_index_cleanup.py
@@ -1,0 +1,42 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('judge', '0143_contest_problem_rank_index'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='submission',
+            name='contest_object',
+            field=models.ForeignKey(blank=True, db_index=False, null=True, on_delete=django.db.models.deletion.SET_NULL,
+                                    related_name='+', to='judge.contest', verbose_name='contest'),
+        ),
+        migrations.AlterField(
+            model_name='submission',
+            name='language',
+            field=models.ForeignKey(db_index=False, on_delete=django.db.models.deletion.CASCADE, to='judge.language',
+                                    verbose_name='submission language'),
+        ),
+        migrations.AlterField(
+            model_name='submission',
+            name='problem',
+            field=models.ForeignKey(db_index=False, on_delete=django.db.models.deletion.CASCADE, to='judge.problem',
+                                    verbose_name='problem'),
+        ),
+        migrations.AlterField(
+            model_name='submission',
+            name='user',
+            field=models.ForeignKey(db_index=False, on_delete=django.db.models.deletion.CASCADE, to='judge.profile',
+                                    verbose_name='user'),
+        ),
+        migrations.AlterField(
+            model_name='submissiontestcase',
+            name='submission',
+            field=models.ForeignKey(db_index=False, on_delete=django.db.models.deletion.CASCADE,
+                                    related_name='test_cases', to='judge.submission',
+                                    verbose_name='associated submission'),
+        ),
+    ]

--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -64,13 +64,14 @@ class Submission(models.Model):
         'AB': _('Aborted'),
     }
 
-    user = models.ForeignKey(Profile, verbose_name=_('user'), on_delete=models.CASCADE)
-    problem = models.ForeignKey(Problem, verbose_name=_('problem'), on_delete=models.CASCADE)
+    user = models.ForeignKey(Profile, verbose_name=_('user'), on_delete=models.CASCADE, db_index=False)
+    problem = models.ForeignKey(Problem, verbose_name=_('problem'), on_delete=models.CASCADE, db_index=False)
     date = models.DateTimeField(verbose_name=_('submission time'), auto_now_add=True, db_index=True)
     time = models.FloatField(verbose_name=_('execution time'), null=True)
     memory = models.FloatField(verbose_name=_('memory usage'), null=True)
     points = models.FloatField(verbose_name=_('points granted'), null=True)
-    language = models.ForeignKey(Language, verbose_name=_('submission language'), on_delete=models.CASCADE)
+    language = models.ForeignKey(Language, verbose_name=_('submission language'),
+                                 on_delete=models.CASCADE, db_index=False)
     status = models.CharField(verbose_name=_('status'), max_length=2, choices=STATUS, default='QU', db_index=True)
     result = models.CharField(verbose_name=_('result'), max_length=3, choices=SUBMISSION_RESULT,
                               default=None, null=True, blank=True)
@@ -85,7 +86,7 @@ class Submission(models.Model):
     rejudged_date = models.DateTimeField(verbose_name=_('last rejudge date by admin'), null=True, blank=True)
     is_pretested = models.BooleanField(verbose_name=_('was ran on pretests only'), default=False)
     contest_object = models.ForeignKey('Contest', verbose_name=_('contest'), null=True, blank=True,
-                                       on_delete=models.SET_NULL, related_name='+')
+                                       on_delete=models.SET_NULL, related_name='+', db_index=False)
     locked_after = models.DateTimeField(verbose_name=_('submission lock'), null=True, blank=True)
 
     @classmethod
@@ -274,7 +275,7 @@ class SubmissionSource(models.Model):
 class SubmissionTestCase(models.Model):
     RESULT = SUBMISSION_RESULT
 
-    submission = models.ForeignKey(Submission, verbose_name=_('associated submission'),
+    submission = models.ForeignKey(Submission, verbose_name=_('associated submission'), db_index=False,
                                    related_name='test_cases', on_delete=models.CASCADE)
     case = models.IntegerField(verbose_name=_('test case ID'))
     status = models.CharField(max_length=3, verbose_name=_('status flag'), choices=SUBMISSION_RESULT)


### PR DESCRIPTION
The four dropped `Submission` indexes will save 78 MB each in production, and the `SubmissionTestCase` index saves 2.6 GB.