### PR TITLE
Use faster organization check for get_visible_problems

### DIFF
--- a/judge/views/select2.py
+++ b/judge/views/select2.py
@@ -60,7 +60,7 @@ class ClassSelect2View(Select2View):
 class ProblemSelect2View(Select2View):
     def get_queryset(self):
         return Problem.get_visible_problems(self.request.user) \
-                      .filter(Q(code__icontains=self.term) | Q(name__icontains=self.term)).distinct()
+                      .filter(Q(code__icontains=self.term) | Q(name__icontains=self.term))
 
 
 class ContestSelect2View(Select2View):

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -218,7 +218,7 @@ def abort_submission(request, submission):
 def filter_submissions_by_visible_problems(queryset, user):
     join_sql_subquery(
         queryset,
-        subquery=str(Problem.get_visible_problems(user).distinct().only('id').query),
+        subquery=str(Problem.get_visible_problems(user).only('id').query),
         params=[],
         join_fields=[('problem_id', 'id')],
         alias='visible_problems',


### PR DESCRIPTION
This means that we can remove the expensive distinct call from `get_visible_problems` callers.