### PR TITLE
Rework misc config to run exactly one query

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -287,6 +287,7 @@ MIDDLEWARE = (
     'judge.middleware.APIMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'judge.middleware.MiscConfigMiddleware',
     'judge.middleware.DMOJLoginMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/judge/signals.py
+++ b/judge/signals.py
@@ -2,10 +2,9 @@ import errno
 import os
 
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.core.cache.utils import make_template_fragment_key
-from django.db.models.signals import post_delete, post_save, pre_save
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from .caching import finished_submission
@@ -128,35 +127,14 @@ def organization_update(sender, instance, **kwargs):
                        for engine in EFFECTIVE_MATH_ENGINES])
 
 
-_misc_config_i18n = [code for code, _ in settings.LANGUAGES]
-_misc_config_i18n.append('')
-
-
-def misc_config_cache_delete(key):
-    cache.delete_many(['misc_config:%s:%s:%s' % (domain, lang, key.split('.')[0])
-                       for lang in _misc_config_i18n
-                       for domain in Site.objects.values_list('domain', flat=True)])
-
-
-@receiver(pre_save, sender=MiscConfig)
-def misc_config_pre_save(sender, instance, **kwargs):
-    try:
-        old_key = MiscConfig.objects.filter(id=instance.id).values_list('key').get()[0]
-    except MiscConfig.DoesNotExist:
-        old_key = None
-    instance._old_key = old_key
-
-
 @receiver(post_save, sender=MiscConfig)
 def misc_config_update(sender, instance, **kwargs):
-    misc_config_cache_delete(instance.key)
-    if instance._old_key is not None and instance._old_key != instance.key:
-        misc_config_cache_delete(instance._old_key)
+    cache.delete('misc_config')
 
 
 @receiver(post_delete, sender=MiscConfig)
 def misc_config_delete(sender, instance, **kwargs):
-    misc_config_cache_delete(instance.key)
+    cache.delete('misc_config')
 
 
 @receiver(post_save, sender=ContestSubmission)

--- a/templates/base.html
+++ b/templates/base.html
@@ -281,8 +281,8 @@
         <div id="content-body">{% block body %}{% endblock %}</div>
     </main>
 
-    {% if i18n_config.announcement %}
-        <div id="announcement">{{ i18n_config.announcement|safe }}</div>
+    {% if misc_config.announcement %}
+        <div id="announcement">{{ misc_config.announcement|safe }}</div>
     {% endif %}
 
     {% block bodyend %}{% endblock %}
@@ -291,8 +291,8 @@
         <span id="footer-content">
             <br>
             <a style="color: #808080" href="https://dmoj.ca">{{ _('proudly powered by **DMOJ**')|markdown('default', strip_paragraphs=True) }}</a> |
-            {% if i18n_config.footer %}
-                {{ i18n_config.footer|safe }} |
+            {% if misc_config.footer %}
+                {{ misc_config.footer|safe }} |
             {% endif %}
             <form action="{{ url('set_language') }}" method="post" style="display: inline">
                 {% csrf_token %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,12 +1,12 @@
 {% extends "blog/list.html" %}
 {% block before_posts %}
-    {% if i18n_config.home_page_top %}
-        {{ render_django(i18n_config.home_page_top, request=request, user_count=user_count, problem_count=problem_count, submission_count=submission_count, language_count=language_count, perms=perms) }}
+    {% if misc_config.home_page_top %}
+        {{ render_django(misc_config.home_page_top, request=request, user_count=user_count, problem_count=problem_count, submission_count=submission_count, language_count=language_count, perms=perms) }}
     {% endif %}
 {% endblock %}
 {% block meta %}
-    {% if i18n_config.meta_description %}
-        <meta name="description" content="{{ i18n_config['meta_description'] }}">
+    {% if misc_config.meta_description %}
+        <meta name="description" content="{{ misc_config['meta_description'] }}">
     {% endif %}
     <script type="application/ld+json">
         {


### PR DESCRIPTION
There should never be that much stuff in MiscConfig, so let's just read it all and deal with it in python instead of trying to run one query for each item of interest and poorly cache it.

This PR also moved MiscConfigDict into a middleware so it can be used outside of templates.