### PR TITLE
Fix PDF rendering for relative STATIC_URL

### DIFF
--- a/templates/problem/raw.html
+++ b/templates/problem/raw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="stylesheet" href="{{ static('style.css') }}">
+    <link rel="stylesheet" href="{{ urljoin(url, static('style.css')) }}">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <style>
         html {
@@ -81,7 +81,7 @@
     {{ description|markdown(problem.markdown_style, 'tex' if math_engine == 'jax' else math_engine)|reference|absolutify(url)|str|safe }}
 </div>
 {% if math_engine == 'jax' %}
-    <script type="text/javascript" src="{{ static('mathjax_config.js') }}"></script>
+    <script type="text/javascript" src="{{ urljoin(url, static('mathjax_config.js')) }}"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.0/es5/tex-chtml.min.js"></script>
     <script type="text/javascript">
         MathJax.typesetPromise().then(function () {


### PR DESCRIPTION
If `STATIC_URL` is relative, then we get a relative path in the HTML, which fails to render correctly. Use `urljoin` with the full URL to convert to an absolute URL. Should still work if `STATIC_URL` is already absolute.

```py
>>> from urllib.parse import urljoin
>>> urljoin('https://dmoj.ca/', '/static/a.js')
'https://dmoj.ca/static/a.js'
>>> urljoin('https://dmoj.ca/', 'https://static.dmoj.ca/a.js')
'https://static.dmoj.ca/a.js'
```