### PR TITLE
Autofocus TOTP input field when logging in

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -180,7 +180,7 @@ class NoAutoCompleteCharField(forms.CharField):
 class TOTPForm(Form):
     TOLERANCE = settings.DMOJ_TOTP_TOLERANCE_HALF_MINUTES
 
-    totp_or_scratch_code = NoAutoCompleteCharField(required=False)
+    totp_or_scratch_code = NoAutoCompleteCharField(required=False, widget=forms.TextInput(attrs={'autofocus': True}))
 
     def __init__(self, *args, **kwargs):
         self.profile = kwargs.pop('profile')


### PR DESCRIPTION
This is so you avoid having to click into the field before being able to enter code.