### PR TITLE
Make 'create_problem' command work and add options

### DIFF
--- a/judge/management/commands/create_problem.py
+++ b/judge/management/commands/create_problem.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from judge.models import Problem, ProblemGroup, ProblemType
-from judge.models.runtime import Language
+from judge.models import Problem, ProblemGroup, ProblemType, Language
 
 
 class Command(BaseCommand):
@@ -27,7 +26,7 @@ class Command(BaseCommand):
         problem.name = options['name']
         problem.description = options['body']
         problem.group = ProblemGroup.objects.get(name=options['group'])
-        problem.time_limit = options["time_limit"]
+        problem.time_limit = options['time_limit']
         problem.memory_limit = options["memory_limit"]
         problem.points = options["points"]
         if options['pr_pts']:
@@ -36,5 +35,5 @@ class Command(BaseCommand):
 
         problem.types.set([ProblemType.objects.get(name=options['type'])])
         if options['all_lang']:
-            problem.allowed_languages.set([l for l in Language.objects.all()])
+            problem.allowed_languages.set(Language.objects.all())
         problem.save()

--- a/judge/management/commands/create_problem.py
+++ b/judge/management/commands/create_problem.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 
 from judge.models import Problem, ProblemGroup, ProblemType
+from judge.models.runtime import Language
 
 
 class Command(BaseCommand):
@@ -12,6 +13,13 @@ class Command(BaseCommand):
         parser.add_argument('body', help='problem description')
         parser.add_argument('type', help='problem type')
         parser.add_argument('group', help='problem group')
+        parser.add_argument('time_limit', help='time limit in (fractional) seconds')
+        parser.add_argument('memory_limit', help='memory limit in kilobytes')
+        parser.add_argument('points', help='problem points')
+        parser.add_argument('--partial-points', help='allow partial points',
+            action='store_true', default=False, dest='pr_pts')
+        parser.add_argument('--all-languages', help='allow all languages',
+            action='store_true', default=False, dest='all_lang')
 
     def handle(self, *args, **options):
         problem = Problem()
@@ -19,5 +27,14 @@ class Command(BaseCommand):
         problem.name = options['name']
         problem.description = options['body']
         problem.group = ProblemGroup.objects.get(name=options['group'])
-        problem.types = [ProblemType.objects.get(name=options['type'])]
+        problem.time_limit = options["time_limit"]
+        problem.memory_limit = options["memory_limit"]
+        problem.points = options["points"]
+        if options['pr_pts']:
+            problem.partial = 1
+        problem.save()
+
+        problem.types.set([ProblemType.objects.get(name=options['type'])])
+        if options['all_lang']:
+            problem.allowed_languages.set([l for l in Language.objects.all()])
         problem.save()

--- a/judge/management/commands/create_problem.py
+++ b/judge/management/commands/create_problem.py
@@ -27,8 +27,8 @@ class Command(BaseCommand):
         problem.description = options['body']
         problem.group = ProblemGroup.objects.get(name=options['group'])
         problem.time_limit = options['time_limit']
-        problem.memory_limit = options["memory_limit"]
-        problem.points = options["points"]
+        problem.memory_limit = options['memory_limit']
+        problem.points = options['points']
         if options['pr_pts']:
             problem.partial = 1
         problem.save()

--- a/judge/management/commands/create_problem.py
+++ b/judge/management/commands/create_problem.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from judge.models import Problem, ProblemGroup, ProblemType, Language
+from judge.models import Language, Problem, ProblemGroup, ProblemType
 
 
 class Command(BaseCommand):
@@ -16,9 +16,9 @@ class Command(BaseCommand):
         parser.add_argument('memory_limit', help='memory limit in kilobytes')
         parser.add_argument('points', help='problem points')
         parser.add_argument('--partial-points', help='allow partial points',
-            action='store_true', default=False, dest='pr_pts')
+                            action='store_true', default=False, dest='pr_pts')
         parser.add_argument('--all-languages', help='allow all languages',
-            action='store_true', default=False, dest='all_lang')
+                            action='store_true', default=False, dest='all_lang')
 
     def handle(self, *args, **options):
         problem = Problem()


### PR DESCRIPTION
Corresponding to the issue #2255 

Commit details:
- properly assign `types` to match Django's new rules
- initialize fields of `time_limit`, `memory_limit`, and `points` to be able to save the model
- add options `--partial-points` and `--all-languages` to make added problems immediately usable in automation