### PR TITLE
UserList: sort users by id

### DIFF
--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -435,7 +435,7 @@ class UserList(QueryStringSortMixin, InfinitePaginationMixin, DiggPaginatorMixin
     default_sort = '-performance_points'
 
     def get_queryset(self):
-        return (Profile.objects.filter(is_unlisted=False).order_by(self.order).select_related('user')
+        return (Profile.objects.filter(is_unlisted=False).order_by(self.order, 'id').select_related('user')
                 .only('display_rank', 'user__username', 'username_display_override', 'points', 'rating',
                       'performance_points', 'problem_count'))
 


### PR DESCRIPTION
Otherwise, `user_ranking_redirect` returns the wrong page for users at the end of the ranking table because it assumes the list is sorted by `performance_points` and `id`, and those users have `performance_points = 0`.

I've only tested this on my fork (VNOJ, too lazy to setup DMOJ), though. Please test this on DMOJ.