### PR TITLE
Make "Contest Ends..." link to timeanddate.com of contest end time instead of start time

### DIFF
--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -27,7 +27,8 @@
 {% block body %}
     <div id="banner">
         <a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg={{ contest.name|urlquote('') }}&amp;iso=
-                {{- contest.start_time|utc|date('Y-m-d\TH:i:s') }}" class="date">
+                {% if contest.start_time > now %} {{- contest.start_time|utc|date('Y-m-d\TH:i:s') }}
+                {% else %} {{- contest.end_time|utc|date('Y-m-d\TH:i:s') }} {% endif %}" class="date">
             {%- if contest.is_in_contest(request.user) and not request.participation.live -%}
                 {% if request.participation.spectate %}
                     {{- _('Spectating, contest ends in %(countdown)s.', countdown=as_countdown(contest.time_before_end)) -}}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -27,8 +27,7 @@
 {% block body %}
     <div id="banner">
         <a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg={{ contest.name|urlquote('') }}&amp;iso=
-                {% if contest.start_time > now %} {{- contest.start_time|utc|date('Y-m-d\TH:i:s') }}
-                {% else %} {{- contest.end_time|utc|date('Y-m-d\TH:i:s') }} {% endif %}" class="date">
+                {{- (contest.start_time if contest.start_time > now else contest.end_time)|utc|date('Y-m-d\TH:i:s') }}" class="date">
             {%- if contest.is_in_contest(request.user) and not request.participation.live -%}
                 {% if request.participation.spectate %}
                     {{- _('Spectating, contest ends in %(countdown)s.', countdown=as_countdown(contest.time_before_end)) -}}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -27,7 +27,7 @@
 {% block body %}
     <div id="banner">
         <a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg={{ contest.name|urlquote('') }}&amp;iso=
-                {{- (contest.start_time if contest.start_time > now else contest.end_time)|utc|date('Y-m-d\TH:i:s') }}" class="date">
+                {{- (contest.start_time if contest.start_time >= now else contest.end_time)|utc|date('Y-m-d\TH:i:s') }}" class="date">
             {%- if contest.is_in_contest(request.user) and not request.participation.live -%}
                 {% if request.participation.spectate %}
                     {{- _('Spectating, contest ends in %(countdown)s.', countdown=as_countdown(contest.time_before_end)) -}}


### PR DESCRIPTION
Fixes #2027

the link now goes to the contest end time if it has already started
might be a bad solution, this is my first pr ever idk 