### PR TITLE
Relabel the version matrix page to just "Versions"

### DIFF
--- a/judge/views/status.py
+++ b/judge/views/status.py
@@ -105,7 +105,7 @@ def version_matrix(request):
 
     languages = sorted(languages, key=lambda lang: version.parse(lang.name))
     return render(request, 'status/versions.html', {
-        'title': _('Version matrix'),
+        'title': _('Version'),
         'judges': sorted(matrix.keys()),
         'languages': languages,
         'matrix': matrix,

--- a/templates/status/status-tabs.html
+++ b/templates/status/status-tabs.html
@@ -3,5 +3,5 @@
 {% block tabs %}
     {{ make_tab('judges', 'fa-server', url('status_all'), _('Judges')) }}
     {{ make_tab('runtimes', 'fa-code', url('runtime_list'), _('Runtimes')) }}
-    {{ make_tab('matrix', 'fa-table', url('version_matrix'), _('Version Matrix')) }}
+    {{ make_tab('matrix', 'fa-table', url('version_matrix'), _('Versions')) }}
 {% endblock %}


### PR DESCRIPTION
We had an inconsistency in "Version Matrix" versus "Version matrix", but in fixing it I figured just calling this tab "Versions" makes sense.