### PR TITLE
Make user profile picture look better in dark mode

### DIFF
--- a/resources/users.scss
+++ b/resources/users.scss
@@ -117,7 +117,6 @@ tr:target {
 img.user-gravatar {
     display: block;
     border-radius: 6px;
-    background-color: white;
 }
 
 .user-content {


### PR DESCRIPTION
# Problem:
Background not inherited from body.

# Solution

Remove the pointless background tag, as in light mode, the tag is also inherited from body


## Dark
Before:
![image](https://github.com/DMOJ/online-judge/assets/58890327/d65340af-355a-4405-ae01-fc44ef2e14a3)

ewwwww

After:
![image](https://github.com/DMOJ/online-judge/assets/58890327/50651edb-7f3c-42d6-9c31-2f0b3c0c7655)

Yay my pfp works

## Light
Before:
![image](https://github.com/DMOJ/online-judge/assets/58890327/c6b86617-1665-4e13-8f73-bb2d45cd2493)

After:
![image](https://github.com/DMOJ/online-judge/assets/58890327/c88e4912-fce5-420f-9163-9f5990c39a1b)

no change :)