### PR TITLE
Add unordered checker as an option

### DIFF
--- a/judge/models/problem_data.py
+++ b/judge/models/problem_data.py
@@ -26,6 +26,7 @@ CHECKERS = (
     ('floatsrel', _('Floats (relative)')),
     ('rstripped', _('Non-trailing spaces')),
     ('sorted', _('Sorted')),
+    ('unordered', _('Unordered')),
     ('identical', _('Byte identical')),
     ('linecount', _('Line-by-line')),
 )


### PR DESCRIPTION
This adds the unordered checker to the dropdown containing the list of available checkers to use for a problem.