### PR TITLE
Clean up code for chart colors

### DIFF
--- a/judge/utils/stats.py
+++ b/judge/utils/stats.py
@@ -3,25 +3,17 @@ from operator import itemgetter
 __all__ = ('chart_colors', 'highlight_colors', 'get_pie_chart', 'get_bar_chart')
 
 
-chart_colors = [0x3366CC, 0xDC3912, 0xFF9900, 0x109618, 0x990099, 0x3B3EAC, 0x0099C6, 0xDD4477, 0x66AA00, 0xB82E2E,
-                0x316395, 0x994499, 0x22AA99, 0xAAAA11, 0x6633CC, 0xE67300, 0x8B0707, 0x329262, 0x5574A6, 0x3B3EAC]
+BASE_COLORS = [0x3366CC, 0xDC3912, 0xFF9900, 0x109618, 0x990099, 0x3B3EAC, 0x0099C6, 0xDD4477, 0x66AA00, 0xB82E2E,
+               0x316395, 0x994499, 0x22AA99, 0xAAAA11, 0x6633CC, 0xE67300, 0x8B0707, 0x329262, 0x5574A6, 0x3B3EAC]
 
 
-highlight_colors = []
+def _to_highlight_color(color):
+    r, g, b = color >> 16, (color >> 8) & 0xFF, color & 0xFF
+    return '#%02X%02X%02X' % (min(int(r * 1.2), 255), min(int(g * 1.2), 255), min(int(b * 1.2), 255))
 
 
-def _highlight_colors():
-    for color in chart_colors:
-        r, g, b = color >> 16, (color >> 8) & 0xFF, color & 0xFF
-        highlight_colors.append('#%02X%02X%02X' % (min(int(r * 1.2), 255),
-                                                   min(int(g * 1.2), 255),
-                                                   min(int(b * 1.2), 255)))
-
-
-_highlight_colors()
-
-
-chart_colors = list(map('#%06X'.__mod__, chart_colors))
+chart_colors = list(map('#%06X'.__mod__, BASE_COLORS))
+highlight_colors = list(map(_to_highlight_color, BASE_COLORS))
 
 
 def get_pie_chart(data):


### PR DESCRIPTION
both codes produce the same values for `chart_colors` and `highlight_colors`. i.e.

```
['#3366CC', '#DC3912', '#FF9900', '#109618', '#990099', '#3B3EAC', '#0099C6', '#DD4477', '#66AA00', '#B82E2E', '#316395', '#994499', '#22AA99', '#AAAA11', '#6633CC', '#E67300', '#8B0707', '#329262', '#5574A6', '#3B3EAC']
['#3D7AF4', '#FF4415', '#FFB700', '#13B41C', '#B700B7', '#464ACE', '#00B7ED', '#FF518E', '#7ACC00', '#DC3737', '#3A76B2', '#B751B7', '#28CCB7', '#CCCC14', '#7A3DF4', '#FF8A00', '#A60808', '#3CAF75', '#668BC7', '#464ACE']
```