### PR TITLE
Fix user admin object creation and deletion

### DIFF
--- a/judge/admin/__init__.py
+++ b/judge/admin/__init__.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry
+from django.contrib.auth.models import User
 from django.contrib.flatpages.models import FlatPage
 
 from judge.admin.comments import CommentAdmin
@@ -7,7 +8,7 @@ from judge.admin.contest import ContestAdmin, ContestParticipationAdmin, Contest
 from judge.admin.interface import BlogPostAdmin, FlatPageAdmin, LicenseAdmin, LogEntryAdmin, NavigationBarAdmin
 from judge.admin.organization import ClassAdmin, OrganizationAdmin, OrganizationRequestAdmin
 from judge.admin.problem import ProblemAdmin, ProblemPointsVoteAdmin
-from judge.admin.profile import ProfileAdmin
+from judge.admin.profile import ProfileAdmin, UserAdmin
 from judge.admin.runtime import JudgeAdmin, LanguageAdmin
 from judge.admin.submission import SubmissionAdmin
 from judge.admin.taxon import ProblemGroupAdmin, ProblemTypeAdmin
@@ -40,3 +41,5 @@ admin.site.register(ProblemType, ProblemTypeAdmin)
 admin.site.register(Profile, ProfileAdmin)
 admin.site.register(Submission, SubmissionAdmin)
 admin.site.register(Ticket, TicketAdmin)
+admin.site.unregister(User)
+admin.site.register(User, UserAdmin)


### PR DESCRIPTION
Refs #931. Closes #2288.

- Automatically create profile when adding a user through admin
- Disallow adding profiles through admin
- (Soft) disallow deleting profiles through admin