### PR TITLE
Implement user email change functionality

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -107,8 +107,15 @@ DMOJ_STATS_SUBMISSION_RESULT_COLORS = {
 }
 DMOJ_API_PAGE_SIZE = 1000
 
-DMOJ_PASSWORD_RESET_LIMIT_WINDOW = 3600
+# Number of password resets per window (in minutes)
+DMOJ_PASSWORD_RESET_LIMIT_WINDOW = 60
 DMOJ_PASSWORD_RESET_LIMIT_COUNT = 10
+
+# Number of email change requests per window (in minutes)
+DMOJ_EMAIL_CHANGE_LIMIT_WINDOW = 60
+DMOJ_EMAIL_CHANGE_LIMIT_COUNT = 10
+# Number of minutes before an email change request activation key expires
+DMOJ_EMAIL_CHANGE_EXPIRY_MINUTES = 60
 
 # At the bare minimum, dark and light theme CSS file locations must be declared
 DMOJ_THEME_CSS = {
@@ -600,6 +607,9 @@ except IOError:
 
 # Check settings are consistent
 assert DMOJ_PROBLEM_MIN_USER_POINTS_VOTE >= DMOJ_PROBLEM_MIN_PROBLEM_POINTS
+
+# <= 1 minute expiry is unusable UX
+assert DMOJ_EMAIL_CHANGE_EXPIRY_MINUTES > 1
 
 if DMOJ_PDF_PDFOID_URL:
     # If a cache is configured, it must already exist and be a directory

--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -60,6 +60,9 @@ register_patterns = [
         template_name='registration/password_reset_done.html',
     ), name='password_reset_done'),
     path('social/error/', register.social_auth_error, name='social_auth_error'),
+    path('email/change/', user.EmailChangeRequestView.as_view(), name='email_change'),
+    path('email/change/activate/<str:activation_key>/',
+         user.EmailChangeActivateView.as_view(), name='email_change_activate'),
 
     path('2fa/', two_factor.TwoFactorLoginView.as_view(), name='login_2fa'),
     path('2fa/enable/', two_factor.TOTPEnableView.as_view(), name='enable_2fa'),

--- a/judge/utils/mail.py
+++ b/judge/utils/mail.py
@@ -1,0 +1,42 @@
+import re
+from typing import Any, Dict, List, Optional, Pattern
+
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.forms import ValidationError
+from django.template import loader
+from django.utils.translation import gettext
+
+
+bad_mail_regex: List[Pattern[str]] = list(map(re.compile, settings.BAD_MAIL_PROVIDER_REGEX))
+
+
+def validate_email_domain(email: str) -> None:
+    if '@' in email:
+        domain = email.split('@')[-1].lower()
+        if domain in settings.BAD_MAIL_PROVIDERS or any(regex.match(domain) for regex in bad_mail_regex):
+            raise ValidationError(gettext('Your email provider is not allowed due to history of abuse. '
+                                          'Please use a reputable email provider.'))
+
+
+# Inspired by django.contrib.auth.forms.PasswordResetForm.send_mail
+def send_mail(
+    context: Dict[str, Any],
+    *,
+    from_email: Optional[str] = None,
+    to_email: str,
+    subject_template_name: str,
+    email_template_name: str,
+    html_email_template_name: Optional[str] = None,
+) -> None:
+    subject = loader.render_to_string(subject_template_name, context)
+    # Email subject *must not* contain newlines
+    subject = ''.join(subject.splitlines())
+    body = loader.render_to_string(email_template_name, context)
+
+    email_message = EmailMultiAlternatives(subject, body, from_email, [to_email])
+    if html_email_template_name is not None:
+        html_email = loader.render_to_string(html_email_template_name, context)
+        email_message.attach_alternative(html_email, 'text/html')
+
+    email_message.send()

--- a/templates/registration/email_change.html
+++ b/templates/registration/email_change.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block media %}
+<style>
+.errorlist {
+    list-style-type: none;
+    margin-block-start: 0;
+    margin-block-end: 0.5em;
+    padding: 0;
+}
+</style>
+{% endblock %}
+
+{% block body %}
+    <div class="centered-form" style="text-align: center">
+        <form action="" method="post" class="form-area">
+            {% csrf_token %}
+            <table border="0" class="django-as-table">{{ form.as_table() }}</table>
+            <hr>
+            <button class="submit-bar" type="submit">{{ _('Request email change') }}</button>
+        </form>
+    </div>
+{% endblock %}

--- a/templates/registration/email_change_activate_email.html
+++ b/templates/registration/email_change_activate_email.html
@@ -1,0 +1,24 @@
+<div style="border:2px solid #fd0;margin:4px 0;"><div style="background:#000;border:6px solid #000;">
+<a href="{{ protocol }}://{{ domain }}"><img src="{{ protocol }}://{{ domain }}/static/icons/logo.svg" alt="{{ site_name }}" width="160" height="44"></a>
+</div></div>
+
+<div style="border:2px solid #337ab7;margin:4px 0;"><div style="background:#fafafa;border:12px solid #fafafa;font-family:segoe ui,lucida grande,Arial,sans-serif;font-size:14px;">
+<br><br>
+{{ user.get_username() }},
+<br>
+{% trans %}You have requested to change your email address to this email for your user account at {{ site_name }}.{% endtrans %}
+<br><br>
+{% trans trimmed count=expiry_minutes %}
+Please click the link to confirm this email change. The link will expire in {{ count }} minute.
+{% pluralize %}
+Please click the link to confirm this email change. The link will expire in {{ count }} minutes.
+{% endtrans %}
+<br>
+<a href="{{ protocol }}://{{ domain }}{{ url('email_change_activate', activation_key=activation_key) }}">{{ protocol }}://{{ domain }}{{ url('email_change_activate', activation_key=activation_key) }}</a>
+<br><br>
+{% if site_admin_email %}
+{% with link='<a href="mailto:%(email)s">%(email)s</a>'|safe|format(email=site_admin_email) %}
+{{ _('If you have encounter any problems, feel free to shoot us an email at %(email)s.', email=link) }}
+{% endwith %}
+{% endif %}
+</div></div>

--- a/templates/registration/email_change_activate_email.txt
+++ b/templates/registration/email_change_activate_email.txt
@@ -1,0 +1,15 @@
+{{ user.get_username() }},
+
+{% trans %}You have requested to change your email address to this email for your user account at {{ site_name }}.{% endtrans %}
+
+{% trans trimmed count=expiry_minutes %}
+Please go to this page to confirm this email change. The link will expire in {{ count }} minute.
+{% pluralize %}
+Please go to this page to confirm this email change. The link will expire in {{ count }} minutes.
+{% endtrans %}
+
+{{ protocol }}://{{ domain }}{{ url('email_change_activate', activation_key=activation_key) }}
+
+{% if site_admin_email %}
+{{ _('If you have encounter any problems, feel free to shoot us an email at %(email)s.', email=site_admin_email) }}
+{% endif %}

--- a/templates/registration/email_change_activate_subject.txt
+++ b/templates/registration/email_change_activate_subject.txt
@@ -1,0 +1,1 @@
+{% trans %}Email change request on {{ site_name }}{% endtrans %}

--- a/templates/registration/email_change_notify_email.html
+++ b/templates/registration/email_change_notify_email.html
@@ -1,0 +1,23 @@
+<div style="border:2px solid #fd0;margin:4px 0;"><div style="background:#000;border:6px solid #000;">
+<a href="{{ protocol }}://{{ domain }}"><img src="{{ protocol }}://{{ domain }}/static/icons/logo.svg" alt="{{ site_name }}" width="160" height="44"></a>
+</div></div>
+
+<div style="border:2px solid #337ab7;margin:4px 0;"><div style="background:#fafafa;border:12px solid #fafafa;font-family:segoe ui,lucida grande,Arial,sans-serif;font-size:14px;">
+<br><br>
+{{ user.get_username() }},
+<br>
+{% trans %}Someone (hopefully you!) has requested to change the email address associated with your user account at {{ site_name }} to {{ new_email }}. {% endtrans %}
+<br><br>
+{{ _('If this was you, no further action is required.') }}
+
+<br>
+<b>
+{% if site_admin_email %}
+{% with link='<a href="mailto:%(email)s">%(email)s</a>'|safe|format(email=site_admin_email) %}
+{{ _('If this was not you, please change your password and email us immediately at %(email)s.', email=link) }}
+{% endwith %}
+{% else %}
+{{ _('If this was not you, please change your password and reply to this email immediately.') }}
+{% endif %}
+</b>
+</div></div>

--- a/templates/registration/email_change_notify_email.txt
+++ b/templates/registration/email_change_notify_email.txt
@@ -1,0 +1,9 @@
+{{ user.get_username() }},
+{% trans %}Someone (hopefully you!) has requested to change the email address associated with your user account at {{ site_name }} to {{ new_email }}. {% endtrans %}
+
+{{ _('If this was you, no further action is required.') }}
+{% if site_admin_email %}
+{{ _('If this was not you, please change your password and email us immediately at %(email)s.', email=site_admin_email) }}
+{% else %}
+{{ _('If this was not you, please change your password and reply to this email immediately.') }}
+{% endif %}

--- a/templates/registration/email_change_notify_subject.txt
+++ b/templates/registration/email_change_notify_subject.txt
@@ -1,0 +1,1 @@
+{% trans %}Alert: Email change request on {{ site_name }}{% endtrans %}

--- a/templates/user/edit-profile.html
+++ b/templates/user/edit-profile.html
@@ -338,6 +338,11 @@
                                 {{ _('Change your password') }}
                             </a>
                         </td></tr>
+                        <tr><td>
+                            <a href="{{ url('email_change') }}" class="inline-header">
+                                {{ _('Change your email') }}
+                            </a>
+                        </td></tr>
                         {% if can_download_data %}
                             <tr><td>
                                 <a href="{{ url('user_prepare_data') }}" class="inline-header">


### PR DESCRIPTION
Fixes #1996.

Request email change process:
1. User goes to email change endpoint with a form that consists of a password and email. This endpoint is accessible via edit profile.
2. Verify password and verify email is not used or blacklisted.
3. Create a base64-encoded key that is {user id, new email} signed by SECRET_KEY and create an endpoint that accepts this key. This key will contains a timestamp, which will be used to check expiry.
4. Send this URL to the new email, send a security notice to the old email (email change requested).

Confirm email change process:
1. User clicks the URL in the email.
2. Verify signing, verify expiry timestamp, verify user id matches currently logged in user.
3. Verify again that new email is not used and update email in the database (atomically).
