### PR TITLE
events: properly publish abort events

### DIFF
--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -476,8 +476,8 @@ class JudgeHandler(ZlibPacketHandler):
         self._free_self(packet)
 
         if Submission.objects.filter(id=packet['submission-id']).update(status='AB', result='AB', points=0):
-            event.post('sub_%s' % Submission.get_id_secret(packet['submission-id']), {'type': 'aborted-submission'})
-            self._post_update_submission(packet['submission-id'], 'terminated', done=True)
+            event.post('sub_%s' % Submission.get_id_secret(packet['submission-id']), {'type': 'aborted'})
+            self._post_update_submission(packet['submission-id'], 'aborted', done=True)
             json_log.info(self._make_json_log(packet, action='aborted', finish=True, result='AB'))
         else:
             logger.warning('Unknown submission: %s', packet['submission-id'])

--- a/judge/judgeapi.py
+++ b/judge/judgeapi.py
@@ -119,5 +119,5 @@ def abort_submission(submission):
     # and returns a bad-request, the submission is not falsely shown as "Aborted" when it will still be judged.
     if not response.get('judge-aborted', True):
         Submission.objects.filter(id=submission.id).update(status='AB', result='AB', points=0)
-        event.post('sub_%s' % Submission.get_id_secret(submission.id), {'type': 'aborted-submission'})
+        event.post('sub_%s' % Submission.get_id_secret(submission.id), {'type': 'aborted'})
         _post_update_submission(submission, done=True)

--- a/templates/submission/status.html
+++ b/templates/submission/status.html
@@ -38,6 +38,7 @@
                     "{{ EVENT_DAEMON_LOCATION }}", "{{ EVENT_DAEMON_POLL_LOCATION }}",
                     ['sub_{{ submission.id_secret }}'], {{ last_msg }}, function (message) {
                         switch (message.type) {
+                            case 'aborted':
                             case 'internal-error':
                             case 'grading-end':
                             case 'compile-error':


### PR DESCRIPTION
I think this should avoid cases of the "Abort" button sticking around.