### PR TITLE
Sort contest users with 0 points by submission count

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -677,7 +677,8 @@ def base_contest_ranking_list(contest, problems, queryset):
 def contest_ranking_list(contest, problems):
     return base_contest_ranking_list(contest, problems, contest.users.filter(virtual=0)
                                      .prefetch_related('user__organizations')
-                                     .order_by('is_disqualified', '-score', 'cumtime', 'tiebreaker'))
+                                     .annotate(submission_cnt=Count('submission'))
+                                     .order_by('is_disqualified', '-score', 'cumtime', 'tiebreaker', '-submission_cnt'))
 
 
 def get_contest_ranking_list(request, contest, participation=None, ranking_list=contest_ranking_list,


### PR DESCRIPTION
Fixes #650. When 2 users score 0 points, the user who submitted will appear first.

![Screenshot 2024-01-02 003918](https://github.com/DMOJ/online-judge/assets/14223529/72d7352a-53ad-47bf-bc60-7c59aa8fb026)

Also, using `'submission_cnt'` will sort the users the other way.