### PR TITLE
Add hCaptcha backend as an alternative to reCAPTCHA

### DIFF
--- a/judge/utils/hcaptcha.py
+++ b/judge/utils/hcaptcha.py
@@ -1,0 +1,10 @@
+try:
+    from hcaptcha_field import hCaptchaField, hCaptchaWidget
+except ImportError:
+    hCaptchaField = None
+    hCaptchaWidget = None
+else:
+    from django.conf import settings
+    if not hasattr(settings, 'HCAPTCHA_SECRET'):
+        hCaptchaField = None
+        hCaptchaWidget = None

--- a/judge/views/register.py
+++ b/judge/views/register.py
@@ -14,6 +14,7 @@ from sortedm2m.forms import SortedMultipleChoiceField
 from judge.models import Language, Organization, Profile, TIMEZONE
 from judge.utils.mail import validate_email_domain
 from judge.utils.recaptcha import ReCaptchaField, ReCaptchaWidget
+from judge.utils.hcaptcha import hCaptchaField, hCaptchaWidget
 from judge.utils.subscription import Subscription, newsletter_id
 from judge.widgets import Select2MultipleWidget, Select2Widget
 
@@ -34,7 +35,10 @@ class CustomRegistrationForm(RegistrationForm):
         newsletter = forms.BooleanField(label=_('Subscribe to newsletter?'), initial=True, required=False)
 
     if ReCaptchaField is not None:
-        captcha = ReCaptchaField(widget=ReCaptchaWidget())
+        recaptcha = ReCaptchaField(widget=ReCaptchaWidget())
+    
+    if hCaptchaField is not None:
+        hcaptcha = hCaptchaField()
 
     def clean_email(self):
         if User.objects.filter(email=self.cleaned_data['email']).exists():

--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -126,7 +126,7 @@
             } catch (e) {}
         });
     </script>
-    {% if form.captcha %}
+    {% if form.recaptcha %}
         {{ recaptcha_init(LANGUAGE_CODE) }}
     {% endif %}
 {% endblock %}
@@ -196,10 +196,17 @@
                 </div>
             {% endif %}
 
-            {% if form.captcha %}
-                <div style="margin-top: 0.5em">{{ form.captcha }}</div>
-                {% if form.captcha.errors %}
-                    <div class="form-field-error">{{ form.captcha.errors }}</div>
+            {% if form.recaptcha %}
+                <div style="margin-top: 0.5em">{{ form.recaptcha }}</div>
+                {% if form.recaptcha.errors %}
+                    <div class="form-field-error">{{ form.recaptcha.errors }}</div>
+                {% endif %}
+            {% endif %}
+
+            {% if form.hcaptcha %}
+                <div style="margin-top: 0.5em">{{ form.hcaptcha }}</div>
+                {% if form.hcaptcha.errors %}
+                    <div class="form-field-error">{{ form.hcaptcha.errors }}</div>
                 {% endif %}
             {% endif %}
 


### PR DESCRIPTION
<img width="528" alt="Screenshot 2024-01-20 at 4 57 08 PM" src="https://github.com/DMOJ/online-judge/assets/75343012/7e5f14b0-3fb5-47f8-a065-dbd119810430">

This PR adds support for an hCaptcha backend powered by `django-hcaptcha-field`. Most additions are duplicated from the existing reCAPTCHA backend as the hCaptcha package is very similar.

See https://blog.cloudflare.com/moving-from-recaptcha-to-hcaptcha for possible benefits over reCAPTCHA.
