### PR TITLE
Add Kazakh language option in UI

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -398,6 +398,7 @@ LANGUAGES = [
     ('hr', _('Croatian')),
     ('hu', _('Hungarian')),
     ('ja', _('Japanese')),
+    ('kk', _('Kazakh')),
     ('ko', _('Korean')),
     ('pt', _('Brazilian Portuguese')),
     ('ro', _('Romanian')),

--- a/judge/jinja2/markdown/__init__.py
+++ b/judge/jinja2/markdown/__init__.py
@@ -154,9 +154,9 @@ def strip_paragraphs_tags(tree):
         parent = p.getparent()
         prev = p.getprevious()
         if prev is not None:
-            prev.tail = (prev.tail or '') + p.text
+            prev.tail = (prev.tail or '') + (p.text or '')
         else:
-            parent.text = (parent.text or '') + p.text
+            parent.text = (parent.text or '') + (p.text or '')
         parent.remove(p)
 
 


### PR DESCRIPTION
* Add `kk` to language selector dropdown.
* Fix a bug with `{{ _('**a** b')|markdown('default', strip_paragraphs=True) }}`.
  * The bug is that `p.text` could be `None`, and Python can't add a string to `None`.