### PR TITLE
Fix lxml for unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-social-share
 django-sortedm2m>=3.1.0
 django-impersonate
 dmoj-wpadmin @ git+https://github.com/DMOJ/dmoj-wpadmin.git
-lxml
+lxml[html_clean]
 Pygments
 mistune<2
 social-auth-core==4.3.0


### PR DESCRIPTION
Unit tests are failing because of this error:

```
  File "/home/runner/work/online-judge/online-judge/judge/migrations/0091_compiler_message_ansi2html.py", line 4, in <module>
    from lxml.html.clean import clean_html
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/lxml/html/clean.py", line 21, in <module>
    ) from None
ImportError: lxml.html.clean module is now a separate project lxml_html_clean.
Install lxml[html_clean] or lxml_html_clean directly.
Error: Process completed with exit code 1.
```