### PR TITLE
Fix comment revision count

### DIFF
--- a/judge/migrations/0146_comment_revision_count_v2.py
+++ b/judge/migrations/0146_comment_revision_count_v2.py
@@ -1,0 +1,39 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import migrations, models
+
+
+def populate_revisions(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    try:
+        content_type = ContentType.objects.get(app_label='judge', model='Comment')
+    except ObjectDoesNotExist:
+        # If you don't have content types, then you obviously haven't had any edited comments.
+        # Therefore, it's safe to all revision counts as zero.
+        pass
+    else:
+        schema_editor.execute("""\
+UPDATE `judge_comment` INNER JOIN (
+    SELECT CAST(`reversion_version`.`object_id` AS INT) AS `id`, COUNT(*) AS `count`
+    FROM `reversion_version`
+    WHERE `reversion_version`.`content_type_id` = %s AND
+          `reversion_version`.`db` = %s
+    GROUP BY 1
+) `versions` ON (`judge_comment`.`id` = `versions`.`id`)
+SET `judge_comment`.`revisions` = `versions`.`count`;
+""", (content_type.id, db_alias))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('judge', '0145_site_data_batch_prerequisites'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='comment',
+            name='revisions',
+            field=models.IntegerField(default=1, verbose_name='revisions'),
+        ),
+        migrations.RunPython(populate_revisions, migrations.RunPython.noop, atomic=False, elidable=True),
+    ]

--- a/judge/models/comment.py
+++ b/judge/models/comment.py
@@ -33,7 +33,7 @@ class Comment(MPTTModel):
     hidden = models.BooleanField(verbose_name=_('hidden'), default=0)
     parent = TreeForeignKey('self', verbose_name=_('parent'), null=True, blank=True, related_name='replies',
                             on_delete=CASCADE)
-    revisions = models.IntegerField(verbose_name=_('revisions'), default=0)
+    revisions = models.IntegerField(verbose_name=_('revisions'), default=1)
 
     class Meta:
         verbose_name = _('comment')


### PR DESCRIPTION
Fixes #2295. This fixes all comments created since #2216.

When a comment is created, the comment is on the first revision. So the default value of `revisions` should be 1.

Migration 0146 is a copy of 0142, except for the `AlterField` operation.

## Screenshots

Stay on the old code. Make a comment with 3 edits: ![Screenshot 2024-04-11 205130](https://github.com/DMOJ/online-judge/assets/14223529/ccaec0c5-b23e-4c53-b49d-176b3671ed09)

Go to the new code and run migration. Make a comment with 5 edits: ![Screenshot 2024-04-11 205412](https://github.com/DMOJ/online-judge/assets/14223529/2c0a4597-3221-4212-8740-53013bfe309e)