### PR TITLE
Fix i18n in js strings

### DIFF
--- a/judge/jinja2/format.py
+++ b/judge/jinja2/format.py
@@ -1,4 +1,6 @@
-from django.utils.html import format_html
+import html
+
+from django.utils.html import escapejs, format_html
 
 from . import registry
 
@@ -6,3 +8,8 @@ from . import registry
 @registry.function
 def bold(text):
     return format_html('<b>{0}</b>', text)
+
+
+@registry.filter
+def htmltojs(text):
+    return format_html("'{0}'", escapejs(html.unescape(text)))

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -28,7 +28,7 @@
                                     <a href="javascript:comment_upvote({{ node.id }})"
                                        class="upvote-link fa fa-chevron-up fa-fw{% if node.vote_score == 1 %} voted{% endif %}"></a>
                                 {% else %}
-                                    <a href="javascript:alert('{{ _('Please log in to vote')|escapejs }}')" title="{{ _('Please log in to vote') }}"
+                                    <a href="javascript:alert({{ _('Please log in to vote')|htmltojs }})" title="{{ _('Please log in to vote') }}"
                                        class="upvote-link fa fa-chevron-up fa-fw"></a>
                                 {% endif %}
                                 <br>
@@ -37,7 +37,7 @@
                                     <a href="javascript:comment_downvote({{ node.id }})"
                                        class="downvote-link fa fa-chevron-down fa-fw{% if node.vote_score == -1 %} voted{% endif %}"></a>
                                 {% else %}
-                                    <a href="javascript:alert('{{ _('Please log in to vote')|escapejs }}')" title="{{ _('Please log in to vote') }}"
+                                    <a href="javascript:alert({{ _('Please log in to vote')|htmltojs }})" title="{{ _('Please log in to vote') }}"
                                        class="downvote-link fa fa-chevron-down fa-fw"></a>
                                 {% endif %}
                             </div>

--- a/templates/comments/media-js.html
+++ b/templates/comments/media-js.html
@@ -9,7 +9,7 @@
                 var new_id = 'id' + parent + '_body';
                 if ($comment_reply.find('#' + reply_id).length == 0) {
                     var $reply_form = $('#new-comment').clone(true).prop('id', reply_id);
-                    $reply_form.find('h3').html('{{ _('Replying to comment') }}');
+                    $reply_form.find('h3').html({{ _('Replying to comment')|htmltojs }});
                     $reply_form.prepend('<a class="close">x</a>');
                     $reply_form.find('form.comment-submit-form input#id_parent').val(parent);
                     $reply_form.find('div#id_body-wmd-wrapper').prop('id', new_id + '-wmd-wrapper');
@@ -69,12 +69,12 @@
                     $comment.find('.next-revision').css({visibility: show_revision == max_revision ? 'hidden' : ''});
                     var $content = $comment.find('.content').html(body);
 
-                    var edit_text = '{{ _('edit {edits}') }}'.replace("{edits}", show_revision);
+                    var edit_text = {{ _('edit {edits}')|htmltojs }}.replace('{edits}', show_revision);
 
                     if (show_revision == 0) {
-                        edit_text = '{{ _('original') }}';
+                        edit_text = {{ _('original')|htmltojs }};
                     } else if (show_revision == max_revision && max_revision == 1) {
-                        edit_text = '{{ _('edited') }}';
+                        edit_text = {{ _('edited')|htmltojs }};
                     }
 
                     $comment.find('.comment-edit-text').text(' ' + edit_text + ' ');
@@ -98,7 +98,7 @@
                             on_success();
                     },
                     error: function (data, textStatus, jqXHR) {
-                        alert('{{ _('Could not vote: {error}') }}'.replace('{error}', data.responseText));
+                        alert({{ _('Could not vote: {error}')|htmltojs }}.replace('{error}', data.responseText));
                     }
                 });
             }
@@ -134,7 +134,7 @@
             var $comments = $('.comments');
             $comments.find('a.hide-comment').click(function (e) {
                 e.preventDefault();
-                if (!(e.ctrlKey || e.metaKey || confirm('{{ _('Are you sure you want to hide this comment?') }}')))
+                if (!(e.ctrlKey || e.metaKey || confirm({{ _('Are you sure you want to hide this comment?')|htmltojs }})))
                     return;
 
                 var id = $(this).attr('data-id');
@@ -142,7 +142,7 @@
                     $('#comment-' + id).remove();
                     $('#comment-' + id + '-children').remove();
                 }).catch(function () {
-                    alert('{{ _('Could not hide comment.') }}');
+                    alert({{ _('Could not hide comment.')|htmltojs }});
                 });
             });
 
@@ -177,12 +177,12 @@
                                 if (window.add_code_copy_buttons)
                                     window.add_code_copy_buttons($area);
                                 var $edits = $comment.find('.comment-edits').first();
-                                $edits.text('{{ _('updated') }}');
+                                $edits.text({{ _('updated')|htmltojs }});
                             }).fail(function () {
-                                alert('{{ _('Failed to update comment body.') }}');
+                                alert({{ _('Failed to update comment body.')|htmltojs }});
                             });
                         }).fail(function (data) {
-                            alert('{{ _('Could not edit comment: {error}') }}'.replace('{error}', data.responseText));
+                            alert({{ _('Could not edit comment: {error}')|htmltojs }}.replace('{error}', data.responseText));
                         });
                     });
                 },

--- a/templates/common-content.html
+++ b/templates/common-content.html
@@ -29,8 +29,8 @@
                             .append(copyButton = $('<span>', {
                                 'class': 'btn-clipboard',
                                 'data-clipboard-text': $(this).text(),
-                                'title': '{{ _('Click to copy') }}'
-                            }).text('{{ _('Copy') }}')));
+                                'title': {{ _('Click to copy')|htmltojs }}
+                            }).text({{ _('Copy')|htmltojs }})));
 
                         $(copyButton.get(0)).mouseleave(function () {
                             $(this).attr('class', 'btn-clipboard');
@@ -41,7 +41,7 @@
 
                         curClipboard.on('success', function (e) {
                             e.clearSelection();
-                            showTooltip(e.trigger, '{{ _('Copied!') }}');
+                            showTooltip(e.trigger, {{ _('Copied!')|htmltojs }});
                         });
 
                         curClipboard.on('error', function (e) {

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -14,8 +14,8 @@
             $('.contest-tag').find('a[data-featherlight]').featherlight();
 
             $('.join-warning').click(function () {
-                return confirm('{{ _('Are you sure you want to join?') }}\n' +
-                    '{{ _('Joining a contest for the first time starts your timer, after which it becomes unstoppable.') }}');
+                return confirm({{ _('Are you sure you want to join?')|htmltojs }} + '\n' +
+                    {{ _('Joining a contest for the first time starts your timer, after which it becomes unstoppable.')|htmltojs }});
             });
 
             // var tooltip_classes = 'tooltipped tooltipped-e';

--- a/templates/contest/media-js.html
+++ b/templates/contest/media-js.html
@@ -1,19 +1,19 @@
 <script type="text/javascript">
     $(function () {
         $('.leaving-forever').click(function () {
-            return confirm('{{ _('Are you sure you want to leave?') }}\n' +
-                '{{ _('You cannot come back to a virtual participation. You will have to start a new one.') }}');
+            return confirm({{ _('Are you sure you want to leave?')|htmltojs }} + '\n' +
+                {{ _('You cannot come back to a virtual participation. You will have to start a new one.')|htmltojs }});
         });
 
         $('.first-join').click(function () {
-            return confirm('{{ _('Are you sure you want to join?') }}\n' +
-                '{{ _('Joining a contest starts your timer, after which it becomes unstoppable.') }}');
+            return confirm({{ _('Are you sure you want to join?')|htmltojs }} + '\n' +
+                {{ _('Joining a contest starts your timer, after which it becomes unstoppable.')|htmltojs }});
         });
 
         {% if request.in_contest %}
             $('.contest-join').click(function () {
-                return confirm('{{ _('Are you sure you want to join?') }}\n' +
-                    '{{ _('Joining this contest will leave %(contest)s.', contest=request.participation.contest.name) }}');
+                return confirm({{ _('Are you sure you want to join?')|htmltojs }} + '\n' +
+                    {{ _('Joining this contest will leave %(contest)s.', contest=request.participation.contest.name)|htmltojs }});
             });
         {% endif %}
     });

--- a/templates/contest/moss.html
+++ b/templates/contest/moss.html
@@ -25,10 +25,10 @@
     <script type="text/javascript">
         $(function () {
             $('.contest-moss').click(function () {
-                return confirm('{{ _('Are you sure you want to MOSS the contest?') }}');
+                return confirm({{ _('Are you sure you want to MOSS the contest?')|htmltojs }});
             });
             $('.contest-moss-delete').click(function () {
-                return confirm('{{ _('Are you sure you want to delete the MOSS results?') }}');
+                return confirm({{ _('Are you sure you want to delete the MOSS results?')|htmltojs }});
             });
         });
     </script>

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -43,12 +43,12 @@
             $(function () {
                 $('a.disqualify-participation').click(function (e) {
                     e.preventDefault();
-                    if (e.ctrlKey || e.metaKey || confirm("{{ _('Are you sure you want to disqualify this participation?') }}"))
+                    if (e.ctrlKey || e.metaKey || confirm({{ _('Are you sure you want to disqualify this participation?')|htmltojs }}))
                         $(this).closest('form').submit();
                 })
                 $('a.un-disqualify-participation').click(function (e) {
                     e.preventDefault();
-                    if (e.ctrlKey || e.metaKey || confirm("{{ _('Are you sure you want to un-disqualify this participation?') }}"))
+                    if (e.ctrlKey || e.metaKey || confirm({{ _('Are you sure you want to un-disqualify this participation?')|htmltojs }}))
                         $(this).closest('form').submit();
                 })
             });

--- a/templates/organization/home.html
+++ b/templates/organization/home.html
@@ -25,11 +25,11 @@
     <script type="text/javascript">
         $(function () {
             $('.leave-organization').click(function () {
-                return confirm('{{ _('Are you sure you want to leave this organization?') }}\n' +
+                return confirm({{ _('Are you sure you want to leave this organization?')|htmltojs }} + '\n' +
                     {% if organization.is_open %}
-                        '{{ _('You will have to rejoin to show up on the organization leaderboard.') }}'
+                        {{ _('You will have to rejoin to show up on the organization leaderboard.')|htmltojs }}
                     {% else %}
-                        '{{ _('You will have to request membership in order to join again.') }}'
+                        {{ _('You will have to request membership in order to join again.')|htmltojs }}
                     {% endif %}
                 );
             });

--- a/templates/organization/users.html
+++ b/templates/organization/users.html
@@ -26,7 +26,7 @@
     <script type="text/javascript">
         $(function () {
             $('form.kick-form').find('a.button').click(function () {
-                if (confirm("{{ _('Are you sure you want to kick this user?') }}")) {
+                if (confirm({{ _('Are you sure you want to kick this user?')|htmltojs }})) {
                     $(this).parent().submit();
                 }
                 return false;

--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -68,7 +68,7 @@
                 var $precision = $('<input>', {
                     type: 'number',
                     value: try_parse_json($args.val()).precision || 6,
-                    title: '{{ _('precision (decimal digits)') }}',
+                    title: {{ _('precision (decimal digits)')|htmltojs }},
                     style: 'width: 4em'
                 }).change(function () {
                     if ($checker.val().startsWith('floats'))

--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -46,7 +46,7 @@
                 }).css({'visibility': 'visible'}).change(clean_submit);
                 $('#types').select2({
                     theme: '{{ DMOJ_SELECT2_THEME }}',
-                    multiple: 1, placeholder: '{{ _('Filter by type...') }}'
+                    multiple: 1, placeholder: {{ _('Filter by type...')|htmltojs }}
                 }).css({'visibility': 'visible'});
 
                 // This is incredibly nasty to do but it's needed because otherwise the select2 steals the focus

--- a/templates/problem/manage_submission.html
+++ b/templates/problem/manage_submission.html
@@ -53,13 +53,13 @@
             $('#by-lang-filter').select2({
                 theme: '{{ DMOJ_SELECT2_THEME }}',
                 multiple: true,
-                placeholder: '{{ _('Leave empty to not filter by language') }}'
+                placeholder: {{ _('Leave empty to not filter by language')|htmltojs }}
             });
 
             $('#by-result-filter').select2({
                 theme: '{{ DMOJ_SELECT2_THEME }}',
                 multiple: true,
-                placeholder: '{{ _('Leave empty to not filter by result') }}'
+                placeholder: {{ _('Leave empty to not filter by result')|htmltojs }}
             });
 
             $('#rescore-all').click(function (e) {
@@ -78,10 +78,10 @@
                     var start = parseInt($id_start.val());
                     var end = parseInt($id_end.val());
                     if (!start || !end) {
-                        alert("{{ _('Need valid values for both start and end IDs.') }}");
+                        alert({{ _('Need valid values for both start and end IDs.')|htmltojs }});
                         return;
                     } else if (start > end) {
-                        alert("{{ _('End ID must be after start ID.') }}");
+                        alert({{ _('End ID must be after start ID.')|htmltojs }});
                         return;
                     }
                 }
@@ -89,13 +89,13 @@
                 var $form = $(this).parents('form');
                 $.post('{{ url('problem_submissions_rejudge_preview', problem.code) }}', $form.serialize(), 'text')
                     .done(function (count) {
-                        if (confirm("{{ _('You are about to rejudge {count} submissions. Are you sure you want to do this?') }}"
+                        if (confirm({{ _('You are about to rejudge {count} submissions. Are you sure you want to do this?')|htmltojs }}
                             .replace('{count}', count))) {
                             $form.submit();
                         }
                     })
                     .fail(function () {
-                        if (confirm("{{ _('You are about to rejudge a few submissions. Are you sure you want to do this?') }}")) {
+                        if (confirm({{ _('You are about to rejudge a few submissions. Are you sure you want to do this?')|htmltojs }})) {
                             $form.submit();
                         }
                     });

--- a/templates/problem/submit.html
+++ b/templates/problem/submit.html
@@ -115,7 +115,7 @@
 
                 $('#problem_submit').submit(function (event) {
                     if ($('#id_source').val().length > 65536) {
-                        alert("{{ _('Your source code must contain at most 65536 characters.') }}");
+                        alert({{ _('Your source code must contain at most 65536 characters.')|htmltojs }});
                         event.preventDefault();
                         $('#problem_submit').find(':submit').attr('disabled', false);
                     }

--- a/templates/registration/two_factor_auth.html
+++ b/templates/registration/two_factor_auth.html
@@ -30,7 +30,7 @@
                 event.preventDefault();
 
                 if (typeof window.PublicKeyCredential === 'undefined') {
-                    alert('{{ _('WebAuthn is not supported by your browser.') }}');
+                    alert({{ _('WebAuthn is not supported by your browser.')|htmltojs }});
                     return;
                 }
 
@@ -51,7 +51,7 @@
                                 $('#2fa-form').submit();
                             });
                     })
-                    .fail(() => alert('{{ _('Failed to contact server.') }}'));
+                    .fail(() => alert({{ _('Failed to contact server.')|htmltojs }}));
             })
         });
     </script>

--- a/templates/submission/list.html
+++ b/templates/submission/list.html
@@ -32,7 +32,7 @@
             <script type="text/javascript">
                 window.rejudge_submission = function (id, e) {
                     if ((typeof e !== 'undefined' && (e.ctrlKey || e.metaKey)) ||
-                        confirm('{{ _('Are you sure you want to rejudge?') }}')) {
+                        confirm({{ _('Are you sure you want to rejudge?')|htmltojs }})) {
                         $.ajax({
                             url: '{{ url('submission_rejudge') }}',
                             type: "POST",
@@ -72,14 +72,14 @@
                 $('#status').select2({
                     theme: '{{ DMOJ_SELECT2_THEME }}',
                     multiple: 1,
-                    placeholder: '{{ _('Filter by status...') }}',
+                    placeholder: {{ _('Filter by status...')|htmltojs }},
                     matcher: idAndTextMatcher,
                 }).css({'visibility': 'visible'});
 
                 $('#language').select2({
                     theme: '{{ DMOJ_SELECT2_THEME }}',
                     multiple: 1,
-                    placeholder: '{{ _('Filter by language...') }}',
+                    placeholder: {{ _('Filter by language...')|htmltojs }},
                     matcher: idAndTextMatcher,
                 }).css({'visibility': 'visible'});
             });

--- a/templates/submission/status.html
+++ b/templates/submission/status.html
@@ -78,7 +78,7 @@
         {% compress js %}
             <script type="text/javascript">
                 window.confirm_and_rejudge = function (form) {
-                    if (confirm("{{ _('Are you sure you want to rejudge?') }}")) {
+                    if (confirm({{ _('Are you sure you want to rejudge?')|htmltojs }})) {
                         form.submit();
                     }
                 };

--- a/templates/ticket/list.html
+++ b/templates/ticket/list.html
@@ -67,10 +67,10 @@
                     var $status = $row.find('td').first().find('i');
                     if (ticket.open) {
                         $status.removeClass('fa-check-circle-o').addClass('fa-exclamation-circle');
-                        notify('ticket', '{{ _('Reopened: ') }}' + ticket.title);
+                        notify('ticket', {{ _('Reopened: ')|htmltojs }} + ticket.title);
                     } else {
                         $status.removeClass('fa-exclamation-circle').addClass('fa-check-circle-o');
-                        notify('ticket', '{{ _('Closed: ') }}' + ticket.title);
+                        notify('ticket', {{ _('Closed: ')|htmltojs }} + ticket.title);
                     }
                 }
             }

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -27,7 +27,7 @@
                         update_ticket_state(open);
                     },
                     error: function (data) {
-                        alert('{{ _('Could not change ticket: {error}') }}'.replace('{error}', data.responseText));
+                        alert({{ _('Could not change ticket: {error}')|htmltojs }}.replace('{error}', data.responseText));
                     }
                 });
             });
@@ -92,8 +92,8 @@
             function ticket_status(ticket) {
                 update_ticket_state(ticket.open);
                 if (is_highest_ref())
-                    notify('ticket', (ticket.open ? '{{ _('Reopened: ') }}' :
-                        '{{ _('Closed: ') }}') + $title.text());
+                    notify('ticket', (ticket.open ? {{ _('Reopened: ')|htmltojs }} :
+                        {{ _('Closed: ')|htmltojs }}) + $title.text());
             }
 
             function ticket_message(ticket) {

--- a/templates/user/base-users.html
+++ b/templates/user/base-users.html
@@ -12,7 +12,7 @@
             var in_user_redirect = false;
             $('#search-handle').select2({
                 theme: '{{ DMOJ_SELECT2_THEME }}',
-                placeholder: '{{ _('Search by handle...') }}',
+                placeholder: {{ _('Search by handle...')|htmltojs }},
                 ajax: {
                     url: '{{ url('user_search_select2_ajax') }}'
                 },

--- a/templates/user/edit-profile.html
+++ b/templates/user/edit-profile.html
@@ -99,16 +99,16 @@
             });
 
             $('#disable-2fa-button').click(function () {
-                alert("{{ _('The administrators for this site require all the staff to have Two-factor Authentication enabled, so it may not be disabled at this time.') }}");
+                alert({{ _('The administrators for this site require all the staff to have Two-factor Authentication enabled, so it may not be disabled at this time.')|htmltojs }});
             });
 
             $('#generate-api-token-button').click(function (event) {
                 event.preventDefault();
-                if (confirm("{{ _('Are you sure you want to generate or regenerate your API token?') }}\n"
-                          + "{{ _('This will invalidate any previous API tokens.') }} "
-                          + "{{ _('It also allows access to your account without Two-factor Authentication.') }}\n\n"
-                          + "{{ _('You will not be able to view your API token after you leave this page!') }}")) {
-                    $('#api-token').text("{{ _('Generating...') }}");
+                if (confirm({{ _('Are you sure you want to generate or regenerate your API token?')|htmltojs }} + '\n'
+                          + {{ _('This will invalidate any previous API tokens.')|htmltojs }} + ' '
+                          + {{ _('It also allows access to your account without Two-factor Authentication.')|htmltojs }} + '\n\n'
+                          + {{ _('You will not be able to view your API token after you leave this page!')|htmltojs }})) {
+                    $('#api-token').text({{ _('Generating...')|htmltojs }});
 
                     $.ajax({
                         type: 'POST',
@@ -116,7 +116,7 @@
                         dataType: 'json',
                         success: function(data) {
                             $('#api-token').text(data.data.token);
-                            $('#generate-api-token-button').text("{{ _('Regenerate') }}");
+                            $('#generate-api-token-button').text({{ _('Regenerate')|htmltojs }});
 
                             // Add remove button on-the-fly
                             if ($('#remove-api-token-button').length == 0) {
@@ -132,14 +132,14 @@
             // Delegated event handler because the remove button may have been added on-the-fly
             $('#api-token-td').on('click', '#remove-api-token-button', function (event) {
                 event.preventDefault();
-                if (confirm("{{ _('Are you sure you want to remove your API token?') }}")) {
+                if (confirm({{ _('Are you sure you want to remove your API token?')|htmltojs }})) {
                     $.ajax({
                         type: 'POST',
                         url: $(this).attr('href'),
                         dataType: 'json',
                         success: function(data) {
                             $('#api-token').text('');
-                            $('#generate-api-token-button').text("{{ _('Generate') }}");
+                            $('#generate-api-token-button').text({{ _('Generate')|htmltojs }});
                             $('#remove-api-token-button').remove();
                         },
                     });
@@ -156,7 +156,7 @@
                 event.preventDefault();
 
                 if (typeof window.PublicKeyCredential === 'undefined') {
-                    alert('{{ _('WebAuthn is not supported by your browser.') }}');
+                    alert({{ _('WebAuthn is not supported by your browser.')|htmltojs }});
                     return;
                 }
 
@@ -180,12 +180,12 @@
                                     .fail((jqXHR) => alert(jqXHR.responseText));
                             });
                     })
-                    .fail(() => alert('{{ _('Failed to contact server.') }}'));
+                    .fail(() => alert({{ _('Failed to contact server.')|htmltojs }}));
             });
 
             $('.webauthn-delete').click(function (event) {
                 event.preventDefault();
-                if (confirm("{{ _('Are you sure you want to delete this security key?') }}")) {
+                if (confirm({{ _('Are you sure you want to delete this security key?')|htmltojs }})) {
                     $.post($(this).attr('data-delete-url'))
                         .then(() => window.location.reload())
                         .fail((jqXHR) => alert(jqXHR.responseText));
@@ -199,10 +199,10 @@
         $(function () {
             $('#generate-scratch-codes-button').click(function(event) {
                 event.preventDefault();
-                if (confirm("{{ _('Are you sure you want to generate or regenerate a new set of scratch codes?') }}\n"
-                          + "{{ _('This will invalidate any previous scratch codes you have.') }}\n\n"
-                          + "{{ _('You will not be able to view your scratch codes after you leave this page!') }}")) {
-                    $('#scratch-codes').text("{{ _('Generating...') }}");
+                if (confirm({{ _('Are you sure you want to generate or regenerate a new set of scratch codes?')|htmltojs }} + '\n'
+                          + {{ _('This will invalidate any previous scratch codes you have.')|htmltojs }} + '\n\n'
+                          + {{ _('You will not be able to view your scratch codes after you leave this page!')|htmltojs }})) {
+                    $('#scratch-codes').text({{ _('Generating...')|htmltojs }});
 
                     $('pre code').each(function () {
                         var copyButton;
@@ -211,8 +211,8 @@
                                 'class': 'btn-clipboard',
                                 'id': 'scratch-codes-copy-button',
                                 'data-clipboard-text': '',
-                                'title': '{{ _('Click to copy') }}'
-                            }).text('{{ _('Copy') }}')));
+                                'title': {{ _('Click to copy')|htmltojs }}
+                            }).text({{ _('Copy')|htmltojs }})));
 
                         $(copyButton.get(0)).mouseleave(function () {
                             $(this).attr('class', 'btn-clipboard');
@@ -223,7 +223,7 @@
 
                         curClipboard.on('success', function(e) {
                             e.clearSelection();
-                            showTooltip(e.trigger, '{{ _('Copied!') }}');
+                            showTooltip(e.trigger, {{ _('Copied!')|htmltojs }});
                         });
 
                         curClipboard.on('error', function(e) {
@@ -238,7 +238,7 @@
                         success: function(data) {
                             $('#scratch-codes').text(data.data.codes.join('\n'));
                             $('#scratch-codes-copy-button').attr('data-clipboard-text', data.data.codes.join('\n'));
-                            $('#generate-scratch-codes-button').text("{{ _('Regenerate') }}");
+                            $('#generate-scratch-codes-button').text({{ _('Regenerate')|htmltojs }});
                             $('#hidden-word').hide();
                             $('#scratch-codes-regen').show();
                         },

--- a/templates/user/prepare-data.html
+++ b/templates/user/prepare-data.html
@@ -61,7 +61,7 @@
                 check($(this), 300);
             });
             $('#prepare-download').click(function() {
-                return confirm("{{ _('Are you sure you want to prepare a download?') }}");
+                return confirm({{ _('Are you sure you want to prepare a download?')|htmltojs }});
             });
         });
         $(document).ready(function () {


### PR DESCRIPTION
create a new filter `htmltojs` that produces a javascript string. use `htmltojs` in every template that contains js.

`html.unescape` will undo the `escape` that was introduced in #1899.

left side: original code. right side: new code.

![Screenshot 2024-05-04 232635](https://github.com/DMOJ/online-judge/assets/14223529/50832b77-75cc-4214-9274-c2c9b877e9ec)