### PR TITLE
ci/makemessages: install `crowdin3.deb`

### DIFF
--- a/.github/workflows/makemessages.yml
+++ b/.github/workflows/makemessages.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install requirements
       run: |
          sudo apt-get install gettext
-         curl -O https://artifacts.crowdin.com/repo/deb/crowdin.deb
+         curl -O https://artifacts.crowdin.com/repo/deb/crowdin3.deb
          sudo dpkg -i crowdin.deb
          pip install -r requirements.txt
          pip install pymysql


### PR DESCRIPTION
`crowdin.deb` uses the deprecated v1 API.

Closes https://github.com/DMOJ/online-judge/issues/2332