### PR TITLE
Add judge tiering for automatic failover

### DIFF
--- a/judge/admin/runtime.py
+++ b/judge/admin/runtime.py
@@ -65,12 +65,12 @@ class JudgeAdmin(VersionAdmin):
     readonly_fields = ('created', 'online', 'start_time', 'ping', 'load', 'last_ip', 'runtimes', 'problems',
                        'is_disabled')
     fieldsets = (
-        (None, {'fields': ('name', 'auth_key', 'is_blocked', 'is_disabled')}),
+        (None, {'fields': ('name', 'auth_key', 'is_blocked', 'is_disabled', 'tier')}),
         (_('Description'), {'fields': ('description',)}),
         (_('Information'), {'fields': ('created', 'online', 'last_ip', 'start_time', 'ping', 'load')}),
         (_('Capabilities'), {'fields': ('runtimes',)}),
     )
-    list_display = ('name', 'online', 'is_disabled', 'start_time', 'ping', 'load', 'last_ip')
+    list_display = ('name', 'online', 'is_disabled', 'tier', 'start_time', 'ping', 'load', 'last_ip')
     ordering = ['-online', 'name']
     formfield_overrides = {
         TextField: {'widget': AdminMartorWidget},

--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -59,6 +59,7 @@ class JudgeHandler(ZlibPacketHandler):
         self.load = 1e100
         self.name = None
         self.is_disabled = False
+        self.tier = None
         self.batch_id = None
         self.in_batch = False
         self._stop_ping = threading.Event()
@@ -106,6 +107,9 @@ class JudgeHandler(ZlibPacketHandler):
         if judge.is_blocked:
             json_log.warning(self._make_json_log(action='auth', judge=id, info='judge authenticated but is blocked'))
             return False
+
+        # Cache judge tier for use by JudgeList
+        self.tier = judge.tier
 
         return True
 

--- a/judge/bridge/judge_list.py
+++ b/judge/bridge/judge_list.py
@@ -25,16 +25,19 @@ class JudgeList(object):
         self.node_map = {}
         self.submission_map = {}
         self.lock = RLock()
+        self.min_tier = None
 
     def _handle_free_judge(self, judge):
         with self.lock:
+            if judge.tier > self.min_tier:
+                return
+
             node = self.queue.first
             priority = 0
             while node:
                 if isinstance(node.value, PriorityMarker):
                     priority = node.value.priority + 1
-                elif priority >= REJUDGE_PRIORITY and self.count_not_disabled() > 1 and sum(
-                        not judge.working and not judge.is_disabled for judge in self.judges) <= 1:
+                elif priority >= REJUDGE_PRIORITY and self.should_reserve_judge():
                     return
                 else:
                     id, problem, language, source, judge_id = node.value
@@ -52,14 +55,47 @@ class JudgeList(object):
                         break
                 node = node.next
 
-    def count_not_disabled(self):
-        return sum(not judge.is_disabled for judge in self.judges)
+    def _update_min_tier(self):
+        with self.lock:
+            old = self.min_tier
+            try:
+                self.min_tier = min(judge.tier for judge in self.judges
+                                    if judge.tier is not None and not judge.is_disabled)
+            except ValueError:
+                self.min_tier = None
+
+            if old != self.min_tier:
+                logger.info('Minimum tier changed from %s to %s', old, self.min_tier)
+
+            # We must be adding a judge, let register handle the new judge.
+            if old is None:
+                return
+
+            # If the new min tier is larger, then we should treat all judges of the new tier as free and start grading.
+            # This is only possible when removing a judge.
+            if self.min_tier is not None and self.min_tier > old:
+                for judge in self.current_tier_judges():
+                    logger.info('Minimum tier increased, trying to dispatch to judge: %s', judge.name)
+                    if not judge.working:
+                        self._handle_free_judge(judge)
+
+    def current_tier_judges(self):
+        return [judge for judge in self.judges if judge.tier == self.min_tier and not judge.is_disabled]
+
+    def should_reserve_judge(self):
+        judges = self.current_tier_judges()
+        if len(judges) <= 1:
+            return False
+
+        free_judges = sum(not judge.working for judge in judges)
+        return free_judges <= 1
 
     def register(self, judge):
         with self.lock:
             # Disconnect all judges with the same name, see <https://github.com/DMOJ/online-judge/issues/828>
             self.disconnect(judge, force=True)
             self.judges.add(judge)
+            self._update_min_tier()
             self._handle_free_judge(judge)
 
     def disconnect(self, judge_id, force=False):
@@ -77,6 +113,7 @@ class JudgeList(object):
             for judge in self.judges:
                 if judge.name == judge_id:
                     judge.is_disabled = is_disabled
+            self._update_min_tier()
 
     def remove(self, judge):
         with self.lock:
@@ -87,11 +124,13 @@ class JudgeList(object):
                 except KeyError:
                     pass
             self.judges.discard(judge)
+            self._update_min_tier()
 
             # Since we reserve a judge for high priority submissions when there are more than one,
             # we'll need to start judging if there is exactly one judge and it's free.
-            if len(self.judges) == 1:
-                judge = next(iter(self.judges))
+            current_tier = self.current_tier_judges()
+            if len(current_tier) == 1:
+                judge = next(iter(current_tier))
                 if not judge.working:
                     self._handle_free_judge(judge)
 
@@ -131,7 +170,7 @@ class JudgeList(object):
                 # idempotent.
                 return
 
-            candidates = [judge for judge in self.judges if judge.can_judge(problem, language, judge_id)]
+            candidates = [judge for judge in self.current_tier_judges() if judge.can_judge(problem, language, judge_id)]
             available = [judge for judge in candidates if not judge.working and not judge.is_disabled]
             if judge_id:
                 logger.info('Specified judge %s is%savailable', judge_id, ' ' if available else ' not ')

--- a/judge/migrations/0147_judge_add_tiers.py
+++ b/judge/migrations/0147_judge_add_tiers.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('judge', '0146_comment_revision_count_v2'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='judge',
+            name='tier',
+            field=models.PositiveIntegerField(
+                default=1,
+                help_text='The tier of this judge. Only online judges of the minimum tier will be used. This is used for high-availability.',
+                verbose_name='judge tier',
+            ),
+        ),
+    ]

--- a/judge/models/runtime.py
+++ b/judge/models/runtime.py
@@ -131,6 +131,9 @@ class Judge(models.Model):
                                                  'even if its key is correct.'))
     is_disabled = models.BooleanField(verbose_name=_('disable judge'), default=False,
                                       help_text=_('Whether this judge should be removed from judging queue.'))
+    tier = models.PositiveIntegerField(verbose_name=_('judge tier'), default=1,
+                                       help_text=_('The tier of this judge. Only online judges of the minimum tier '
+                                                   'will be used. This is used for high-availability.'))
     online = models.BooleanField(verbose_name=_('judge online status'), default=False)
     start_time = models.DateTimeField(verbose_name=_('judge start time'), null=True)
     ping = models.FloatField(verbose_name=_('response time'), null=True)


### PR DESCRIPTION
This PR adds judge tiering. Only the current lowest tier judge is used for grading while all higher tier judges are held in reserve for high availability.

Fixes #2099.