### PR TITLE
models/contest: clarify rate_all behaviour

### DIFF
--- a/judge/migrations/0148_clarify_rate_all_desc.py
+++ b/judge/migrations/0148_clarify_rate_all_desc.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0147_judge_add_tiers'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contest',
+            name='rate_all',
+            field=models.BooleanField(default=False, help_text='Rate users even if they make no submissions.', verbose_name='rate all'),
+        ),
+    ]

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -114,7 +114,9 @@ class Contest(models.Model):
     rating_ceiling = models.IntegerField(verbose_name=_('rating ceiling'),
                                          help_text=_('Do not rate users who have a higher rating.'),
                                          null=True, blank=True)
-    rate_all = models.BooleanField(verbose_name=_('rate all'), help_text=_('Rate all users who joined.'), default=False)
+    rate_all = models.BooleanField(verbose_name=_('rate all'),
+                                   help_text=_('Rate users even if they make no submissions.'),
+                                   default=False)
     rate_exclude = models.ManyToManyField(Profile, verbose_name=_('exclude from ratings'), blank=True,
                                           related_name='rate_exclude+')
     is_private = models.BooleanField(verbose_name=_('private to specific users'), default=False)


### PR DESCRIPTION
Rate all is confusingly named, since it really means "rate even users who don't submit". In my opinion, this should have been the default, but instead we can simply fix the description.