### PR TITLE
Fix broken links in admin pages

### DIFF
--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -244,7 +244,7 @@ class SubmissionAdmin(VersionAdmin):
         if obj.is_locked:
             return format_html('<input type="button" disabled value="{0}"/>', _('Locked'))
         else:
-            return format_html('<input type="button" value="{0}" onclick="location.href=\'{1}\'"/>', _('Rejudge'),
+            return format_html('<a class="button action-link" href="{1}">{0}</a>', _('Rejudge'),
                                reverse('admin:judge_submission_rejudge', args=(obj.id,)))
 
     def get_urls(self):

--- a/templates/admin/judge/contest/change_form.html
+++ b/templates/admin/judge/contest/change_form.html
@@ -5,8 +5,12 @@
     <script>
         django.jQuery(function ($) {
             $('.rerate-link').appendTo('div#bottombar').show();
-            $('.rejudge-link').click(function () {
-                return confirm('{{ _('Are you sure you want to rejudge ALL the submissions?') }}');
+            $('.rejudge-link').click(function (event) {
+                if (confirm('{{ _('Are you sure you want to rejudge ALL the submissions?') }}')) {
+                    return true;
+                }
+                event.stopImmediatePropagation();
+                return false;
             });
         });
     </script>


### PR DESCRIPTION
My own patch https://github.com/DMOJ/online-judge/commit/8cebcedfa2aa2f8e7508d5ebec37595bfe7bd156 accidentally broke some UI elements.

1. The `Rejudge` button in `/admin/judge/submission/`. It doesn't work.
<img width="555" alt="image" src="https://github.com/user-attachments/assets/53d8181d-0875-4457-859d-ce4f5400a443">

2. The `Rejudge` button in `/judge/contest/{id}/change/`. The rejudge is always processed whether you confirm it or not.
<img width="536" alt="image" src="https://github.com/user-attachments/assets/f84fae20-9cdc-406d-9891-00106c686728">
