### PR TITLE
Minor changes to fix compatibility with older browsers

### DIFF
--- a/django_ace/static/django_ace/widget.js
+++ b/django_ace/static/django_ace/widget.js
@@ -111,9 +111,15 @@
                 }
 
                 setEditorTheme(window.matchMedia('(prefers-color-scheme: dark)').matches);
-                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(ev) {
-                    setEditorTheme(ev.matches);
-                })
+                try {
+                    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(ev) {
+                        setEditorTheme(ev.matches);
+                    })
+                } catch (err) {
+                    window.matchMedia('(prefers-color-scheme: dark)').addListener(function(ev) {
+                        setEditorTheme(ev.matches);
+                    })
+                }
             }
         }
         if (wordwrap == "true") {

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,7 +49,7 @@
             {% if PREFERRED_STYLE_CSS is not none %}
                 <link rel="stylesheet" href="{{ static(PREFERRED_STYLE_CSS) }}">
             {% else %}
-                <link rel="stylesheet" href="{{ static(LIGHT_STYLE_CSS) }}" media="(prefers-color-scheme: light)">
+                <link rel="stylesheet" href="{{ static(LIGHT_STYLE_CSS) }}">
                 <link rel="stylesheet" href="{{ static(DARK_STYLE_CSS) }}" media="(prefers-color-scheme: dark)">
             {% endif %}
         {% else %}


### PR DESCRIPTION
This PR provides 2 changes to fix compatibility with older browsers.

1. Older browsers that do not support the `prefers-color-scheme` media query will fail to load any CSS when the dark/light mode code is enabled. 

Additionally, the W3 Specification states that [the light theme should be loaded as a fallback if no preference is given](https://www.w3.org/TR/mediaqueries-5/#prefers-color-scheme:~:text=or%20has%20not%20expressed%20an%20active%20preference%20(and%20thus%20should%20receive%20the%20%22web%20default%22%20of%20a%20light%20theme).).

This can trivially be resolved by removing the `prefers-color-scheme: light` media query from the light theme, to set it as the default if the browser does not handle the query.

https://github.com/user-attachments/assets/01b6cf52-811f-437a-aa9b-a01782173f5d

This does not impact browsers that support the query, as `prefers-color-scheme` takes priority over the "base" stylesheet:
<img width="1426" alt="Screenshot 2024-10-26 at 2 04 33 PM" src="https://github.com/user-attachments/assets/b73f9faa-7a55-46cf-99c1-f9454fce55c2">

2. Older browsers do not support addEventListener on matchMedia, instead add a fallback using addListener.