### PR TITLE
Fix ContestAdmin make_hidden to actually hide contests

### DIFF
--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -237,7 +237,7 @@ class ContestAdmin(NoBatchDeleteMixin, VersionAdmin):
     def make_hidden(self, request, queryset):
         if not request.user.has_perm('judge.change_contest_visibility'):
             queryset = queryset.filter(Q(is_private=True) | Q(is_organization_private=True))
-        count = queryset.update(is_visible=True)
+        count = queryset.update(is_visible=False)
         self.message_user(request, ngettext('%d contest successfully marked as hidden.',
                                             '%d contests successfully marked as hidden.',
                                             count) % count)


### PR DESCRIPTION
This seems like a regression from 25213ed68a0395cbabdb4899af99e58241ecbb67, which seems to have accidentally used the wrong value (https://github.com/DMOJ/online-judge/commit/25213ed68a0395cbabdb4899af99e58241ecbb67#diff-3925f94ab82b2f59d01c363a29dc2c95b6465b3084feddc465d30643260b9b4dR195)