### PR TITLE
ci: Update Python to 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install flake8
       run: pip install flake8 flake8-import-order flake8-future-import flake8-commas flake8-logging-format flake8-quotes
     - name: Lint with flake8
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Cache pip
       uses: actions/cache@v4
       with:

--- a/.github/workflows/compilemessages.yml
+++ b/.github/workflows/compilemessages.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Checkout submodules
       run: |
         git submodule init

--- a/.github/workflows/makemessages.yml
+++ b/.github/workflows/makemessages.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Checkout submodules
       run: |
         git submodule init

--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -10,10 +10,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Checkout submodules
       run: |
         git submodule init

--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -82,7 +82,7 @@ class ContestSubmissionInline(admin.StackedInline):
                                                                          contest__problems=submission.problem) \
                     .only('id', 'contest__name', 'virtual')
 
-                def label(obj):
+                def label(obj):  # noqa: F811
                     if obj.spectate:
                         return gettext('%s (spectating)') % obj.contest.name
                     if obj.virtual:
@@ -92,7 +92,7 @@ class ContestSubmissionInline(admin.StackedInline):
                 kwargs['queryset'] = ContestProblem.objects.filter(problem=submission.problem) \
                     .only('id', 'problem__name', 'contest__name')
 
-                def label(obj):
+                def label(obj):  # noqa: F811
                     return pgettext('contest problem', '%(problem)s in %(contest)s') % {
                         'problem': obj.problem.name, 'contest': obj.contest.name,
                     }


### PR DESCRIPTION
From https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json, we can see that the latest version of Ubuntu (24.04) no longer supports Python 3.7. This PR upgrades the version of Python used for Github Actions to 3.8. 