### PR TITLE
Use Python 3.11 on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Install flake8
       run: pip install flake8 flake8-import-order flake8-future-import flake8-commas flake8-logging-format flake8-quotes
     - name: Lint with flake8
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Cache pip
       uses: actions/cache@v4
       with:

--- a/.github/workflows/compilemessages.yml
+++ b/.github/workflows/compilemessages.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Checkout submodules
       run: |
         git submodule init

--- a/.github/workflows/makemessages.yml
+++ b/.github/workflows/makemessages.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Checkout submodules
       run: |
         git submodule init

--- a/.github/workflows/updatemessages.yml
+++ b/.github/workflows/updatemessages.yml
@@ -10,10 +10,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Checkout submodules
       run: |
         git submodule init


### PR DESCRIPTION
This is the version used in Debian bookworm, which we are running in production.