### PR TITLE
Fix martor dark style

### DIFF
--- a/judge/widgets/martor.py
+++ b/judge/widgets/martor.py
@@ -5,9 +5,6 @@ __all__ = ['MartorWidget', 'AdminMartorWidget']
 
 class MartorWidget(OldMartorWidget):
     class Media:
-        css = {
-            'all': ['martor-description.css'],
-        }
         js = ['martor-mathjax.js']
 
 
@@ -15,5 +12,7 @@ class AdminMartorWidget(OldAdminMartorWidget):
     UPLOADS_ENABLED = True
 
     class Media:
-        css = MartorWidget.Media.css
+        css = {
+            'all': ['martor-description.css'],
+        }
         js = ['admin/js/jquery.init.js', 'martor-mathjax.js']

--- a/resources/style.scss
+++ b/resources/style.scss
@@ -11,6 +11,7 @@
 @import "ranks";
 @import "users";
 @import "content-description";
+@import "martor-description";
 @import "widgets";
 @import "featherlight";
 @import "comments";


### PR DESCRIPTION
part of #2035

* on the main site, martor preview follows light/dark mode (main site includes `style.scss`, and `style.scss` has light/dark martor)
* on the admin site, martor always uses light mode (see `AdminMartorWidget` for code)

![Screenshot 2024-12-25 032526](https://github.com/user-attachments/assets/bb232b72-deec-4093-af20-57414af04761)
