### PR TITLE
Add separator line for martor dark mode between tooltip and editor

### DIFF
--- a/resources/martor-description.scss
+++ b/resources/martor-description.scss
@@ -59,8 +59,8 @@ form .martor-preview {
         box-shadow: 0px 0px 0px 0px $color_primary0 inset !important;
     }
 
-    .ui.secondary.inverted.pointing.menu .active.item {
-        border-bottom-width: 4px;
+    .ui.attached.inverted.menu {
+        border-bottom: 2px solid $color_primary33 !important;
     }
 
     /* Scroll bar */


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f92e6849-c7e6-47f0-89bd-d99cfecaf70e)
![image](https://github.com/user-attachments/assets/3884a087-ec0e-43b6-a9f7-b4dd370b4951)