### PR TITLE
Clean up martor extension ignores in .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,9 +18,6 @@ per-file-ignores =
     ./judge/management/commands/runmoss.py:F403,F405
     # E501: line too long, ignore in migrations
     ./judge/migrations/*.py:E501
-    # E501: line too long, ignore in martor emoji and mention extensions
-    ./martor/extensions/emoji.py:E501
-    ./martor/extensions/mention.py:E501
 exclude =
     # belongs to the user
     ./dmoj/local_settings.py,


### PR DESCRIPTION
These files no longer exist, oops :facepalm: 