### PR TITLE
Make blockquotes lighter in dark mode

### DIFF
--- a/resources/base-description.scss
+++ b/resources/base-description.scss
@@ -66,7 +66,7 @@
         color: $color_primary50;
         margin: 0;
         padding-left: 1.5em;
-        border-left: 0.5em $color_primary10 solid;
+        border-left: 0.5em $color_base_description_blockquote solid;
     }
 
     hr {

--- a/resources/vars-dark.scss
+++ b/resources/vars-dark.scss
@@ -21,6 +21,8 @@ $color_link200: #d83;   // active
 $color_pageBg: #222;    // #222 because some elements should be darker than pageBg
 
 // custom one-off colours
+$color_base_description_blockquote: #3b3b3b;
+
 $color_contest_ranking_disqualified: #622;
 
 $color_martor_resize_dragger: #232323;

--- a/resources/vars-default.scss
+++ b/resources/vars-default.scss
@@ -21,6 +21,8 @@ $color_link200: #faa700;    // active
 $color_pageBg: #fff;
 
 // custom one-off colours
+$color_base_description_blockquote: #eee;
+
 $color_contest_ranking_disqualified: #ffa8a8;
 
 $color_martor_resize_dragger: #e8e8e8;


### PR DESCRIPTION
Part of https://github.com/DMOJ/online-judge/issues/2035.

Before:
![image](https://github.com/user-attachments/assets/30a9f4e0-5e91-4120-a2b5-1579509ffa37)

After:
![image](https://github.com/user-attachments/assets/a92187f9-fcaf-45fa-b4ef-155adfb280dc)
