### PR TITLE
Migrate martor guide to featherlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,11 @@
 *~
 *.swp
 dmoj/local_settings.py
+resources/ace-dmoj.css
 resources/dark
+resources/featherlight.css
 resources/martor-description.css
 resources/select2-dmoj.css
-resources/ace-dmoj.css
 resources/style.css
 resources/vars.scss
 sass_processed

--- a/judge/widgets/martor.py
+++ b/judge/widgets/martor.py
@@ -13,6 +13,6 @@ class AdminMartorWidget(OldAdminMartorWidget):
 
     class Media:
         css = {
-            'all': ['martor-description.css'],
+            'all': ['martor-description.css', 'featherlight.css'],
         }
-        js = ['admin/js/jquery.init.js', 'martor-mathjax.js']
+        js = ['admin/js/jquery.init.js', 'martor-mathjax.js', 'libs/featherlight/featherlight.min.js']

--- a/make_style.sh
+++ b/make_style.sh
@@ -21,10 +21,11 @@ build_style() {
   cp resources/vars-$1.scss resources/vars.scss
   sass resources:sass_processed
   postcss \
-      sass_processed/style.css \
+      sass_processed/ace-dmoj.css \
+      sass_processed/featherlight.css \
       sass_processed/martor-description.css \
       sass_processed/select2-dmoj.css \
-      sass_processed/ace-dmoj.css \
+      sass_processed/style.css \
       --verbose --use autoprefixer -d "$2"
   rm resources/vars.scss
 }

--- a/martor/static/martor/js/martor.js
+++ b/martor/static/martor/js/martor.js
@@ -829,11 +829,6 @@
                 $('.markdown-reference tbody tr')[1].remove();
             }
 
-            // Modal Popup for Help Guide Cheat Sheet
-            $('.markdown-help[data-field-name=' + field_name + ']').click(function () {
-                $('.modal-help-guide[data-field-name=' + field_name + ']').modal('show');
-            });
-
             // Handle tabs.
             mainMartor.find('.ui.martor-toolbar .ui.dropdown').dropdown();
             mainMartor.find('.ui.tab-martor-menu .item').tab();

--- a/martor/templates/martor/guide.html
+++ b/martor/templates/martor/guide.html
@@ -1,10 +1,9 @@
 {% load i18n static %}
-<div class="ui medium modal scrolling transition modal-help-guide">
-  <i class="close icon"></i>
-  <div class="header"><i class="help circle icon"></i> {% trans "Markdown Guide" %}</div>
-  <div class="content" style="width: auto; margin-bottom: 2.5em;">
+<div style="display: none;">
+  <div class="modal-help-guide">
+    <h2><i class="help circle icon"></i> {% trans "Markdown Guide" %}</h2>
     <p>{% blocktrans with doc_url='https://commonmark.org/help/' %}This site is powered by Markdown. For full documentation, <a href="{{ doc_url }}" target="_blank">click here</a>.{% endblocktrans %}</p>
-    <table class="ui celled table markdown-reference">
+    <table class="table striped">
       <thead>
         <tr>
           <th>{% trans "Code" %}</th>
@@ -23,10 +22,6 @@
             <td>Command+M</td>
             <td><a href="#">username</a></td>
           </tr>
-        {% endif %}
-
-        {% if mentions_enabled %}
-          <tr><td colspan="5"></td></tr>
         {% endif %}
 
         <tr>

--- a/martor/templates/martor/toolbar.html
+++ b/martor/templates/martor/toolbar.html
@@ -65,8 +65,8 @@
     <div class="ui icon button no-border markdown-selector markdown-toggle-maximize" title="{% trans 'Full Screen' %}">
       <i class="window maximize outline icon"></i>
     </div>
-    <div class="ui icon button no-border markdown-selector markdown-help" title="{% trans 'Markdown Guide (Help)' %}">
+    <a class="ui icon button no-border markdown-selector markdown-help" title="{% trans 'Markdown Guide (Help)' %}" data-featherlight=".modal-help-guide[data-field-name={{ field_name }}]" href="javascript:void(0)">
       <i class="help circle icon"></i>
-    </div>
+    </a>
   </div>
 </div>

--- a/resources/featherlight.scss
+++ b/resources/featherlight.scss
@@ -34,7 +34,7 @@
         border-radius: 10px;
         margin-left: 5%;
         margin-right: 5%;
-        max-height: 95%;
+        max-height: 85%;
         background: $color_pageBg;
         cursor: auto;
         white-space: normal;


### PR DESCRIPTION
part of #2035 - this makes the martor guide dark mode friendly

* apply dmoj theme to martor guide
* for admin martor, give access to `featherlight.css` and `featherlight.min.js`
* set `max-height: 85%` to avoid issues with the admin site's z-index

## screenshots

![Screenshot 2024-12-27 223616](https://github.com/user-attachments/assets/afa881b0-be21-422a-b533-c5dc60d2819a)
![Screenshot 2024-12-27 223647](https://github.com/user-attachments/assets/0f70d0f0-ce6d-456a-8050-bbdef01d70fd)