### PR TITLE
Change class for martor help icon

### DIFF
--- a/martor/templates/martor/guide.html
+++ b/martor/templates/martor/guide.html
@@ -1,7 +1,7 @@
 {% load i18n static %}
 <div style="display: none;">
   <div class="modal-help-guide">
-    <h2><i class="help circle icon"></i> {% trans "Markdown Guide" %}</h2>
+    <h2><i class="question circle icon"></i> {% trans "Markdown Guide" %}</h2>
     <p>{% blocktrans with doc_url='https://commonmark.org/help/' %}This site is powered by Markdown. For full documentation, <a href="{{ doc_url }}" target="_blank">click here</a>.{% endblocktrans %}</p>
     <table class="table striped">
       <thead>

--- a/martor/templates/martor/toolbar.html
+++ b/martor/templates/martor/toolbar.html
@@ -66,7 +66,7 @@
       <i class="window maximize outline icon"></i>
     </div>
     <a class="ui icon button no-border markdown-selector markdown-help" title="{% trans 'Markdown Guide (Help)' %}" data-featherlight=".modal-help-guide[data-field-name={{ field_name }}]" href="javascript:void(0)">
-      <i class="help circle icon"></i>
+      <i class="question circle icon"></i>
     </a>
   </div>
 </div>


### PR DESCRIPTION
in the admin site, class=help has other css styles, and they made the help icon look weird

use class=question to avoid css conflicts