### PR TITLE
Dark mode support for alert boxes

### DIFF
--- a/resources/vars-dark.scss
+++ b/resources/vars-dark.scss
@@ -44,6 +44,16 @@ $color_user_submission_activity2: #006d32;
 $color_user_submission_activity3: #26a641;
 $color_user_submission_activity4: #39d353;
 
+$color_info25: #023;
+$color_info50: #068;
+$color_info100: #7df;
+$color_warning25: #320;
+$color_warning50: #960;
+$color_warning100: #fd6;
+$color_danger25: #311;
+$color_danger50: #822;
+$color_danger100: #f99;
+
 $color_problem_submit_select2: #8a8a8a;
 
 $path_to_root: '..';    // relative path from style.css to STATIC_ROOT

--- a/resources/vars-default.scss
+++ b/resources/vars-default.scss
@@ -44,6 +44,16 @@ $color_user_submission_activity2: #40c463;
 $color_user_submission_activity3: #2f9c4c;
 $color_user_submission_activity4: #216e39;
 
+$color_info25: #def;
+$color_info50: #bdf;
+$color_info100: #368;
+$color_warning25: #ffd;
+$color_warning50: #feb;
+$color_warning100: #863;
+$color_danger25: #edd;
+$color_danger50: #dbb;
+$color_danger100: #944;
+
 $color_problem_submit_select2: #757575;
 
 $path_to_root: '.';     // relative path from style.css to STATIC_ROOT

--- a/resources/widgets.scss
+++ b/resources/widgets.scss
@@ -325,21 +325,21 @@ ul.pagination {
 }
 
 .alert-info {
-    color: #31708f;
-    background-color: #d9edf7;
-    border-color: #bce8f1;
+    color: $color_info100;
+    background-color: $color_info25;
+    border-color: $color_info50;
 }
 
 .alert-warning {
-    color: #8a6d3b;
-    background-color: #fcf8e3;
-    border-color: #faebcc;
+    color: $color_warning100;
+    background-color: $color_warning25;
+    border-color: $color_warning50;
 }
 
 .alert-danger {
-    color: #a94442;
-    background-color: #f2dede;
-    border-color: #ebccd1;
+    color: $color_danger100;
+    background-color: $color_danger25;
+    border-color: $color_danger50;
 }
 
 .alert-dismissable, .alert-dismissible {


### PR DESCRIPTION
part of #2035

* for light mode, shorten `#123456` to `#123` without modifying the color too much
* add support for dark mode

![Screenshot 2024-12-29 211122](https://github.com/user-attachments/assets/ab73db8d-7535-4fff-88d1-132a5dbd580b)