### PR TITLE
Improve i18n for formatting memory size

### DIFF
--- a/judge/jinja2/filesize.py
+++ b/judge/jinja2/filesize.py
@@ -1,9 +1,11 @@
+from django.template.defaultfilters import floatformat
 from django.utils.html import avoid_wrapping
+from django.utils.translation import gettext_lazy as _
 
 from . import registry
 
 
-def _format_size(bytes, callback):
+def _format_size(bytes, formats, decimals):
     bytes = float(bytes)
 
     KB = 1 << 10
@@ -13,24 +15,28 @@ def _format_size(bytes, callback):
     PB = 1 << 50
 
     if bytes < KB:
-        return callback('', bytes)
+        return formats[0] % floatformat(bytes, decimals[0])
     elif bytes < MB:
-        return callback('K', bytes / KB)
+        return formats[1] % floatformat(bytes / KB, decimals[1])
     elif bytes < GB:
-        return callback('M', bytes / MB)
+        return formats[2] % floatformat(bytes / MB, decimals[2])
     elif bytes < TB:
-        return callback('G', bytes / GB)
+        return formats[3] % floatformat(bytes / GB, decimals[3])
     elif bytes < PB:
-        return callback('T', bytes / TB)
+        return formats[4] % floatformat(bytes / TB, decimals[4])
     else:
-        return callback('P', bytes / PB)
+        return formats[5] % floatformat(bytes / PB, decimals[5])
 
 
 @registry.filter
-def kbdetailformat(bytes):
-    return avoid_wrapping(_format_size(bytes * 1024, lambda x, y: ['%d %sB', '%.2f %sB'][bool(x)] % (y, x)))
+def kbdetailformat(kb):
+    formats = [_('%s B'), _('%s KB'), _('%s MB'), _('%s GB'), _('%s TB'), _('%s PB')]
+    decimals = [0, 2, 2, 2, 2, 2]
+    return avoid_wrapping(_format_size(kb * 1024, formats, decimals))
 
 
 @registry.filter
 def kbsimpleformat(kb):
-    return _format_size(kb * 1024, lambda x, y: '%.0f%s' % (y, x or 'B'))
+    formats = [_('%sB'), _('%sK'), _('%sM'), _('%sG'), _('%sT'), _('%sP')]
+    decimals = [0, 0, 0, 0, 0, 0]
+    return _format_size(kb * 1024, formats, decimals)

--- a/templates/submission/row.html
+++ b/templates/submission/row.html
@@ -87,7 +87,6 @@
         {% else %}
             <div class="time">---</div>
         {% endif %}
-        {# No one actually likes IEC prefixes, Jinja2. #}
-        <div class="memory">{{ (submission.memory_bytes|filesizeformat(True)).replace('i', '') }}</div>
+        <div class="memory">{{ submission.memory|kbdetailformat }}</div>
     {% endif %}
 </div>


### PR DESCRIPTION
this will use the correct decimal separator for certain languages. example:

![Screenshot 2025-01-05 151942](https://github.com/user-attachments/assets/386aa725-7c1b-4952-aade-c612c4601b36)