### PR TITLE
Standardize i18n for martor

### DIFF
--- a/martor/templates/martor/editor.html
+++ b/martor/templates/martor/editor.html
@@ -2,20 +2,20 @@
 <div class="main-martor main-martor-{{ field_name }}" data-field-name="{{ field_name }}">
   <div class="section-martor">
     <div class="ui top attached tabular pointing secondary menu tab-martor-menu">
-      <a class="item active" data-tab="editor-tab-{{ field_name }}"><i class="edit icon"></i> {% trans "Editor" %}</a>
-      <a class="item" data-tab="preview-tab-{{ field_name }}"><i class="eye icon"></i>{% trans "Preview" %}</a>
+      <a class="item active" data-tab="editor-tab-{{ field_name }}"><i class="edit icon"></i> {{ _('Editor') }}</a>
+      <a class="item" data-tab="preview-tab-{{ field_name }}"><i class="eye icon"></i>{{ _('Preview') }}</a>
       {% include "martor/toolbar.html" %}
     </div>
     <div class="ui bottom attached tab segment active" data-tab="editor-tab-{{ field_name }}">
       <div class="ui active dimmer upload-progress" style="display:none">
-        <div class="ui text loader">{% trans "Uploading... please wait..." %}</div>
+        <div class="ui text loader">{{ _('Uploading... please wait...') }}</div>
       </div>
       <div id="martor-{{ field_name }}" class="martor-field martor-field-{{ field_name }}"></div>
       {{ martor }}
       <i class="angle double down grey icon expand-editor"></i>
     </div>
     <div class="ui bottom attached tab segment martor-preview" data-tab="preview-tab-{{ field_name }}">
-      <p>{% trans "Nothing to preview" %}</p>
+      <p>{{ _('Nothing to preview') }}</p>
     </div>
   </div><!-- end  /.section-martor -->
 

--- a/martor/templates/martor/guide.html
+++ b/martor/templates/martor/guide.html
@@ -1,16 +1,16 @@
 {% load i18n static %}
 <div style="display: none;">
   <div class="modal-help-guide">
-    <h2><i class="question circle icon"></i> {% trans "Markdown Guide" %}</h2>
+    <h2><i class="question circle icon"></i> {{ _('Markdown Guide') }}</h2>
     <p>{% blocktrans with doc_url='https://commonmark.org/help/' %}This site is powered by Markdown. For full documentation, <a href="{{ doc_url }}" target="_blank">click here</a>.{% endblocktrans %}</p>
     <table class="table striped">
       <thead>
         <tr>
-          <th>{% trans "Code" %}</th>
-          <th>{% trans "Or" %}</th>
-          <th>Linux/Windows</th>
-          <th>Mac OS</th>
-          <th>{% trans "... to Get" %}</th>
+          <th>{{ _('Code') }}</th>
+          <th>{{ _('Or') }}</th>
+          <th>{{ _('Linux/Windows') }}</th>
+          <th>{{ _('macOS') }}</th>
+          <th>{{ _('... to Get') }}</th>
         </tr>
       </thead>
       <tbody>

--- a/martor/templates/martor/toolbar.html
+++ b/martor/templates/martor/toolbar.html
@@ -1,71 +1,71 @@
 {% load i18n %}
 <div class="ui right floated item martor-toolbar">
   <div class="ui basic tiny icon buttons no-border">
-    <div class="ui icon button no-border markdown-selector markdown-bold" title="{% trans 'Bold' %} (Ctrl+B)">
+    <div class="ui icon button no-border markdown-selector markdown-bold" title="{{ _('Bold (Ctrl+B)') }}">
       <i class="bold icon"></i>
     </div>
-    <div class="ui icon button no-border markdown-selector markdown-italic" title="{% trans 'Italic' %} (Ctrl+I)">
+    <div class="ui icon button no-border markdown-selector markdown-italic" title="{{ _('Italic (Ctrl+I)') }}">
       <i class="italic icon"></i>
     </div>
-    <div class="ui icon button no-border markdown-selector markdown-horizontal" title="{% trans 'Horizontal Line' %} (Ctrl+H)">
+    <div class="ui icon button no-border markdown-selector markdown-horizontal" title="{{ _('Horizontal Line (Ctrl+H)') }}">
       <i class="minus icon"></i>
     </div>
-    <div class="ui icon button top left pointing dropdown no-border" title="{% trans 'Heading' %}">
+    <div class="ui icon button top left pointing dropdown no-border" title="{{ _('Heading') }}">
       <i class="header icon"></i>
       <div class="menu">
-        <div class="item markdown-selector markdown-h1" title="">{% trans 'Heading' %} 1 (Ctrl+Alt+1)</div>
-        <div class="item markdown-selector markdown-h2" title="">{% trans 'Heading' %} 2 (Ctrl+Alt+2)</div>
-        <div class="item markdown-selector markdown-h3" title="">{% trans 'Heading' %} 3 (Ctrl+Alt+3)</div>
+        <div class="item markdown-selector markdown-h1" title="">{{ _('Heading 1 (Ctrl+Alt+1)') }}</div>
+        <div class="item markdown-selector markdown-h2" title="">{{ _('Heading 2 (Ctrl+Alt+2)') }}</div>
+        <div class="item markdown-selector markdown-h3" title="">{{ _('Heading 3 (Ctrl+Alt+3)') }}</div>
       </div>
     </div>
 
-    <div class="ui icon button top left pointing dropdown no-border" title="{% trans 'Pre or Code' %}">
+    <div class="ui icon button top left pointing dropdown no-border" title="{{ _('Pre or Code') }}">
       <i class="code icon"></i>
       <div class="menu">
-        <div class="item markdown-selector markdown-pre" title="">{% trans 'Pre' %} (Ctrl+Alt+P)</div>
-        <div class="item markdown-selector markdown-code" title="">{% trans 'Code' %} (Ctrl+Alt+C)</div>
+        <div class="item markdown-selector markdown-pre" title="">{{ _('Pre (Ctrl+Alt+P)') }}</div>
+        <div class="item markdown-selector markdown-code" title="">{{ _('Code (Ctrl+Alt+C)') }}</div>
       </div>
     </div>
 
-    <div class="ui icon button top left pointing dropdown no-border" title="{% trans 'Math' %}">
+    <div class="ui icon button top left pointing dropdown no-border" title="{{ _('Math') }}">
       <i class="superscript icon"></i>
       <div class="menu">
-        <div class="item markdown-selector markdown-inline-math" title="">{% trans 'Inline Math' %} (Ctrl+Alt+I)</div>
-        <div class="item markdown-selector markdown-display-math" title="">{% trans 'Display Math' %} (Ctrl+Alt+D)</div>
-        <div class="item markdown-selector markdown-latex" title="">{% trans 'LaTeX' %} (Ctrl+Alt+L)</div>
+        <div class="item markdown-selector markdown-inline-math" title="">{{ _('Inline Math (Ctrl+Alt+I)') }}</div>
+        <div class="item markdown-selector markdown-display-math" title="">{{ _('Display Math (Ctrl+Alt+D)') }}</div>
+        <div class="item markdown-selector markdown-latex" title="">{{ _('LaTeX (Ctrl+Alt+L)') }}</div>
       </div>
     </div>
 
-    <div class="ui icon button no-border markdown-selector markdown-blockquote" title="{% trans 'Quote' %} (Ctrl+Q)">
+    <div class="ui icon button no-border markdown-selector markdown-blockquote" title="{{ _('Quote (Ctrl+Q)') }}">
       <i class="quote left icon"></i>
     </div>
-    <div class="ui icon button no-border markdown-selector markdown-unordered-list" title="{% trans 'Unordered List' %} (Ctrl+U)">
+    <div class="ui icon button no-border markdown-selector markdown-unordered-list" title="{{ _('Unordered List (Ctrl+U)') }}">
       <i class="unordered list icon"></i>
     </div>
-    <div class="ui icon button no-border markdown-selector markdown-ordered-list" title="{% trans 'Ordered List' %} (Ctrl+Shift+O)">
+    <div class="ui icon button no-border markdown-selector markdown-ordered-list" title="{{ _('Ordered List (Ctrl+Shift+O)') }}">
       <i class="ordered list icon"></i>
     </div>
 
-    <div class="ui icon button no-border markdown-selector markdown-link" title="{% trans 'URL/Link' %} (Ctrl+L)">
+    <div class="ui icon button no-border markdown-selector markdown-link" title="{{ _('URL/Link (Ctrl+L)') }}">
       <i class="linkify icon"></i>
     </div>
-    <div class="ui icon button no-border markdown-selector markdown-image-link" title="{% trans 'Insert Image Link' %} (Ctrl+Shift+I)">
+    <div class="ui icon button no-border markdown-selector markdown-image-link" title="{{ _('Insert Image Link (Ctrl+Shift+I)') }}">
       <i class="image icon"></i>
     </div>
     {% if uploads_enabled %}
-      <div class="ui icon button no-border markdown-selector markdown-image-upload" title="{% trans 'Upload an Image' %}">
+      <div class="ui icon button no-border markdown-selector markdown-image-upload" title="{{ _('Upload an Image') }}">
         <i class="upload icon"></i>
-        <input name="markdown-image-upload" class="button" type="file" accept="image/*" title="{% trans 'Upload an Image' %}">
+        <input name="markdown-image-upload" class="button" type="file" accept="image/*" title="{{ _('Upload an Image') }}">
       </div>
     {% endif %}
-    <div class="ui icon button no-border markdown-selector markdown-direct-mention" title="{% trans 'Direct Mention a User' %} (Ctrl+M)">
+    <div class="ui icon button no-border markdown-selector markdown-direct-mention" title="{{ _('Direct Mention a User (Ctrl+M)') }}">
       <i class="at icon"></i>
     </div>
 
-    <div class="ui icon button no-border markdown-selector markdown-toggle-maximize" title="{% trans 'Full Screen' %}">
+    <div class="ui icon button no-border markdown-selector markdown-toggle-maximize" title="{{ _('Full Screen') }}">
       <i class="window maximize outline icon"></i>
     </div>
-    <a class="ui icon button no-border markdown-selector markdown-help" title="{% trans 'Markdown Guide (Help)' %}" data-featherlight=".modal-help-guide[data-field-name={{ field_name }}]" href="javascript:void(0)">
+    <a class="ui icon button no-border markdown-selector markdown-help" title="{{ _('Markdown Guide (Help)') }}" data-featherlight=".modal-help-guide[data-field-name={{ field_name }}]" href="javascript:void(0)">
       <i class="question circle icon"></i>
     </a>
   </div>


### PR DESCRIPTION
most templates use `{{ _('foo') }}` for i18n. apply this to martor.

this shouldn't change the editor's behaviour