### PR TITLE
Force users to click "Preview" before posting

### DIFF
--- a/judge/comments.py
+++ b/judge/comments.py
@@ -31,12 +31,15 @@ class CommentForm(ModelForm):
             'parent': forms.HiddenInput(),
         }
 
-        widgets['body'] = MartorWidget(attrs={'data-markdownfy-url': reverse_lazy('comment_preview')})
+        widgets['body'] = MartorWidget(
+            editor_msg=_('Please click on "Preview" before posting your comment.'),
+            button_text=_('Post!'),
+            attrs={'data-markdownfy-url': reverse_lazy('comment_preview')},
+        )
 
     def __init__(self, request, *args, **kwargs):
         self.request = request
         super(CommentForm, self).__init__(*args, **kwargs)
-        self.fields['body'].widget.attrs.update({'placeholder': _('Comment body')})
 
     def clean(self):
         if self.request is not None and self.request.user.is_authenticated:

--- a/judge/views/ticket.py
+++ b/judge/views/ticket.py
@@ -24,7 +24,11 @@ from judge.utils.views import SingleObjectFormView, TitleMixin, paginate_query_c
 from judge.views.problem import ProblemMixin
 from judge.widgets import MartorWidget
 
-ticket_widget = MartorWidget(attrs={'data-markdownfy-url': reverse_lazy('ticket_preview')})
+ticket_widget = MartorWidget(
+    editor_msg=_('Please click on "Preview" before creating your ticket.'),
+    button_text=_('Create'),
+    attrs={'data-markdownfy-url': reverse_lazy('ticket_preview')})
+ticket_comment_widget = MartorWidget(attrs={'data-markdownfy-url': reverse_lazy('ticket_preview')})
 
 
 class TicketForm(forms.Form):
@@ -35,7 +39,6 @@ class TicketForm(forms.Form):
         self.request = request
         super(TicketForm, self).__init__(*args, **kwargs)
         self.fields['title'].widget.attrs.update({'placeholder': _('Ticket title')})
-        self.fields['body'].widget.attrs.update({'placeholder': _('Issue description')})
 
     def clean(self):
         if self.request is not None and self.request.user.is_authenticated:
@@ -100,7 +103,7 @@ class NewProblemTicketView(ProblemMixin, TitleMixin, NewTicketView):
 
 
 class TicketCommentForm(forms.Form):
-    body = forms.CharField(widget=ticket_widget)
+    body = forms.CharField(widget=ticket_comment_widget)
 
 
 class TicketMixin(LoginRequiredMixin):

--- a/martor/static/martor/js/martor.js
+++ b/martor/static/martor/js/martor.js
@@ -206,8 +206,8 @@
 
             if (editorConfig.living !== 'true') {
                 previewTabButton.click(function () {
-                    // hide the `.martor-toolbar` for this current editor if under preview.
-                    $(this).closest('.tab-martor-menu').find('.martor-toolbar').hide();
+                    mainMartor.find('.show-on-editor').hide();
+                    mainMartor.find('.show-on-preview').show();
                     refreshPreview();
                 });
             } else {
@@ -216,8 +216,8 @@
 
             var editorTabButton = $('.item[data-tab=editor-tab-' + field_name + ']');
             editorTabButton.click(function () {
-                // show the `.martor-toolbar` for this current editor if under preview.
-                $(this).closest('.tab-martor-menu').find('.martor-toolbar').show();
+                mainMartor.find('.show-on-editor').show();
+                mainMartor.find('.show-on-preview').hide();
             });
 
             // win/linux: Ctrl+B, mac: Command+B

--- a/martor/templates/martor/editor.html
+++ b/martor/templates/martor/editor.html
@@ -17,6 +17,18 @@
     <div class="ui bottom attached tab segment martor-preview" data-tab="preview-tab-{{ field_name }}">
       <p>{% trans "Nothing to preview" %}</p>
     </div>
+    {% if editor_msg and button_text %}
+      <hr>
+      <div class="ui tab show-on-editor active">
+        <input style="float: right" type="submit" value="{{ button_text }}" class="button disabled" disabled>
+      </div>
+      <div class="ui tab show-on-preview">
+        <input style="float: right" type="submit" value="{{ button_text }}" class="button">
+      </div>
+      <div class="ui tab show-on-editor active">
+        <p>{{ editor_msg }}</p>
+      </div>
+    {% endif %}
   </div><!-- end  /.section-martor -->
 
   {% include 'martor/guide.html' %}

--- a/martor/templates/martor/toolbar.html
+++ b/martor/templates/martor/toolbar.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="ui right floated item martor-toolbar">
+<div class="ui right floated item martor-toolbar show-on-editor">
   <div class="ui basic tiny icon buttons no-border">
     <div class="ui icon button no-border markdown-selector markdown-bold" title="{% trans 'Bold' %} (Ctrl+B)">
       <i class="bold icon"></i>

--- a/martor/widgets.py
+++ b/martor/widgets.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.admin import widgets
+from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import get_template
 
 from .settings import (
@@ -12,6 +13,15 @@ from .settings import (
 
 class MartorWidget(forms.Textarea):
     UPLOADS_ENABLED = False
+
+    # editor_msg: Display a message under the editor. This message does not appear during preview.
+    # button_text: Display a button that is disabled during editing and enabled during preview.
+    def __init__(self, editor_msg=None, button_text=None, *args, **kwargs):
+        if (editor_msg and not button_text) or (not editor_msg and button_text):
+            raise ImproperlyConfigured('Unsupported use of editor_msg and button_text')
+        self.editor_msg = editor_msg
+        self.button_text = button_text
+        super().__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None, renderer=None, **kwargs):
         # Make the settings the default attributes to pass
@@ -46,6 +56,8 @@ class MartorWidget(forms.Textarea):
             'field_name': name,
             'mentions_enabled': mentions_enabled,
             'uploads_enabled': self.UPLOADS_ENABLED,
+            'editor_msg': self.editor_msg,
+            'button_text': self.button_text,
         })
 
     class Media:

--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -64,18 +64,6 @@ a {
     min-width: 60em;
 }
 
-.comment-post-wrapper {
-    padding-bottom: 5px;
-
-    input, textarea {
-        min-width: 100%;
-        max-width: 100%;
-
-        // Hack for 4k on Chrome
-        font-size: $base_font_size;
-    }
-}
-
 .comment {
     list-style: none none;
     border-radius: $widget_border_radius;

--- a/resources/martor-description.scss
+++ b/resources/martor-description.scss
@@ -88,7 +88,9 @@ form .martor-preview {
     cursor: ns-resize;
 }
 
-.main-martor {}
+.main-martor {
+    overflow: hidden;
+}
 
 .martor-toolbar {
     padding: 0 0.85714286em !important;

--- a/resources/ticket.scss
+++ b/resources/ticket.scss
@@ -9,10 +9,6 @@ form#ticket-form {
     #id_title {
         width: 100%;
     }
-
-    .submit {
-        margin: 10px 0 0 auto;
-    }
 }
 
 #ticket-list {

--- a/templates/comments/edit-ajax.html
+++ b/templates/comments/edit-ajax.html
@@ -9,9 +9,7 @@
                 {{ form.body.errors }}
             </div>
         {% endif %}
-        <div class="comment-post-wrapper">
-            <div id="comment-form-body">{{ form.body }}</div>
-        </div>
+        <div id="comment-form-body">{{ form.body }}</div>
         <hr>
         <input style="float: right" type="submit" value="{{ _('Post!') }}" class="button">
     </form>

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -156,11 +156,7 @@
                         </div>
                     {% endif %}
                     {{ comment_form.parent }}
-                    <div class="comment-post-wrapper">
-                        <div id="comment-form-body">{{ comment_form.body }}</div>
-                    </div>
-                    <hr>
-                    <input style="float:right" type="submit" value="{{ _('Post!') }}" class="button">
+                    <div id="comment-form-body">{{ comment_form.body }}</div>
                 </form>
             {% endif %}
         </div>

--- a/templates/ticket/new.html
+++ b/templates/ticket/new.html
@@ -17,6 +17,5 @@
             </div>
         {% endif %}
         <div class="body-block">{{ form.body }}</div>
-        <button type="submit" class="submit">{{ _('Create') }}</button>
     </form>
 {% endblock %}


### PR DESCRIPTION
force users to click on "Preview" before posting a comment or creating a ticket

![Screenshot 2025-02-10 231310](https://github.com/user-attachments/assets/dcea77c1-760f-428d-9da5-b772f7a816d6)

this should improve the quality of comments and tickets

places that use a MartorWidget:

| form | affected url's | notes |
| -- | -- | -- |
| `CommentForm` | `/post/1-first-post`, `/contest/<key>`, `/problem/aplusb`, `/problem/aplusb/editorial` | the 2 messages are `Please click on "Preview" before posting your comment.` and `Post!` |
| `ProfileForm` | `/edit/profile/` and a social auth thing? | no change |
| `EditOrganizationForm` | `/organization/1-dmoj/edit` | no change |
| `CommentEditForm` | editing a comment | no change, button is still `Post!` |
| `TicketForm` | `/problem/aplusb/tickets/new` | the 2 messages are `Please click on "Preview" before creating your ticket.` and `Create` |
| `TicketCommentForm` | `/ticket/1` | no change, button is still `Post!` |