### PR TITLE
Code quality fixes

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -542,7 +542,6 @@ LANGUAGE_CODE = 'en'
 TIME_ZONE = 'UTC'
 DEFAULT_USER_TIME_ZONE = 'America/Toronto'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 # Cookies

--- a/judge/jinja2/datetime.py
+++ b/judge/jinja2/datetime.py
@@ -1,10 +1,10 @@
 import functools
+from datetime import timezone
 
 from django.template.defaultfilters import date, time
 from django.templatetags.tz import localtime
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
-from django.utils.timezone import utc
 from django.utils.translation import gettext as _
 
 from . import registry
@@ -27,6 +27,6 @@ registry.filter(localtime_wrapper(time))
 @registry.function
 def relative_time(time, **kwargs):
     abs_time = date(time, kwargs.get('format', _('N j, Y, g:i a')))
-    return mark_safe(f'<span data-iso="{time.astimezone(utc).isoformat()}" class="time-with-rel"'
+    return mark_safe(f'<span data-iso="{time.astimezone(timezone.utc).isoformat()}" class="time-with-rel"'
                      f' title="{escape(abs_time)}" data-format="{escape(kwargs.get("rel", _("{time}")))}">'
                      f'{escape(kwargs.get("abs", _("on {time}")).replace("{time}", abs_time))}</span>')

--- a/judge/user_translations.py
+++ b/judge/user_translations.py
@@ -7,7 +7,6 @@ if settings.USE_I18N:
     _translations = {}
 
     def translation(language):
-        global _translations
         if language not in _translations:
             _translations[language] = DjangoTranslation(language, domain='dmoj-user')
         return _translations[language]

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -1,9 +1,9 @@
 import base64
 import binascii
+import datetime
 import itertools
 import json
 import os
-from datetime import datetime
 from operator import attrgetter, itemgetter
 
 from django.conf import settings
@@ -156,7 +156,7 @@ class CustomPasswordChangeView(PasswordChangeView):
         return super().form_valid(form)
 
 
-EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
 
 
 class UserAboutPage(UserPage):


### PR DESCRIPTION
Deals with the following issues:
1. RemovedInDjango50Warning: The USE_L10N setting is deprecated.
2. RemovedInDjango50Warning: The django.utils.timezone.utc alias is deprecated. Please update your code to use datetime.timezone.utc instead.
3. ./judge/user_translations.py:10:9: F824 \`global _translations\` is unused: name is never assigned in scope