### PR TITLE
Add contest performance ceiling to API

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -1,5 +1,3 @@
-from math import inf
-
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
@@ -304,7 +302,7 @@ class Contest(models.Model):
         elif self.rating_ceiling:
             return self.rating_ceiling + settings.DMOJ_CONTEST_PERF_CEILING_INCREMENT
         else:
-            return inf
+            return None
 
     @cached_property
     def ended(self):

--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -82,7 +82,9 @@ def recalculate_ratings(ranking, old_mean, times_ranked, historical_p, perf_ceil
     new_p = [0.] * n
     new_mean = [0.] * n
 
-    updated_bounds = [VALID_RANGE[0], min(VALID_RANGE[1], perf_ceiling)]
+    updated_bounds = VALID_RANGE[:]
+    if perf_ceiling is not None:
+        updated_bounds[1] = min(updated_bounds[1], perf_ceiling)
 
     # Note: pre-multiply delta by TANH_C to improve efficiency.
     delta = [TANH_C * sqrt(get_var(t) + VAR_PER_CONTEST + BETA2) for t in times_ranked]

--- a/judge/views/api/api_v2.py
+++ b/judge/views/api/api_v2.py
@@ -290,6 +290,7 @@ class APIContestDetail(APIDetailView):
             'has_rating': contest.ratings.exists(),
             'rating_floor': contest.rating_floor,
             'rating_ceiling': contest.rating_ceiling,
+            'performance_ceiling': contest.performance_ceiling,
             'hidden_scoreboard': contest.scoreboard_visibility in (contest.SCOREBOARD_AFTER_CONTEST,
                                                                    contest.SCOREBOARD_AFTER_PARTICIPATION,
                                                                    contest.SCOREBOARD_HIDDEN),


### PR DESCRIPTION
We add the new contest performance ceiling to the API.

I changed `Contest.performance_ceiling` to return `None` if there is no performance ceiling:
1. This maintains parity with `rating_ceiling` (i.e. `None` if there is no rating ceiling).
2. This also removes the need for `math.inf`, which is a bit weird for the API, and in the call to `min`.
```
>>> json.dumps({'a': math.inf})
'{"a": Infinity}'
```
I don't think this is valid JSON, and breaks a lot of JSON loaders.

See DMOJ/docs#168