### PR TITLE
chore: replace one last django.utils.timezone.utc with datetime.timezone.utc

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 from calendar import Calendar, SUNDAY
 from collections import defaultdict, namedtuple
 from datetime import date, datetime, time, timedelta
@@ -566,15 +567,15 @@ class ContestICal(TitleMixin, ContestListMixin, BaseListView):
         cal.add('prodid', '-//DMOJ//NONSGML Contests Calendar//')
         cal.add('version', '2.0')
 
-        now = timezone.now().astimezone(timezone.utc)
+        now = timezone.now().astimezone(datetime.timezone.utc)
         domain = self.request.get_host()
         for contest in self.get_queryset():
             event = Event()
             event.add('uid', f'contest-{contest.key}@{domain}')
             event.add('summary', contest.name)
             event.add('location', self.request.build_absolute_uri(contest.get_absolute_url()))
-            event.add('dtstart', contest.start_time.astimezone(timezone.utc))
-            event.add('dtend', contest.end_time.astimezone(timezone.utc))
+            event.add('dtstart', contest.start_time.astimezone(datetime.timezone.utc))
+            event.add('dtend', contest.end_time.astimezone(datetime.timezone.utc))
             event.add('dtstamp', now)
             cal.add_component(event)
         return cal.to_ical()


### PR DESCRIPTION
### Motivation

I was trying to deploy DMOJ to a Ubuntu 24.04 LTS server, and for it to work, I had to upgrade to the latest version of Django. I realized that https://github.com/DMOJ/online-judge/commit/6285f972d5e4849c65ad7f21d6830aa469744743 already fixed most cases of `django.utils.timezone.utc` no longer existing (thanks @kiritofeng!), but there was one instance that was still causing errors.

### Changes

- Replace `contests.py` use of timezone.utc with datetime.timezone.utc too

### Testing

Ran:

```sh
python3 -Wa manage.py test
```

on a server with MySQL, etc. installed as recommended in https://docs.dmoj.ca/#/site/installation