### PR TITLE
Don't allow live contest submissions to be aborted

### DIFF
--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -169,6 +169,20 @@ class Submission(models.Model):
 
         return False
 
+    def can_abort(self, user):
+        if not user.is_authenticated:
+            return False
+        if user.has_perm('judge.abort_any_submission'):
+            return True
+        # If this is a rejudged submission, or this is not the user's submission, deny the abort
+        if self.rejudged_date is not None or user.profile != self.user:
+            return False
+        # If the submission is the user's and is made in a live contest, deny the abort
+        if hasattr(self, 'contest') and not self.contest.participation.live:
+            return False
+
+        return True
+
     def update_contest(self):
         try:
             contest = self.contest

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -208,8 +208,7 @@ class SubmissionSourceRaw(SubmissionSource):
 @require_POST
 def abort_submission(request, submission):
     submission = get_object_or_404(Submission, id=int(submission))
-    if (not request.user.has_perm('judge.abort_any_submission') and
-       (submission.rejudged_date is not None or request.profile != submission.user)):
+    if not submission.can_abort(request.user):
         raise PermissionDenied()
     submission.abort()
     return HttpResponseRedirect(reverse('submission_status', args=(submission.id,)))

--- a/templates/submission/status.html
+++ b/templates/submission/status.html
@@ -71,7 +71,7 @@
 {% block body %}
     <br>
     <div><a href="{{ url('submission_source', submission.id) }}">{{ _('View source') }}</a></div>
-    {% if request.user == submission.user.user or perms.judge.resubmit_other %}
+    {% if submission.can_abort(request.user) %}
         <div><a href="{{ url('problem_submit', submission.problem.code, submission.id) }}">{{ _('Resubmit') }}</a></div>
     {% endif %}
     {% if perms.judge.rejudge_submission and not submission.is_locked %}


### PR DESCRIPTION
I believe this was requested by @xiaowuc1 some years ago, with the logic being that aborts are courtesy, and should not apply in a contest.

Note that we allow for aborts in a virtual contest so scoring systems still have to take them into account.