### PR TITLE
Fix #2444: Set markdown table width to auto in problem statements

### DIFF
--- a/resources/problem.scss
+++ b/resources/problem.scss
@@ -346,3 +346,9 @@ ul.problem-list {
         font-size: 13px;
     }
 }
+
+.problem-description {
+    table.table {
+        width: auto;
+    }
+}

--- a/templates/problem/problem.html
+++ b/templates/problem/problem.html
@@ -300,9 +300,11 @@
 {% endblock %}
 
 {% block description %}
-    {% cache 86400 'problem_html' problem.id MATH_ENGINE LANGUAGE_CODE %}
-        {{ description|markdown(problem.markdown_style, MATH_ENGINE)|reference|str|safe }}
-    {% endcache %}
+    <div class="problem-description">
+        {% cache 86400 'problem_html' problem.id MATH_ENGINE LANGUAGE_CODE %}
+            {{ description|markdown(problem.markdown_style, MATH_ENGINE)|reference|str|safe }}
+        {% endcache %}
+    </div>
 
     {% with license=problem.license %}
         {% if license %}


### PR DESCRIPTION
Addresses an issue where markdown tables within problem statements are forced to 100% width, which can create awkward empty space for tables with narrow content.

This change introduces a `.problem-description` wrapper around the problem's markdown content and applies `width: auto` to tables nested within it.

This ensures the fix is scoped only to problem statements and does not affect other user-generated content areas (e.g., editorials, comments).
- If desired, the same CSS rule can be moved to the ``/resources/base-description.scss`` where it would then just apply to all user-generated markdown tables (like in contests, editorials, user profiles, etc). 

Closes #2444 