### PR TITLE
Add ability to pin comments for staff announcements

### DIFF
--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -181,6 +181,7 @@ urlpatterns = [
     path('comments/upvote/', comment.upvote_comment, name='comment_upvote'),
     path('comments/downvote/', comment.downvote_comment, name='comment_downvote'),
     path('comments/hide/', comment.comment_hide, name='comment_hide'),
+    path('comments/pin/', comment.comment_pin, name='comment_pin'),
     path('comments/<int:id>/', include([
         path('edit', comment.CommentEdit.as_view(), name='comment_edit'),
         path('history/ajax', comment.CommentRevisionAjax.as_view(), name='comment_revision_ajax'),

--- a/judge/admin/comments.py
+++ b/judge/admin/comments.py
@@ -21,13 +21,13 @@ class CommentForm(ModelForm):
 
 class CommentAdmin(VersionAdmin):
     fieldsets = (
-        (None, {'fields': ('author', 'page', 'parent', 'time', 'score', 'hidden')}),
+        (None, {'fields': ('author', 'page', 'parent', 'time', 'score', 'hidden', 'is_pinned')}),
         (_('Content'), {'fields': ('body',)}),
     )
-    list_display = ['author', 'linked_page', 'time', 'score', 'hidden']
+    list_display = ['author', 'linked_page', 'time', 'score', 'hidden', 'is_pinned']
     search_fields = ['author__user__username', 'page', 'body']
-    actions = ['hide_comment', 'unhide_comment']
-    list_filter = ['hidden']
+    actions = ['hide_comment', 'unhide_comment', 'pin_comment', 'unpin_comment']
+    list_filter = ['hidden', 'is_pinned']
     readonly_fields = ['time', 'score']
     actions_on_top = True
     actions_on_bottom = True
@@ -49,6 +49,20 @@ class CommentAdmin(VersionAdmin):
         count = queryset.update(hidden=False)
         self.message_user(request, ngettext('%d comment successfully unhidden.',
                                             '%d comments successfully unhidden.',
+                                            count) % count)
+
+    @admin.display(description=_('Pin comments'))
+    def pin_comment(self, request, queryset):
+        count = queryset.update(is_pinned=True)
+        self.message_user(request, ngettext('%d comment successfully pinned.',
+                                            '%d comments successfully pinned.',
+                                            count) % count)
+
+    @admin.display(description=_('Unpin comments'))
+    def unpin_comment(self, request, queryset):
+        count = queryset.update(is_pinned=False)
+        self.message_user(request, ngettext('%d comment successfully unpinned.',
+                                            '%d comments successfully unpinned.',
                                             count) % count)
 
     @admin.display(description=_('associated page'), ordering='page')

--- a/judge/jinja2/__init__.py
+++ b/judge/jinja2/__init__.py
@@ -19,7 +19,22 @@ registry.filter('highlight', highlight_code)
 registry.filter('urlquote', quote)
 registry.filter('roundfloat', round)
 registry.function('inlinei18n', inlinei18n)
-registry.function('mptt_tree', get_cached_trees)
+def _pinned_first_trees(queryset):
+    trees = get_cached_trees(queryset)
+    trees.sort(key=lambda c: (not getattr(c, 'is_pinned', False)))
+    _sort_pinned(trees)
+    return trees
+
+
+def _sort_pinned(nodes):
+    for node in nodes:
+        children = getattr(node, '_cached_children', [])
+        if children:
+            children.sort(key=lambda c: (not getattr(c, 'is_pinned', False)))
+            _sort_pinned(children)
+
+
+registry.function('mptt_tree', _pinned_first_trees)
 registry.function('user_trans', gettext)
 
 

--- a/judge/migrations/0153_comment_is_pinned.py
+++ b/judge/migrations/0153_comment_is_pinned.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0152_deactivate_user_permission'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='comment',
+            name='is_pinned',
+            field=models.BooleanField(default=False, verbose_name='pinned'),
+        ),
+        migrations.AlterModelOptions(
+            name='comment',
+            options={
+                'permissions': (('pin_comment', 'Pin comments'),),
+                'verbose_name': 'comment',
+                'verbose_name_plural': 'comments',
+            },
+        ),
+    ]

--- a/judge/models/__init__.py
+++ b/judge/models/__init__.py
@@ -25,5 +25,5 @@ revisions.register(BlogPost)
 revisions.register(Solution)
 revisions.register(Judge, fields=['name', 'created', 'auth_key', 'description'])
 revisions.register(Language)
-revisions.register(Comment, fields=['author', 'time', 'page', 'score', 'body', 'hidden', 'parent'])
+revisions.register(Comment, fields=['author', 'time', 'page', 'score', 'body', 'hidden', 'is_pinned', 'parent'])
 del revisions

--- a/judge/models/comment.py
+++ b/judge/models/comment.py
@@ -31,6 +31,7 @@ class Comment(MPTTModel):
     score = models.IntegerField(verbose_name=_('votes'), default=0)
     body = models.TextField(verbose_name=_('body of comment'), max_length=8192)
     hidden = models.BooleanField(verbose_name=_('hidden'), default=0)
+    is_pinned = models.BooleanField(verbose_name=_('pinned'), default=False)
     parent = TreeForeignKey('self', verbose_name=_('parent'), null=True, blank=True, related_name='replies',
                             on_delete=CASCADE)
     revisions = models.IntegerField(verbose_name=_('revisions'), default=1)
@@ -38,6 +39,9 @@ class Comment(MPTTModel):
     class Meta:
         verbose_name = _('comment')
         verbose_name_plural = _('comments')
+        permissions = (
+            ('pin_comment', _('Pin comments')),
+        )
 
     class MPTTMeta:
         order_insertion_by = ['-time']

--- a/judge/views/comment.py
+++ b/judge/views/comment.py
@@ -20,7 +20,7 @@ from judge.utils.views import TitleMixin
 from judge.widgets import MartorWidget
 
 __all__ = ['upvote_comment', 'downvote_comment', 'CommentEditAjax', 'CommentContent',
-           'CommentEdit']
+           'CommentEdit', 'comment_pin']
 
 
 @login_required
@@ -193,4 +193,19 @@ def comment_hide(request):
 
     comment = get_object_or_404(Comment, id=comment_id)
     comment.get_descendants(include_self=True).update(hidden=True)
+    return HttpResponse('ok')
+
+
+@require_POST
+def comment_pin(request):
+    if not request.user.has_perm('judge.pin_comment'):
+        raise PermissionDenied()
+    try:
+        comment_id = int(request.POST['id'])
+    except ValueError:
+        return HttpResponseBadRequest()
+
+    comment = get_object_or_404(Comment, id=comment_id)
+    comment.is_pinned = not comment.is_pinned
+    comment.save(update_fields=['is_pinned'])
     return HttpResponse('ok')

--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -179,3 +179,12 @@ a {
         transform: translatez(0);
     }
 }
+
+.pinned-indicator {
+    color: $color_primary75;
+    font-size: 0.85em;
+}
+
+.pin-comment .fa.pinned {
+    color: $highlight_blue;
+}

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -21,7 +21,7 @@
                 <li id="comment-{{ node.id }}" data-revision="{{ node.revisions - 1 }}"
                     data-max-revision="{{ node.revisions - 1 }}"
                     data-revision-ajax="{{ url('comment_revision_ajax', node.id) }}" class="comment">
-                    <div class="comment-display{% if node.score <= vote_hide_threshold %} bad-comment{% endif %}">
+                    <div class="comment-display{% if node.score <= vote_hide_threshold and not node.is_pinned %} bad-comment{% endif %}{% if node.is_pinned %} pinned-comment{% endif %}">
                         <div class="info">
                             <div class="vote">
                                 {% if logged_in %}
@@ -57,6 +57,9 @@
                                     {% endwith %}
                                     {{ link_user(node.author) }}&nbsp;
                                 </span>
+                                {% if node.is_pinned %}
+                                    <span class="pinned-indicator"><i class="fa fa-thumb-tack"></i> {{ _('Pinned') }}</span>
+                                {% endif %}
                                 {% with abs=_('commented on {time}'), rel=_('commented {time}') %}
                                     {{ relative_time(node.time, abs=abs, rel=rel) }}
                                 {% endwith %}
@@ -106,14 +109,20 @@
                                                    class="edit-link"><i class="fa fa-pencil fa-fw"></i></a>
                                             {% endif %}
                                         {% endif %}
+                                        {% if perms.judge.pin_comment %}
+                                            <a href="javascript:void(0)" title="{{ _('Unpin') if node.is_pinned else _('Pin') }}"
+                                               data-id="{{ node.id }}" class="pin-comment">
+                                                <i class="fa fa-thumb-tack fa-fw{% if node.is_pinned %} pinned{% endif %}"></i>
+                                            </a>
+                                        {% endif %}
                                     {% endif %}
                             </span>
                             </div>
                             <div class="content content-description">
-                                <div class="comment-body"{% if node.score <= vote_hide_threshold %} style="display:none"{% endif %}>
+                                <div class="comment-body"{% if node.score <= vote_hide_threshold and not node.is_pinned %} style="display:none"{% endif %}>
                                     {{ node.body|markdown('comment', MATH_ENGINE, True)|reference|str|safe }}
                                 </div>
-                                {% if node.score <= vote_hide_threshold %}
+                                {% if node.score <= vote_hide_threshold and not node.is_pinned %}
                                     <div class="comment-body bad-comment-body">
                                         <p>
                                             {{ _('This comment is hidden due to too much negative feedback.') }}

--- a/templates/comments/media-js.html
+++ b/templates/comments/media-js.html
@@ -161,6 +161,19 @@
                 });
             });
 
+            $comments.find('a.pin-comment').click(function (e) {
+                e.preventDefault();
+                var $this = $(this);
+                var id = $this.attr('data-id');
+                $.post('{{ url('comment_pin') }}', {id: id}).then(function () {
+                    var $icon = $this.find('i');
+                    $icon.toggleClass('pinned');
+                    $this.attr('title', $icon.hasClass('pinned') ? {{ _('Unpin')|htmltojs }} : {{ _('Pin')|htmltojs }});
+                }).catch(function () {
+                    alert({{ _('Could not pin/unpin comment.')|htmltojs }});
+                });
+            });
+
             $comments.find('a.edit-link').featherlight({
                 afterOpen: function () {
                     var $widget = $('.featherlight #comment-form-body');


### PR DESCRIPTION
Pinned comments appear before all sibling comments and are never hidden by the downvote threshold. Adds a new `judge.pin_comment` permission and a pin/unpin toggle button on the frontend comment UI.

Closes #2415 