### PR TITLE
Fix re-rating contests when user is DQ'd; #2414

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -487,7 +487,7 @@ class Contest(models.Model):
         with transaction.atomic():
             Rating.objects.filter(contest__end_time__range=(self.end_time, self._now)).delete()
             for contest in Contest.objects.filter(
-                is_rated=True, end_time__range=(self.end_time, self._now),
+                is_rated=True, ended=True, end_time__range=(self.end_time, self._now),
             ).order_by('end_time'):
                 rate_contest(contest)
 


### PR DESCRIPTION
Added the parameter "ended=true" to ensure that it only re-rates contests that have ended (previously been rated), and not new ones.

Closes #2414 