### PR TITLE
Cleaned-up border-radius from 6px to 4px; #2172

### DIFF
--- a/resources/submission.scss
+++ b/resources/submission.scss
@@ -29,6 +29,24 @@
         border-top: none;
     }
 
+    &:first-child {
+        border-top-left-radius: 4px;
+        border-top-right-radius: 4px;
+
+        .sub-result {
+            border-top-left-radius: 4px;
+        }
+    }
+
+    &:last-child {
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+
+        .sub-result {
+            border-bottom-left-radius: 4px;
+        }
+    }
+
     &.submission-archived {
         opacity: 0.6;
 

--- a/resources/users.scss
+++ b/resources/users.scss
@@ -119,7 +119,7 @@ tr:target {
 
 img.user-gravatar {
     display: block;
-    border-radius: 6px;
+    border-radius: 4px;
     background-color: white;
 }
 

--- a/resources/vars-common.scss
+++ b/resources/vars-common.scss
@@ -4,6 +4,6 @@ $announcement_red: #ae0000;
 $base_font_size: 14px;
 $widget_border_radius: 4px;
 
-$table_header_rounding: 6px;
+$table_header_rounding: 4px;
 
 $monospace-fonts: Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace;


### PR DESCRIPTION
Changed table_header_round to 4px from 6px.
Changed img.user-gravatar to 4px from 6px.
Added border radius of 4px to the top left and right to the first child of the submissions page.
Closes #2172 

<img width="344" height="262" alt="Screenshot 2026-05-18 at 3 11 42 PM" src="https://github.com/user-attachments/assets/7a7bc99f-bb23-40d3-9c2b-8221c1a1c052" />
<img width="240" height="218" alt="Screenshot 2026-05-18 at 3 11 28 PM" src="https://github.com/user-attachments/assets/ee5f5555-8f9c-4da4-be4b-a4256e896980" />
<img width="693" height="335" alt="Screenshot 2026-05-18 at 3 11 14 PM" src="https://github.com/user-attachments/assets/b0c7230d-4688-49e5-9120-3954a2db361f" />
<img width="535" height="235" alt="Screenshot 2026-05-18 at 3 10 56 PM" src="https://github.com/user-attachments/assets/a98f649d-91f1-4a8b-9c29-6e40518691ec" />
